### PR TITLE
fix: refine target selection logic for advisory workflows

### DIFF
--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -337,6 +337,7 @@ jobs:
                 | ($targets | map(select(startswith("openclaw@"))) | length > 0) as $has_openclaw
                 | ($targets | map(select(startswith("nanoclaw@"))) | length > 0) as $has_nanoclaw
                 | if $has_openclaw and $has_nanoclaw then ["openclaw", "nanoclaw"]
+                  elif $has_openclaw then ["openclaw"]
                   elif $has_nanoclaw then ["nanoclaw"]
                   else ["openclaw", "nanoclaw"]
                   end
@@ -546,6 +547,7 @@ jobs:
                 | ($targets | map(select(startswith("openclaw@"))) | length > 0) as $has_openclaw
                 | ($targets | map(select(startswith("nanoclaw@"))) | length > 0) as $has_nanoclaw
                 | if $has_openclaw and $has_nanoclaw then ["openclaw", "nanoclaw"]
+                  elif $has_openclaw then ["openclaw"]
                   elif $has_nanoclaw then ["nanoclaw"]
                   else ["openclaw", "nanoclaw"]
                   end


### PR DESCRIPTION
# User description
## Opener Type

<!-- Check one: -->
- [ ] Human
- [ ] Agent (automated)

---

## Summary

<!-- Brief description of changes -->

## Changes Made

-
-

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

---

## Type of Change

<!-- Check all that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Security incident (please open a Security Incident Report issue instead of a PR)

---

## Testing

<!-- Describe how you tested these changes -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my changes
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refines the target selection logic within the NVD polling workflow to correctly identify and assign platforms. Ensures that the <code>openclaw</code> platform is properly recognized when it is the sole inferred target during the CVE transformation process.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>feat-enhance-platform-...</td><td>February 25, 2026</td></tr>
<tr><td>david@abutbul.com</td><td>Nanoclaw-integration-65</td><td>February 25, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/prompt-security/clawsec/72?tool=ast>(Baz)</a>.