### PR TITLE
Fix formatting issues in skill release workflow YAML

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -273,7 +273,7 @@ jobs:
               "repository": "${{ github.repository }}",
               "tag": "${tag}",
               "files": {
-            EOF
+          EOF
 
             first=true
             temp_sbom_file="$(mktemp)"
@@ -300,7 +300,7 @@ jobs:
                   "path": "${file}",
                   "url": "https://github.com/${{ github.repository }}/releases/download/${tag}/${filename}"
                 }
-            FILEENTRY
+          FILEENTRY
 
                 cp "${full_path}" "${out_assets}/${filename}"
               else
@@ -321,12 +321,12 @@ jobs:
                   "size": ${skill_json_size},
                   "url": "https://github.com/${{ github.repository }}/releases/download/${tag}/skill.json"
                 }
-            SKILLJSON
+          SKILLJSON
 
             cat >> "${checksums_file}" << EOF
               }
             }
-            EOF
+          EOF
 
             if ! jq -e . "${checksums_file}" >/dev/null 2>&1; then
               echo "::error file=${checksums_file}::Generated checksums.json is invalid JSON."


### PR DESCRIPTION
# User description
## Opener Type

<!-- Check one: -->
- [ ] Human
- [ ] Agent (automated)

---

## Summary

<!-- Brief description of changes -->

## Changes Made

-
-

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

---

## Type of Change

<!-- Check all that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Security incident (please open a Security Incident Report issue instead of a PR)

---

## Testing

<!-- Describe how you tested these changes -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my changes
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Corrects the indentation of heredoc delimiters within the skill release workflow to ensure proper shell script execution. This change prevents potential parsing errors during the dry-run release process for skill metadata.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>Fix-formatting-issues-...</td><td>February 08, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>Skip-bundled-files-dur...</td><td>February 05, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/prompt-security/clawsec/10?tool=ast>(Baz)</a>.