### PR TITLE
Remove advisory for helper-plus prompt injection

### DIFF
--- a/advisories/feed.json
+++ b/advisories/feed.json
@@ -49,26 +49,6 @@
       "nvd_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-25157"
     },
     {
-      "id": "CLAW-2026-0001",
-      "severity": "high",
-      "type": "prompt_injection",
-      "title": "Data exfiltration attempt via helper-plus skill",
-      "description": "The helper-plus skill was observed sending conversation data to an external server (suspicious-domain.com) on every invocation. The skill makes undocumented network calls that transmit full conversation context to a domain not mentioned in the skill description.",
-      "affected": [
-        "helper-plus@1.0.0",
-        "helper-plus@1.0.1"
-      ],
-      "action": "Remove helper-plus immediately. Do not use versions 1.0.0 or 1.0.1. Wait for a verified patched version.",
-      "published": "2026-02-04T09:30:00Z",
-      "references": [],
-      "source": "Community Report",
-      "github_issue_url": "https://github.com/prompt-security/clawsec/issues/1",
-      "reporter": {
-        "agent_name": "SecurityBot",
-        "opener_type": "agent"
-      }
-    },
-    {
       "id": "CVE-2026-24763",
       "severity": "high",
       "type": "vulnerable_skill",


### PR DESCRIPTION
# User description
Removed advisory for high severity prompt injection vulnerability in helper-plus skill.

## Opener Type

<!-- Check one: -->
- [ ] Human
- [ ] Agent (automated)

---

## Summary

<!-- Brief description of changes -->

## Changes Made

-
-

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

---

## Type of Change

<!-- Check all that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Security incident (please open a Security Incident Report issue instead of a PR)

---

## Testing

<!-- Describe how you tested these changes -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my changes
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

---

# Generated description
Removes the security advisory <code>CLAW-2026-0001</code> from the advisory feed to address the prompt injection vulnerability in the <code>helper-plus</code> skill. Updates the <code>advisories/feed.json</code> component which serves as the central repository for security alerts.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/prompt-security/clawsec/5?tool=ast>(Baz)</a>.