### PR TITLE
fix(release): guard duplicate ClawHub versions + bump watchdog to 0.1.4

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -1135,6 +1135,36 @@ jobs:
           CLAWHUB_DISABLE_TELEMETRY=1 CLAWHUB_SITE="$SITE" CLAWHUB_REGISTRY="$REGISTRY" \
             clawhub login --token "$CLAWHUB_TOKEN" --site "$SITE" --no-input
 
+      - name: Guard duplicate ClawHub version
+        if: needs.release-tag.outputs.publishable == 'true' && env.CLAWHUB_TOKEN != ''
+        run: |
+          set -euo pipefail
+          SITE=${CLAWHUB_SITE:-https://clawhub.ai}
+          REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
+          SKILL_NAME="${{ needs.release-tag.outputs.skill_name }}"
+          VERSION="${{ needs.release-tag.outputs.version }}"
+          export CLAWHUB_CONFIG_PATH="$HOME/.clawhub-ci/config.json"
+
+          set +e
+          CLAWHUB_DISABLE_TELEMETRY=1 CLAWHUB_SITE="$SITE" CLAWHUB_REGISTRY="$REGISTRY" \
+            clawhub inspect "$SKILL_NAME" --version "$VERSION" --json \
+            > /tmp/clawhub-existing-version.json 2> /tmp/clawhub-existing-version.err
+          STATUS=$?
+          set -e
+
+          if [ "$STATUS" -eq 0 ]; then
+            echo "::error::ClawHub already contains ${SKILL_NAME}@${VERSION}. Bump the version before tagging."
+            exit 1
+          fi
+
+          if grep -Eqi "Version not found|Skill not found" /tmp/clawhub-existing-version.err; then
+            echo "No existing ${SKILL_NAME}@${VERSION} detected in ClawHub. Proceeding."
+          else
+            echo "::error::Failed to verify ClawHub version precondition."
+            cat /tmp/clawhub-existing-version.err
+            exit 1
+          fi
+
       - name: Publish to ClawHub
         if: needs.release-tag.outputs.publishable == 'true' && env.CLAWHUB_TOKEN != ''
         run: |
@@ -1149,7 +1179,6 @@ jobs:
 
           export CLAWHUB_CONFIG_PATH="$HOME/.clawhub-ci/config.json"
 
-          # Publish with idempotent retry handling
           if ! CLAWHUB_DISABLE_TELEMETRY=1 CLAWHUB_SITE="$SITE" CLAWHUB_REGISTRY="$REGISTRY" \
             clawhub publish "$SKILL_PATH" \
               --slug "$SKILL_NAME" \
@@ -1158,15 +1187,8 @@ jobs:
               --changelog "$CHANGELOG" \
               --tags "latest" \
               --no-input 2>&1 | tee /tmp/clawhub-publish.log; then
-
-            # Check if it's a "version already exists" error (which means previous run partially succeeded)
-            if grep -qi "version already exists" /tmp/clawhub-publish.log; then
-              echo "::warning::Version $VERSION already published to ClawHub (from previous run)"
-              exit 0
-            else
-              echo "::error::ClawHub publish failed. Check logs above for details."
-              exit 1
-            fi
+            echo "::error::ClawHub publish failed. Check logs above for details."
+            exit 1
           fi
 
           echo "✓ Successfully published $SKILL_NAME@$VERSION to ClawHub"

--- a/skills/openclaw-audit-watchdog/CHANGELOG.md
+++ b/skills/openclaw-audit-watchdog/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-04-17
+
+### Changed
+
+- Re-released metadata and docs updates under a new version after detecting that `0.1.3` was already present in ClawHub with older artifact content.
+- No runtime behavior changes to audit execution, cron setup, or report delivery logic.
+
 ## [0.1.3] - 2026-04-16
 
 ### Changed

--- a/skills/openclaw-audit-watchdog/SKILL.md
+++ b/skills/openclaw-audit-watchdog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openclaw-audit-watchdog
-version: 0.1.3
+version: 0.1.4
 description: Automated daily security audits for OpenClaw agents with DM delivery and optional email reporting. Runs deep audits, creates or updates a recurring cron job, and sends formatted reports to configured recipients.
 homepage: https://clawsec.prompt.security
 metadata:

--- a/skills/openclaw-audit-watchdog/skill.json
+++ b/skills/openclaw-audit-watchdog/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-audit-watchdog",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Automated daily security audits for OpenClaw agents with DM delivery and optional email reporting. Creates or updates an unattended cron job and sends formatted reports to configured recipients.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
# User description
## Summary
- bump openclaw-audit-watchdog to 0.1.4 in skill.json + SKILL.md
- add 0.1.4 changelog entry explaining the version-collision re-release
- add a pre-publish ClawHub guard in skill-release.yml that fails if <skill>@<version> already exists
- remove the prior "version already exists" success fallback so duplicate immutable version publishes fail loudly

## Why
0.1.3 was already present in ClawHub with older artifact content, so a later tag/release with the same version could not overwrite immutable content. This change makes that condition fail fast and forces a version bump.

## Verification
- python3 utils/validate_skill.py skills/openclaw-audit-watchdog
- version parity confirmed between skills/openclaw-audit-watchdog/skill.json and skills/openclaw-audit-watchdog/SKILL.md

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Bump the openclaw-audit-watchdog metadata, documentation, and changelog to 0.1.4 after the re-release replaced the previous ClawHub artifact. Add a guard to the skill-release workflow that checks for existing <code><skill>@<version></code> entries and remove the silent version-exists success path so duplicate immutable publishes fail fast.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/201?tool=ast&topic=Watchdog+v0.1.4>Watchdog v0.1.4</a>
        </td><td>Bump the audit watchdog metadata, SKILL descriptor, and changelog to 0.1.4 to document the re-release.<details><summary>Modified files (3)</summary><ul><li>skills/openclaw-audit-watchdog/CHANGELOG.md</li>
<li>skills/openclaw-audit-watchdog/SKILL.md</li>
<li>skills/openclaw-audit-watchdog/skill.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>fix(openclaw-audit-wat...</td><td>April 16, 2026</td></tr>
<tr><td>aldo@osstek.com</td><td>fix(portability): hard...</td><td>February 25, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/201?tool=ast&topic=Release+guard>Release guard</a>
        </td><td>Guard the workflow by verifying that ClawHub does not already host the targeted <code><skill>@<version></code> before publishing and by removing the prior silencers that treated duplicate-version responses as successes.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/skill-release.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>chore(clawsec-suite): ...</td><td>April 08, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>fix: improve changelog...</td><td>February 12, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/prompt-security/clawsec/201?tool=ast>(Baz)</a>.