### PR TITLE
docs: enforce release verify triad and clarify Hermes positioning

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -19,6 +19,7 @@ permissions: read-all
 
 env:
   CLAWHUB_CLI_VERSION: 0.7.0
+  RELEASE_SIGNING_PUBKEY_SHA256: 711424e4535f84093fefb024cd1ca4ec87439e53907b305b79a631d5befba9c8
 
 concurrency:
   group: skill-release-${{ github.ref }}
@@ -969,31 +970,43 @@ jobs:
 
             **Manual download with verification:**
             ```bash
-            # 1. Download the release archive, checksums, and signing material
-            curl -sLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ steps.parse.outputs.skill_name }}-v${{ steps.parse.outputs.version }}.zip
-            curl -sLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/checksums.json
-            curl -sLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/checksums.sig
-            curl -sLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/signing-public.pem
+            # 1. Download release archive + mandatory verification inputs (fail-closed)
+            curl -fsSLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ steps.parse.outputs.skill_name }}-v${{ steps.parse.outputs.version }}.zip
+            curl -fsSLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/checksums.json
+            curl -fsSLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/checksums.sig
+            curl -fsSLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/signing-public.pem
 
-            # 2. Verify the checksums manifest signature (Ed25519)
+            # 2. Mandatory gate triad: checksums.json + checksums.sig + pinned signing-key fingerprint
+            [ -s checksums.json ] || { echo "ERROR: missing checksums.json" >&2; exit 1; }
+            [ -s checksums.sig ] || { echo "ERROR: missing checksums.sig" >&2; exit 1; }
+            ACTUAL_KEY_SHA256="$(openssl pkey -pubin -in signing-public.pem -outform DER | sha256sum | awk '{print $1}')"
+            [ "$ACTUAL_KEY_SHA256" = "${{ env.RELEASE_SIGNING_PUBKEY_SHA256 }}" ] || { echo "ERROR: signing-public.pem fingerprint mismatch" >&2; exit 1; }
+
+            # 3. Verify checksums manifest signature (Ed25519)
             openssl base64 -d -A -in checksums.sig -out checksums.sig.bin
             openssl pkeyutl -verify -rawin -pubin -inkey signing-public.pem -sigfile checksums.sig.bin -in checksums.json
 
-            # 3. Verify archive checksum from the signed manifest
-            echo "$(jq -r '.archive.sha256' checksums.json)  ${{ steps.parse.outputs.skill_name }}-v${{ steps.parse.outputs.version }}.zip" | sha256sum -c
+            # 4. Verify archive checksum from the signed manifest
+            ZIP_SHA="$(jq -r '.archive.sha256 // empty' checksums.json)"
+            [ -n "$ZIP_SHA" ] || { echo "ERROR: checksums.json missing archive.sha256" >&2; exit 1; }
+            echo "$ZIP_SHA  ${{ steps.parse.outputs.skill_name }}-v${{ steps.parse.outputs.version }}.zip" | sha256sum -c
 
-            # 4. Extract (creates ${{ steps.parse.outputs.skill_name }}/ directory)
+            # 5. Extract only after triad + signature + checksum verification pass
             unzip ${{ steps.parse.outputs.skill_name }}-v${{ steps.parse.outputs.version }}.zip
             ```
 
             ### Verification
 
             `checksums.json` is cryptographically signed (`checksums.sig`) using the ClawSec CI signing key.
