### PR TITLE
fix(release): require changelog entry for tagged skill releases

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -852,9 +852,8 @@ jobs:
           VERSION="${{ steps.parse.outputs.version }}"
 
           if [ ! -f "$SKILL_PATH/CHANGELOG.md" ]; then
-            echo "No CHANGELOG.md found"
-            echo "changelog=" >> $GITHUB_OUTPUT
-            exit 0
+            echo "::error::Missing required changelog file: $SKILL_PATH/CHANGELOG.md"
+            exit 1
           fi
 
           # Extract the changelog section for this version
@@ -868,17 +867,18 @@ jobs:
           ' "$SKILL_PATH/CHANGELOG.md" | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}')
 
           if [ -z "$CHANGELOG_ENTRY" ]; then
-            echo "No changelog entry found for version $VERSION"
-            echo "changelog=" >> $GITHUB_OUTPUT
-          else
-            echo "Found changelog entry for version $VERSION"
-            # Use multiline output format for GitHub Actions
-            {
-              echo "changelog<<EOF"
-              echo "$CHANGELOG_ENTRY"
-              echo "EOF"
-            } >> $GITHUB_OUTPUT
+            echo "::error::No changelog entry found for version $VERSION in $SKILL_PATH/CHANGELOG.md"
+            echo "::error::Expected heading format: ## [$VERSION] - YYYY-MM-DD"
+            exit 1
           fi
+
+          echo "Found changelog entry for version $VERSION"
+          # Use multiline output format for GitHub Actions
+          {
+            echo "changelog<<EOF"
+            echo "$CHANGELOG_ENTRY"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0

--- a/skills/clawsec-scanner/CHANGELOG.md
+++ b/skills/clawsec-scanner/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the ClawSec Scanner will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2026-02-27
+## [0.0.1] - 2026-02-27
 
 ### Added
 


### PR DESCRIPTION
# User description
## Summary

- align  initial heading from  to  to match the already-tagged initial release
- make skill release pipeline fail fast when changelog metadata is missing for the tagged version

## Why

 was tagged/released, but changelog extraction was empty because the changelog heading was .
This PR prevents silent empty release notes by enforcing changelog/version consistency in CI.

## Changes

1. 
- changed heading from  to 

2. 
-  step now fails when:
  -  is missing
  - no entry matching the tagged version is found
- emits actionable error messages () with expected heading format

## Verification

- 
- verified  changelog section extraction returns non-empty content

## Note

No re-release is performed in this PR. It only fixes metadata consistency and adds release-guard behavior.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align the skill release workflow with changelog metadata by enforcing the expected heading format and making the changelog extraction step fail fast when a required release entry is missing. Document the initial <code>clawsec-scanner</code> release as <code>0.0.1</code> so the existing extraction logic can locate the tagged changelog notes.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/118?tool=ast&topic=Release+gating>Release gating</a>
        </td><td>Enforce the <code>skill-release</code> workflows changelog extraction step to emit actionable errors and exit when the required file or tagged entry is absent so CI fails fast on inconsistent metadata.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/skill-release.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>fix-ci-temporary-clawh...</td><td>March 09, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>fix-improve-changelog-...</td><td>February 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/118?tool=ast&topic=Changelog+metadata>Changelog metadata</a>
        </td><td>Fix the <code>clawsec-scanner</code> changelog heading to <code>0.0.1</code> so the tagged release notes match the workflows expected version format.<details><summary>Modified files (1)</summary><ul><li>skills/clawsec-scanner/CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>Automated-Vulnerabilit...</td><td>March 09, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/prompt-security/clawsec/118?tool=ast>(Baz)</a>.