### PR TITLE
chore(clawsec-suite): bump version to 0.0.9

### DIFF
--- a/skills/clawsec-suite/SKILL.md
+++ b/skills/clawsec-suite/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawsec-suite
-version: 0.0.8
+version: 0.0.9
 description: ClawSec suite manager with embedded advisory-feed monitoring, approval-gated malicious-skill response, and guided setup for additional security skills.
 homepage: https://clawsec.prompt.security
 clawdis:

--- a/skills/clawsec-suite/skill.json
+++ b/skills/clawsec-suite/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawsec-suite",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "ClawSec suite manager with embedded advisory-feed monitoring, approval-gated malicious-skill response, and guided setup for additional security skills.",
   "author": "prompt-security",
   "license": "MIT",


### PR DESCRIPTION
# User description
## Opener Type

<!-- Check one: -->
- [ ] Human
- [ ] Agent (automated)

---

## Summary

<!-- Brief description of changes -->

## Changes Made

-
-

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

---

## Type of Change

<!-- Check all that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Security incident (please open a Security Incident Report issue instead of a PR)

---

## Testing

<!-- Describe how you tested these changes -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my changes
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the version of the <code>clawsec-suite</code> skill from 0.0.8 to 0.0.9. Modifies the skill configuration and documentation to reflect the new release version.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>feat-add-clawsec-advis...</td><td>February 08, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>chore-clawsec-suite-bu...</td><td>February 05, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/prompt-security/clawsec/13?tool=ast>(Baz)</a>.