### PR TITLE
fix(deps): patch ajv ReDoS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1611,9 +1611,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "vite": "^7.3.1"
   },
   "overrides": {
+    "ajv": "6.14.0",
     "balanced-match": "4.0.3",
     "brace-expansion": "5.0.2",
     "minimatch": "10.2.1"


### PR DESCRIPTION
# User description
## Summary
- add an npm `overrides` entry to force `ajv` to `6.14.0`
- update `package-lock.json` so the resolved `ajv` package is `6.14.0` from `registry.npmjs.org`

## Why
Fixes advisory `GHSA-2g4f-4pwh-qvx6` (`ajv` ReDoS when using `$data` option).

Alert: https://github.com/prompt-security/clawsec/security/code-scanning/18

## Validation
- `npm ls ajv --package-lock-only`
  - `eslint -> ajv@6.14.0`
  - `@eslint/eslintrc -> ajv@6.14.0`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the <code>ajv</code> dependency to version <code>6.14.0</code> to mitigate a known ReDoS security advisory. Ensures consistent package resolution by adding an override in the project configuration and updating the lockfile.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>fix-ci-resolve-minimat...</td><td>February 22, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>ClawSec-init</td><td>February 05, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/prompt-security/clawsec/52?tool=ast>(Baz)</a>.