### PR TITLE
fix(ci): repair invalid setup-python pin in advisory workflows

### DIFF
--- a/.github/workflows/community-advisory.yml
+++ b/.github/workflows/community-advisory.yml
@@ -195,7 +195,7 @@ jobs:
 
       - name: Set up Python for exploitability analysis
         if: steps.parse.outputs.already_exists != 'true'
-        uses: actions/setup-python@8d2f52b6169cf4c0f64d2e9f6f8f6d6a6e1c90f7 # v5.4.1
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.10'
 

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -588,7 +588,7 @@ jobs:
 
       - name: Set up Python for exploitability analysis
         if: steps.transform.outputs.new_count != '0'
-        uses: actions/setup-python@8d2f52b6169cf4c0f64d2e9f6f8f6d6a6e1c90f7 # v5.4.1
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
## Summary
Fixes the Poll NVD and community advisory workflow bootstrap failure caused by an invalid `actions/setup-python` commit pin.

## Root cause
Both workflows pinned `actions/setup-python` to `8d2f52b6169cf4c0f64d2e9f6f8f6d6a6e1c90f7` (commented as `v5.4.1`), but `v5.4.1` is not a published tag and that SHA cannot be downloaded by Actions.

Failing run example: https://github.com/prompt-security/clawsec/actions/runs/22547829373/job/65312982509

## Changes
- `.github/workflows/poll-nvd-cves.yml`
- `.github/workflows/community-advisory.yml`

Updated pin to a valid published release commit for `actions/setup-python` `v5.4.0`:
- `42375524e23c412d93fb67b49958b491fce71c38`

## Notes
No behavior change to advisory logic; this only restores workflow action resolution during job setup.
