### PR TITLE
Codex/wiki sync revert working

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -7,7 +7,8 @@ on:
       - 'wiki/**'
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: write
 
 concurrency:
   group: wiki-sync
@@ -22,17 +23,12 @@ jobs:
 
       - name: Sync wiki folder to repository wiki
         env:
-          AUTOMATION_TOKEN: ${{ secrets.POLL_NVD_CVES_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
           if [ ! -d wiki ]; then
             echo "::error::wiki/ directory not found"
-            exit 1
-          fi
-
-          if [ -z "$AUTOMATION_TOKEN" ]; then
-            echo "::error::Set POLL_NVD_CVES_PAT with repo write permissions."
             exit 1
           fi
 
@@ -44,7 +40,7 @@ jobs:
           fi
           cp wiki/INDEX.md wiki/Home.md
 
-          WIKI_REMOTE="https://x-access-token:${AUTOMATION_TOKEN}@github.com/${{ github.repository }}.wiki.git"
+          WIKI_REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.wiki.git"
           if ! git ls-remote "$WIKI_REMOTE" >/dev/null 2>&1; then
             echo "::warning::Wiki remote unavailable (repository wiki may be disabled). Skipping sync."
             exit 0


### PR DESCRIPTION
# User description
## Opener Type

<!-- Check one: -->
- [ ] Human
- [ ] Agent (automated)

---

## Summary

<!-- Brief description of changes -->

## Changes Made

-
-

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

---

## Type of Change

<!-- Check all that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Security incident (please open a Security Incident Report issue instead of a PR)

---

## Testing

<!-- Describe how you tested these changes -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my changes
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the wiki synchronization workflow to use the standard <code>GITHUB_TOKEN</code> instead of a custom automation token. Simplifies the sync script by removing manual token validation and permission checks while ensuring the workflow has the necessary write permissions.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/79?tool=ast&topic=Auth+Migration>Auth Migration</a>
        </td><td>Replaces <code>POLL_NVD_CVES_PAT</code> with <code>GITHUB_TOKEN</code> and updates the workflow permissions to <code>contents: write</code> to allow wiki updates.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/wiki-sync.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>fix-wiki-sync-use-sing...</td><td>February 25, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/79?tool=ast&topic=Script+Cleanup>Script Cleanup</a>
        </td><td>Removes redundant shell script logic that performed manual GitHub API calls to validate token scopes and repository permissions.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/wiki-sync.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>fix-wiki-sync-use-sing...</td><td>February 25, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/prompt-security/clawsec/79?tool=ast>(Baz)</a>.