### PR TITLE
fix(ci): resolve minimatch audit vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1803,8 +1803,8 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.3",
-      "resolved": "https://codeload.github.com/juliangruber/balanced-match/tar.gz/refs/tags/v4.0.3",
-      "integrity": "sha512-Ty6TX2nEm7Qe+1bAJJNHxYHukWto6W1uL0a+e82uz5qSKZOdMIFL+twOvOR0v295OkQXBW5KsonrxpmCW37Bew==",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1821,8 +1821,8 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.2",
-      "resolved": "https://codeload.github.com/juliangruber/brace-expansion/tar.gz/refs/tags/v5.0.2",
-      "integrity": "sha512-mbQ5Z6rRIOzVryzyl0W267KTUN57nFnsPAR7DAcKASUx/6QpfolTR0nAXr9k4XlZFZdqFKYfWSZeaca+jgyk/w==",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4452,8 +4452,8 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.1",
-      "resolved": "https://codeload.github.com/isaacs/minimatch/tar.gz/refs/tags/v10.2.1",
-      "integrity": "sha512-h+wuaVkjm4T/I0s4Ng99hUQsru6Pn9DhQBnlsQilel+HwnvHYpIzRiyP33CLPK0P0EJ/l4LRJMmyPjNl4gxBTw==",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
+      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "vite": "^7.3.1"
   },
   "overrides": {
-    "balanced-match": "https://codeload.github.com/juliangruber/balanced-match/tar.gz/refs/tags/v4.0.3",
-    "brace-expansion": "https://codeload.github.com/juliangruber/brace-expansion/tar.gz/refs/tags/v5.0.2",
-    "minimatch": "https://codeload.github.com/isaacs/minimatch/tar.gz/refs/tags/v10.2.1"
+    "balanced-match": "4.0.3",
+    "brace-expansion": "5.0.2",
+    "minimatch": "10.2.1"
   }
 }


### PR DESCRIPTION
# User description
## Summary
- add npm `overrides` for `minimatch`, `brace-expansion`, and `balanced-match` to eliminate vulnerable minimatch chains in lint transitive dependencies
- regenerate `package-lock.json` so all minimatch consumers resolve to `minimatch@10.2.1`
- use HTTPS tarball sources (no SSH dependency) so CI runners can install without git SSH keys

## Why
CI run [#22275799774](https://github.com/prompt-security/clawsec/actions/runs/22275799774) fails in `Dependency Audit` on `GHSA-3ppc-4f35-3m26` (`minimatch <10.2.1`).

## Validation
- `npm ls minimatch --package-lock-only`
  - shows all dependency paths resolving to `minimatch@10.2.1`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Resolves a security vulnerability in the <code>minimatch</code> dependency by enforcing specific versions through npm overrides. Ensures CI stability by migrating to HTTPS tarball sources, removing the need for SSH keys during dependency installation.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>Security-Audit-Suppres...</td><td>February 16, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>ClawSec-init</td><td>February 05, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/prompt-security/clawsec/51?tool=ast>(Baz)</a>.