-            Verify the signature first, then trust hashes from `checksums.json`:
+            Mandatory fail-closed gate before install: require all 3 inputs (`checksums.json`, `checksums.sig`, pinned signing-key fingerprint), then verify signature:
             ```bash
-            curl -sLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/checksums.json
-            curl -sLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/checksums.sig
-            curl -sLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/signing-public.pem
+            curl -fsSLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/checksums.json
+            curl -fsSLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/checksums.sig
+            curl -fsSLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/signing-public.pem
+            [ -s checksums.json ] || { echo "ERROR: missing checksums.json" >&2; exit 1; }
+            [ -s checksums.sig ] || { echo "ERROR: missing checksums.sig" >&2; exit 1; }
+            ACTUAL_KEY_SHA256="$(openssl pkey -pubin -in signing-public.pem -outform DER | sha256sum | awk '{print $1}')"
+            [ "$ACTUAL_KEY_SHA256" = "${{ env.RELEASE_SIGNING_PUBKEY_SHA256 }}" ] || { echo "ERROR: signing-public.pem fingerprint mismatch" >&2; exit 1; }
             openssl base64 -d -A -in checksums.sig -out checksums.sig.bin
             openssl pkeyutl -verify -rawin -pubin -inkey signing-public.pem -sigfile checksums.sig.bin -in checksums.json
             ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <div align="center">
 
-## Secure Your OpenClaw and NanoClaw Agents with a Complete Security Skill Suite
+## Secure Your OpenClaw, NanoClaw, and Hermes Agents with a Complete Security Skill Suite
 
 <h4>Brought to you by <a href="https://prompt.security">Prompt Security</a>, the Platform for AI Security</h4>
 
@@ -37,8 +37,19 @@ ClawSec is a **complete security skill suite for AI agent platforms**. It provid
 
 ### Supported Platforms
 
-- **OpenClaw** (MoltBot, Clawdbot, and clones) - Full suite with skill installer, file integrity protection, and security audits
+- **OpenClaw** (MoltBot, Clawdbot, and clones) - Full suite with skill installer, file integrity protection, security audits, and hook-based automation
 - **NanoClaw** - Containerized WhatsApp bot security with MCP tools for advisory monitoring, signature verification, and file integrity
+- **Hermes** - Supported via standalone ClawSec skills and source-first install flow for advisory monitoring and file-integrity protections without requiring OpenClaw hooks
+
+### Hermes Support (How It Relates to OpenClaw/NanoClaw)
+
+For operators running Hermes, ClawSec support is practical and incremental:
+
+- Use the same signed advisory feed data and integrity checks used across ClawSec
+- Adopt standalone protections such as `soul-guardian` (drift/integrity) and `clawsec-feed` (threat intelligence)
+- Add platform-specific layers only where they apply: OpenClaw gets hook/suite automation, while NanoClaw uses its dedicated MCP/IPC integration skill
+
+This keeps security coverage consistent across agent stacks while preserving each platform's native integration model.
 
 ### Core Capabilities
 
@@ -165,10 +176,10 @@ The **clawsec-suite** is a skill-of-skills manager that installs, verifies, and 
 
 | Skill | Description | Installation | Compatibility |
 |-------|-------------|--------------|---------------|
-| 📡 **clawsec-feed** | Security advisory feed monitoring with live CVE updates | ✅ Included by default | All agents |
+| 📡 **clawsec-feed** | Security advisory feed monitoring with live CVE updates | ✅ Included by default | All agents (including Hermes) |
 | 🔭 **openclaw-audit-watchdog** | Automated daily audits with email reporting | ⚙️ Optional (install separately) | OpenClaw/MoltBot/Clawdbot |
-| 👻 **soul-guardian** | Drift detection and file integrity guard with auto-restore | ⚙️ Optional | All agents |
-| 🤝 **clawtributor** | Community incident reporting | ❌ Optional (Explicit request) | All agents |
+| 👻 **soul-guardian** | Drift detection and file integrity guard with auto-restore | ⚙️ Optional | All agents (including Hermes) |
+| 🤝 **clawtributor** | Community incident reporting | ❌ Optional (Explicit request) | All agents (including Hermes) |
 
 > ⚠️ **clawtributor** is not installed by default as it may share anonymized incident data. Install only on explicit user request.
 

--- a/skills/clawsec-suite/CHANGELOG.md
+++ b/skills/clawsec-suite/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the ClawSec Suite will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Clarified Hermes support positioning in the project README, including how suite capabilities align with OpenClaw hook automation and NanoClaw MCP/IPC integration.
+- Tightened manual release verification guidance to require the full triad (`checksums.json`, `checksums.sig`, pinned signing-key fingerprint) before install/extract steps.
+
+### Security
+
+- Hardened release verification instructions and release-note examples to fail closed on missing verification artifacts or signing-key fingerprint mismatch.
+
 ## [0.1.6] - 2026-04-14
 
 ### Added

--- a/skills/clawsec-suite/SKILL.md
+++ b/skills/clawsec-suite/SKILL.md
@@ -79,7 +79,11 @@ BASE="https://github.com/prompt-security/clawsec/releases/download/clawsec-suite
 TEMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TEMP_DIR"' EXIT
 
-# Pinned release-signing public key (verify fingerprint out-of-band on first use)
+# Mandatory release verify gate (fail-closed):
+#   1) checksums.json
+#   2) checksums.sig
+#   3) pinned signing public-key fingerprint
+# Do not install if any are missing or mismatched.
 # Fingerprint (SHA-256 of SPKI DER): 711424e4535f84093fefb024cd1ca4ec87439e53907b305b79a631d5befba9c8
 RELEASE_PUBKEY_SHA256="711424e4535f84093fefb024cd1ca4ec87439e53907b305b79a631d5befba9c8"
 cat > "$TEMP_DIR/release-signing-public.pem" <<'PEM'
@@ -96,10 +100,13 @@ fi
 
 ZIP_NAME="clawsec-suite-v${VERSION}.zip"
 
-# 1) Download release archive + signed checksums manifest + signing public key
+# 1) Fetch release archive + mandatory verify inputs (fail-closed)
 curl -fsSL "$BASE/$ZIP_NAME" -o "$TEMP_DIR/$ZIP_NAME"
 curl -fsSL "$BASE/checksums.json" -o "$TEMP_DIR/checksums.json"
 curl -fsSL "$BASE/checksums.sig" -o "$TEMP_DIR/checksums.sig"
+
+[ -s "$TEMP_DIR/checksums.json" ] || { echo "ERROR: missing checksums.json" >&2; exit 1; }
+[ -s "$TEMP_DIR/checksums.sig" ] || { echo "ERROR: missing checksums.sig" >&2; exit 1; }
 
 # 2) Verify checksums manifest signature before trusting any hashes
 openssl base64 -d -A -in "$TEMP_DIR/checksums.sig" -out "$TEMP_DIR/checksums.sig.bin"
@@ -130,7 +137,7 @@ if [ "$EXPECTED_ZIP_SHA" != "$ACTUAL_ZIP_SHA" ]; then
   exit 1
 fi
 
-echo "Checksums manifest signature and archive hash verified."
+echo "Release verify gate passed (checksums.json + checksums.sig + pinned key fingerprint)."
 
 # 3) Install verified archive
 mkdir -p "$INSTALL_ROOT"

--- a/wiki/security-signing-runbook.md
+++ b/wiki/security-signing-runbook.md
@@ -136,7 +136,7 @@ Current behavior:
 - publishes signing key to `public/signing-public.pem` and `public/advisories/feed-signing-public.pem`
 - mirrors advisory + signature/checksum/key companions into `public/releases/latest/download/` compatibility paths
 
-### Skill release pipeline (recommended hardening)
+### Skill release pipeline (mandatory verify gate)
 
 Current release generator:
 - `.github/workflows/skill-release.yml`
@@ -145,6 +145,11 @@ Current behavior:
 - creates `checksums.json`, signs it as `checksums.sig`, and verifies signature before publish
 - includes `signing-public.pem` in release assets
 - validates generated public-key fingerprint against canonical key material
+- release notes enforce a fail-closed triad gate before manual install proceeds:
+  1) `checksums.json` must be present/non-empty
+  2) `checksums.sig` must be present/non-empty
+  3) `signing-public.pem` fingerprint must match the pinned value
+- install/extract instructions come only after triad + signature + archive checksum validation
 
 ## 8) Rotation policy and runbook
 


### PR DESCRIPTION
# User description
This PR contains two focused commits:

1) docs(readme): clarify Hermes support with OpenClaw/NanoClaw positioning
2) docs(security): enforce mandatory release verify triad in suite guidance

Security/doc hardening includes:
- mandatory verification triad before install/extract guidance:
  - checksums.json
  - checksums.sig
  - pinned signing-key fingerprint
- fail-closed wording in suite docs and runbook
- release workflow release-note snippet aligned with same gate

Validation performed:
- python utils/validate_skill.py skills/clawsec-suite (PASS)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify README messaging around Hermes support in the suite installer to explain how it aligns with existing OpenClaw and NanoClaw flows. Strengthen the release guidance, workflow, and runbook components by enforcing a fail-closed verification triad (<code>checksums.json</code>, <code>checksums.sig</code>, pinned signing-key fingerprint) before installing or extracting distributions.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/199?tool=ast&topic=Release+verify+gate>Release verify gate</a>
        </td><td>Enforce a fail-closed release verify gate (<code>checksums.json</code>, <code>checksums.sig</code>, pinned signing-key fingerprint) across workflow scripts, suite install helpers, and runbook guidance before any download or extraction step.<details><summary>Modified files (4)</summary><ul><li>.github/workflows/skill-release.yml</li>
<li>skills/clawsec-suite/CHANGELOG.md</li>
<li>skills/clawsec-suite/SKILL.md</li>
<li>wiki/security-signing-runbook.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>fix(clawsec-suite): re...</td><td>April 16, 2026</td></tr>
<tr><td>aldo@osstek.com</td><td>fix(portability): hard...</td><td>February 25, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/199?tool=ast&topic=Hermes+positioning>Hermes positioning</a>
        </td><td>Clarify how Hermes fits the suite’s security coverage alongside OpenClaw and NanoClaw, emphasizing supported components and installer expectations.<details><summary>Modified files (2)</summary><ul><li>README.md</li>
<li>skills/clawsec-suite/CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>fix(clawsec-suite): re...</td><td>April 16, 2026</td></tr>
<tr><td>aldo@osstek.com</td><td>fix(portability): hard...</td><td>February 25, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/prompt-security/clawsec/199?tool=ast>(Baz)</a>.