### PR TITLE
fix: improve commit handling and rollback logic in release script

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -350,7 +350,8 @@ jobs:
               continue
             fi
 
-            # --- Copy root-level docs alongside the zip ---
+            # --- Copy skill.json and root-level docs alongside the zip ---
+            cp "${json_path}" "${out_assets}/skill.json"
             if [ -f "${skill_dir}/SKILL.md" ]; then
               cp "${skill_dir}/SKILL.md" "${out_assets}/SKILL.md"
             fi
@@ -579,7 +580,8 @@ jobs:
               files: $files
             }' > "release-assets/checksums.json"
 
-          # --- Copy root-level docs alongside the zip ---
+          # --- Copy skill.json and root-level docs alongside the zip ---
+          cp "$SKILL_PATH/skill.json" release-assets/skill.json
           if [ -f "$SKILL_PATH/SKILL.md" ]; then
             cp "$SKILL_PATH/SKILL.md" release-assets/
           fi


### PR DESCRIPTION
# User description
## Opener Type

<!-- Check one: -->
- [ ] Human
- [ ] Agent (automated)

---

## Summary

<!-- Brief description of changes -->

## Changes Made

-
-

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

---

## Type of Change

<!-- Check all that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Security incident (please open a Security Incident Report issue instead of a PR)

---

## Testing

<!-- Describe how you tested these changes -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my changes
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the skill release process by including <code>skill.json</code> in the published release assets and refining the commit and rollback logic in the release script. These changes ensure that version metadata is consistently available in releases and that local tagging operations do not inadvertently corrupt the git history when versions are already up to date.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/12?tool=ast&topic=Release+Script>Release Script</a>
        </td><td>Modify <code>release-skill.sh</code> to handle scenarios where the version is already bumped, preventing empty commits and ensuring that rollbacks only target commits created by the script.<details><summary>Modified files (1)</summary><ul><li>scripts/release-skill.sh</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>feat-add-clawsec-advis...</td><td>February 08, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>ClawSec-init</td><td>February 05, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/12?tool=ast&topic=Workflow+Assets>Workflow Assets</a>
        </td><td>Update the <code>skill-release.yml</code> workflow to explicitly copy <code>skill.json</code> into the release assets directory during both dry-run and actual release jobs.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/skill-release.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>Refactor-release-asset...</td><td>February 08, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>Skip-bundled-files-dur...</td><td>February 05, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/prompt-security/clawsec/12?tool=ast>(Baz)</a>.