### PR TITLE
fix(nvd): support full CVE rebuild without arg overflow

### DIFF
--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -436,14 +436,21 @@ jobs:
                   end
               );
 
+            def preferred_description:
+              (
+                (.cve.descriptions[]? | select(.lang == "en") | .value)
+                // .cve.descriptions[0]?.value
+                // "No description provided by NVD."
+              );
+
             [.[] | {
               id: .cve.id,
               severity: (get_cvss_score | map_severity),
               type: nvd_category_name,
               nvd_category_id: nvd_category_raw,
               cvss_score: get_cvss_score,
-              description: (.cve.descriptions[] | select(.lang == "en") | .value),
-              title: (.cve.descriptions[] | select(.lang == "en") | .value | .[0:100] + (if length > 100 then "..." else "" end)),
+              description: preferred_description,
+              title: (preferred_description | .[0:100] + (if length > 100 then "..." else "" end)),
               affected: normalized_affected,
               platforms: normalized_platforms,
               references: [.cve.references[]?.url // empty] | unique | .[0:3],
@@ -516,16 +523,16 @@ jobs:
       - name: Transform CVEs to advisories
         id: transform
         run: |
-          # Read existing IDs into a jq-friendly format
+          # Read existing IDs into a jq-friendly file for jq (avoids huge CLI args on full scans).
           if [ "${{ inputs.force_full_scan }}" = "true" ]; then
             echo "Full scan mode enabled: rebuilding CVE advisories from scratch."
-            EXISTING_IDS='[]'
+            echo '[]' > tmp/existing_ids.json
           else
-            EXISTING_IDS=$(cat tmp/existing_ids.txt | jq -R -s 'split("\n") | map(select(length > 0))')
+            jq -R -s 'split("\n") | map(select(length > 0))' < tmp/existing_ids.txt > tmp/existing_ids.json
           fi
           
           # Transform NVD CVEs to our advisory format
-          jq --argjson existing "$EXISTING_IDS" '
+          jq --slurpfile existing tmp/existing_ids.json '
             def map_severity:
               if . == null then "medium"
               elif . >= 9.0 then "critical"
@@ -668,16 +675,23 @@ jobs:
                     | if ($from_targets | length) > 0 then $from_targets else ["openclaw", "nanoclaw", "hermes"] end
                   end
               );
+
+            def preferred_description:
+              (
+                (.cve.descriptions[]? | select(.lang == "en") | .value)
+                // .cve.descriptions[0]?.value
+                // "No description provided by NVD."
+              );
             
             [.[] |
-              select(.cve.id as $id | $existing | index($id) | not) |
+              select(.cve.id as $id | (($existing[0] // []) | index($id) | not)) |
               {
                 id: .cve.id,
                 severity: (get_cvss_score | map_severity),
                 type: nvd_category_name,
                 nvd_category_id: nvd_category_raw,
-                title: (.cve.descriptions[] | select(.lang == "en") | .value | .[0:100] + (if length > 100 then "..." else "" end)),
-                description: (.cve.descriptions[] | select(.lang == "en") | .value),
+                title: (preferred_description | .[0:100] + (if length > 100 then "..." else "" end)),
+                description: preferred_description,
                 affected: normalized_affected,
                 platforms: normalized_platforms,
                 action: "Review and update affected components. See NVD for remediation details.",
@@ -694,6 +708,14 @@ jobs:
           NEW_COUNT=$(jq 'length' tmp/new_advisories.json)
           echo "New advisories to add: $NEW_COUNT"
           echo "new_count=$NEW_COUNT" >> $GITHUB_OUTPUT
+
+          if [ "${{ inputs.force_full_scan }}" = "true" ]; then
+            FILTERED_COUNT="${{ steps.process.outputs.filtered_count }}"
+            if [ "$NEW_COUNT" -ne "$FILTERED_COUNT" ]; then
+              echo "::error::Full scan transform mismatch: filtered CVEs=$FILTERED_COUNT transformed advisories=$NEW_COUNT"
+              exit 1
+            fi
+          fi
           
           if [ "$NEW_COUNT" -gt 0 ]; then
             echo "=== New advisories ==="
@@ -747,11 +769,11 @@ jobs:
 
           if [ -f "$FEED_PATH" ] && [ "$FORCE_FULL_SCAN" = "true" ]; then
             # Full scan mode: replace all CVE advisories with rebuilt set and keep non-CVE entries.
-            jq --argjson rebuilt "$(cat tmp/new_advisories.json)" --arg now "$NOW" '
+            jq --slurpfile rebuilt tmp/new_advisories.json --arg now "$NOW" '
               .updated = $now |
               .advisories = (
                 ((.advisories // []) | map(select((.id // "") | startswith("CVE-") | not)))
-                + $rebuilt
+                + ($rebuilt[0] // [])
                 | sort_by(.published)
                 | reverse
               )
@@ -773,16 +795,16 @@ jobs:
             ' "$FEED_PATH" > tmp/feed_with_updates.json
 
             # Step 2: Add new advisories
-            jq --argjson new "$(cat tmp/new_advisories.json)" --arg now "$NOW" '
+            jq --slurpfile new tmp/new_advisories.json --arg now "$NOW" '
               .updated = $now |
-              .advisories = (.advisories + $new | sort_by(.published) | reverse)
+              .advisories = (.advisories + ($new[0] // []) | sort_by(.published) | reverse)
             ' tmp/feed_with_updates.json > tmp/updated_feed.json
           else
-            jq -n --argjson advisories "$(cat tmp/new_advisories.json)" --arg now "$NOW" '{
+            jq -n --slurpfile advisories tmp/new_advisories.json --arg now "$NOW" '{
               version: "1.0.0",
               updated: $now,
               description: "Community-driven security advisory feed for ClawSec",
-              advisories: ($advisories | sort_by(.published) | reverse)
+              advisories: (($advisories[0] // []) | sort_by(.published) | reverse)
             }' > tmp/updated_feed.json
           fi
 

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -402,23 +402,38 @@ jobs:
                   )
               );
 
-            def normalized_affected:
+            def matched_targets:
               (
                 (cpe_criteria + inferred_targets)
                 | unique
                 | .[0:5]
+              );
+
+            def platforms_from_targets($targets):
+              (
+                [
+                  (if ($targets | map(strings | ascii_downcase | select(startswith("openclaw@") or test("^cpe:2\\.3:[aho]:openclaw:openclaw(?::|$)"))) | length > 0) then "openclaw" else empty end),
+                  (if ($targets | map(strings | ascii_downcase | select(startswith("nanoclaw@") or test("^cpe:2\\.3:[aho]:[^:]*:nanoclaw(?::|$)"))) | length > 0) then "nanoclaw" else empty end),
+                  (if ($targets | map(strings | ascii_downcase | select(startswith("hermes@") or test("^cpe:2\\.3:[aho]:software-metadata\\.pub:hermes(?::|$)"))) | length > 0) then "hermes" else empty end)
+                ]
+              );
+
+            def normalized_affected:
+              (
+                matched_targets
                 | if length == 0 then ["openclaw@*", "nanoclaw@*", "hermes@*"] else . end
               );
 
             def normalized_platforms:
               (
-                inferred_targets as $targets
-                | [
-                    (if ($targets | map(select(startswith("openclaw@"))) | length > 0) then "openclaw" else empty end),
-                    (if ($targets | map(select(startswith("nanoclaw@"))) | length > 0) then "nanoclaw" else empty end),
-                    (if ($targets | map(select(startswith("hermes@"))) | length > 0) then "hermes" else empty end)
-                  ]
-                | if length == 0 then ["openclaw", "nanoclaw", "hermes"] else . end
+                inferred_targets as $inferred
+                | platforms_from_targets($inferred) as $from_inferred
+                | if ($from_inferred | length) > 0 then $from_inferred
+                  else
+                    matched_targets as $targets
+                    | platforms_from_targets($targets) as $from_targets
+                    | if ($from_targets | length) > 0 then $from_targets else ["openclaw", "nanoclaw", "hermes"] end
+                  end
               );
 
             [.[] | {
@@ -620,23 +635,38 @@ jobs:
                   )
               );
 
-            def normalized_affected:
+            def matched_targets:
               (
                 (cpe_criteria + inferred_targets)
                 | unique
                 | .[0:5]
+              );
+
+            def platforms_from_targets($targets):
+              (
+                [
+                  (if ($targets | map(strings | ascii_downcase | select(startswith("openclaw@") or test("^cpe:2\\.3:[aho]:openclaw:openclaw(?::|$)"))) | length > 0) then "openclaw" else empty end),
+                  (if ($targets | map(strings | ascii_downcase | select(startswith("nanoclaw@") or test("^cpe:2\\.3:[aho]:[^:]*:nanoclaw(?::|$)"))) | length > 0) then "nanoclaw" else empty end),
+                  (if ($targets | map(strings | ascii_downcase | select(startswith("hermes@") or test("^cpe:2\\.3:[aho]:software-metadata\\.pub:hermes(?::|$)"))) | length > 0) then "hermes" else empty end)
+                ]
+              );
+
+            def normalized_affected:
+              (
+                matched_targets
                 | if length == 0 then ["openclaw@*", "nanoclaw@*", "hermes@*"] else . end
               );
 
             def normalized_platforms:
               (
-                inferred_targets as $targets
-                | [
-                    (if ($targets | map(select(startswith("openclaw@"))) | length > 0) then "openclaw" else empty end),
-                    (if ($targets | map(select(startswith("nanoclaw@"))) | length > 0) then "nanoclaw" else empty end),
-                    (if ($targets | map(select(startswith("hermes@"))) | length > 0) then "hermes" else empty end)
-                  ]
-                | if length == 0 then ["openclaw", "nanoclaw", "hermes"] else . end
+                inferred_targets as $inferred
+                | platforms_from_targets($inferred) as $from_inferred
+                | if ($from_inferred | length) > 0 then $from_inferred
+                  else
+                    matched_targets as $targets
+                    | platforms_from_targets($targets) as $from_targets
+                    | if ($from_targets | length) > 0 then $from_targets else ["openclaw", "nanoclaw", "hermes"] end
+                  end
               );
             
             [.[] |

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -402,38 +402,23 @@ jobs:
                   )
               );
 
-            def matched_targets:
+            def normalized_affected:
               (
                 (cpe_criteria + inferred_targets)
                 | unique
                 | .[0:5]
-              );
-
-            def platforms_from_targets($targets):
-              (
-                [
-                  (if ($targets | map(strings | ascii_downcase | select(startswith("openclaw@") or test("^cpe:2\\.3:[aho]:openclaw:openclaw(?::|$)"))) | length > 0) then "openclaw" else empty end),
-                  (if ($targets | map(strings | ascii_downcase | select(startswith("nanoclaw@") or test("^cpe:2\\.3:[aho]:[^:]*:nanoclaw(?::|$)"))) | length > 0) then "nanoclaw" else empty end),
-                  (if ($targets | map(strings | ascii_downcase | select(startswith("hermes@") or test("^cpe:2\\.3:[aho]:software-metadata\\.pub:hermes(?::|$)"))) | length > 0) then "hermes" else empty end)
-                ]
-              );
-
-            def normalized_affected:
-              (
-                matched_targets
                 | if length == 0 then ["openclaw@*", "nanoclaw@*", "hermes@*"] else . end
               );
 
             def normalized_platforms:
               (
-                inferred_targets as $inferred
-                | platforms_from_targets($inferred) as $from_inferred
-                | if ($from_inferred | length) > 0 then $from_inferred
-                  else
-                    matched_targets as $targets
-                    | platforms_from_targets($targets) as $from_targets
-                    | if ($from_targets | length) > 0 then $from_targets else ["openclaw", "nanoclaw", "hermes"] end
-                  end
+                inferred_targets as $targets
+                | [
+                    (if ($targets | map(select(startswith("openclaw@"))) | length > 0) then "openclaw" else empty end),
+                    (if ($targets | map(select(startswith("nanoclaw@"))) | length > 0) then "nanoclaw" else empty end),
+                    (if ($targets | map(select(startswith("hermes@"))) | length > 0) then "hermes" else empty end)
+                  ]
+                | if length == 0 then ["openclaw", "nanoclaw", "hermes"] else . end
               );
 
             [.[] | {
@@ -635,38 +620,23 @@ jobs:
                   )
               );
 
-            def matched_targets:
+            def normalized_affected:
               (
                 (cpe_criteria + inferred_targets)
                 | unique
                 | .[0:5]
-              );
-
-            def platforms_from_targets($targets):
-              (
-                [
-                  (if ($targets | map(strings | ascii_downcase | select(startswith("openclaw@") or test("^cpe:2\\.3:[aho]:openclaw:openclaw(?::|$)"))) | length > 0) then "openclaw" else empty end),
-                  (if ($targets | map(strings | ascii_downcase | select(startswith("nanoclaw@") or test("^cpe:2\\.3:[aho]:[^:]*:nanoclaw(?::|$)"))) | length > 0) then "nanoclaw" else empty end),
-                  (if ($targets | map(strings | ascii_downcase | select(startswith("hermes@") or test("^cpe:2\\.3:[aho]:software-metadata\\.pub:hermes(?::|$)"))) | length > 0) then "hermes" else empty end)
-                ]
-              );
-
-            def normalized_affected:
-              (
-                matched_targets
                 | if length == 0 then ["openclaw@*", "nanoclaw@*", "hermes@*"] else . end
               );
 
             def normalized_platforms:
               (
-                inferred_targets as $inferred
-                | platforms_from_targets($inferred) as $from_inferred
-                | if ($from_inferred | length) > 0 then $from_inferred
-                  else
-                    matched_targets as $targets
-                    | platforms_from_targets($targets) as $from_targets
-                    | if ($from_targets | length) > 0 then $from_targets else ["openclaw", "nanoclaw", "hermes"] end
-                  end
+                inferred_targets as $targets
+                | [
+                    (if ($targets | map(select(startswith("openclaw@"))) | length > 0) then "openclaw" else empty end),
+                    (if ($targets | map(select(startswith("nanoclaw@"))) | length > 0) then "nanoclaw" else empty end),
+                    (if ($targets | map(select(startswith("hermes@"))) | length > 0) then "hermes" else empty end)
+                  ]
+                | if length == 0 then ["openclaw", "nanoclaw", "hermes"] else . end
               );
             
             [.[] |

--- a/components/AdvisoryCard.tsx
+++ b/components/AdvisoryCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { ExternalLink, Github } from 'lucide-react';
 import { Advisory } from '../types';
+import { AdvisoryPlatformBadge } from './AdvisoryPlatformBadge';
 
 interface AdvisoryCardProps {
   advisory: Advisory;
@@ -41,32 +42,6 @@ export const AdvisoryCard: React.FC<AdvisoryCardProps> = ({ advisory, formatDate
     }
   };
 
-  const getPlatformLabel = (platform: string) => {
-    switch (platform) {
-      case 'openclaw':
-        return 'OpenClaw';
-      case 'nanoclaw':
-        return 'NanoClaw';
-      case 'hermes':
-        return 'Hermes';
-      default:
-        return platform;
-    }
-  };
-
-  const getPlatformClasses = (platform: string) => {
-    switch (platform) {
-      case 'openclaw':
-        return 'bg-clawd-accent/20 text-clawd-accent border border-clawd-accent/40';
-      case 'nanoclaw':
-        return 'bg-clawd-secondary/20 text-clawd-secondary border border-clawd-secondary/40';
-      case 'hermes':
-        return 'bg-emerald-500/20 text-emerald-300 border border-emerald-400/40';
-      default:
-        return 'bg-clawd-700 text-gray-300 border border-clawd-600';
-    }
-  };
-
   // Determine if this is a community report (has github_issue_url) or NVD/staff advisory
   const isCommunityReport = !!advisory.github_issue_url;
 
@@ -95,12 +70,11 @@ export const AdvisoryCard: React.FC<AdvisoryCardProps> = ({ advisory, formatDate
       {advisory.platforms && advisory.platforms.length > 0 && (
         <div className="mb-3 flex flex-wrap gap-1.5">
           {advisory.platforms.map((platform) => (
-            <span
+            <AdvisoryPlatformBadge
               key={`${advisory.id}-${platform}`}
-              className={`text-[11px] px-2 py-0.5 rounded uppercase tracking-wide ${getPlatformClasses(platform)}`}
-            >
-              {getPlatformLabel(platform)}
-            </span>
+              platform={platform}
+              className="text-[11px] px-2 py-0.5 rounded"
+            />
           ))}
         </div>
       )}

--- a/components/AdvisoryCard.tsx
+++ b/components/AdvisoryCard.tsx
@@ -41,6 +41,32 @@ export const AdvisoryCard: React.FC<AdvisoryCardProps> = ({ advisory, formatDate
     }
   };
 
+  const getPlatformLabel = (platform: string) => {
+    switch (platform) {
+      case 'openclaw':
+        return 'OpenClaw';
+      case 'nanoclaw':
+        return 'NanoClaw';
+      case 'hermes':
+        return 'Hermes';
+      default:
+        return platform;
+    }
+  };
+
+  const getPlatformClasses = (platform: string) => {
+    switch (platform) {
+      case 'openclaw':
+        return 'bg-clawd-accent/20 text-clawd-accent border border-clawd-accent/40';
+      case 'nanoclaw':
+        return 'bg-clawd-secondary/20 text-clawd-secondary border border-clawd-secondary/40';
+      case 'hermes':
+        return 'bg-emerald-500/20 text-emerald-300 border border-emerald-400/40';
+      default:
+        return 'bg-clawd-700 text-gray-300 border border-clawd-600';
+    }
+  };
+
   // Determine if this is a community report (has github_issue_url) or NVD/staff advisory
   const isCommunityReport = !!advisory.github_issue_url;
 
@@ -65,6 +91,19 @@ export const AdvisoryCard: React.FC<AdvisoryCardProps> = ({ advisory, formatDate
         {advisory.id}
       </h3>
       <p className="text-sm text-gray-400 line-clamp-3 mb-3">{advisory.title}</p>
+
+      {advisory.platforms && advisory.platforms.length > 0 && (
+        <div className="mb-3 flex flex-wrap gap-1.5">
+          {advisory.platforms.map((platform) => (
+            <span
+              key={`${advisory.id}-${platform}`}
+              className={`text-[11px] px-2 py-0.5 rounded uppercase tracking-wide ${getPlatformClasses(platform)}`}
+            >
+              {getPlatformLabel(platform)}
+            </span>
+          ))}
+        </div>
+      )}
       
       {/* External link - stop propagation to allow clicking without navigating to detail */}
       {isCommunityReport && advisory.github_issue_url ? (

--- a/components/AdvisoryPlatformBadge.tsx
+++ b/components/AdvisoryPlatformBadge.tsx
@@ -1,38 +1,5 @@
 import React from 'react';
-
-interface PlatformDescriptor {
-  label: string;
-  classes: string;
-}
-
-const normalizePlatformSlug = (platform: string) => platform.trim().toLowerCase();
-
-export const getPlatformDescriptor = (platform: string): PlatformDescriptor => {
-  const normalized = normalizePlatformSlug(platform);
-
-  switch (normalized) {
-    case 'openclaw':
-      return {
-        label: 'OpenClaw',
-        classes: 'bg-clawd-accent/20 text-clawd-accent border border-clawd-accent/40',
-      };
-    case 'nanoclaw':
-      return {
-        label: 'NanoClaw',
-        classes: 'bg-clawd-secondary/20 text-clawd-secondary border border-clawd-secondary/40',
-      };
-    case 'hermes':
-      return {
-        label: 'Hermes',
-        classes: 'bg-emerald-500/20 text-emerald-300 border border-emerald-400/40',
-      };
-    default:
-      return {
-        label: platform.trim() || platform,
-        classes: 'bg-clawd-700 text-gray-300 border border-clawd-600',
-      };
-  }
-};
+import { getPlatformDescriptor } from '../utils/advisoryPlatforms';
 
 interface AdvisoryPlatformBadgeProps {
   platform: string;

--- a/components/AdvisoryPlatformBadge.tsx
+++ b/components/AdvisoryPlatformBadge.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+interface PlatformDescriptor {
+  label: string;
+  classes: string;
+}
+
+const normalizePlatformSlug = (platform: string) => platform.trim().toLowerCase();
+
+export const getPlatformDescriptor = (platform: string): PlatformDescriptor => {
+  const normalized = normalizePlatformSlug(platform);
+
+  switch (normalized) {
+    case 'openclaw':
+      return {
+        label: 'OpenClaw',
+        classes: 'bg-clawd-accent/20 text-clawd-accent border border-clawd-accent/40',
+      };
+    case 'nanoclaw':
+      return {
+        label: 'NanoClaw',
+        classes: 'bg-clawd-secondary/20 text-clawd-secondary border border-clawd-secondary/40',
+      };
+    case 'hermes':
+      return {
+        label: 'Hermes',
+        classes: 'bg-emerald-500/20 text-emerald-300 border border-emerald-400/40',
+      };
+    default:
+      return {
+        label: platform.trim() || platform,
+        classes: 'bg-clawd-700 text-gray-300 border border-clawd-600',
+      };
+  }
+};
+
+interface AdvisoryPlatformBadgeProps {
+  platform: string;
+  className?: string;
+}
+
+export const AdvisoryPlatformBadge: React.FC<AdvisoryPlatformBadgeProps> = ({
+  platform,
+  className,
+}) => {
+  const { label, classes } = getPlatformDescriptor(platform);
+  const badgeClasses = ['uppercase tracking-wide', classes, className]
+    .filter(Boolean)
+    .join(' ');
+
+  return <span className={badgeClasses}>{label}</span>;
+};

--- a/pages/AdvisoryDetail.tsx
+++ b/pages/AdvisoryDetail.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, ExternalLink, Shield, AlertTriangle, Github, User, Bot } from 'lucide-react';
-import { AdvisoryPlatformBadge, getPlatformDescriptor } from '../components/AdvisoryPlatformBadge';
+import { AdvisoryPlatformBadge } from '../components/AdvisoryPlatformBadge';
 import { Footer } from '../components/Footer';
 import { Advisory, AdvisoryFeed } from '../types';
+import { getPlatformDescriptor } from '../utils/advisoryPlatforms';
 import {
   ADVISORY_FEED_URL,
   LEGACY_ADVISORY_FEED_URL,

--- a/pages/AdvisoryDetail.tsx
+++ b/pages/AdvisoryDetail.tsx
@@ -100,6 +100,32 @@ export const AdvisoryDetail: React.FC = () => {
     }
   };
 
+  const getPlatformLabel = (platform: string) => {
+    switch (platform) {
+      case 'openclaw':
+        return 'OpenClaw';
+      case 'nanoclaw':
+        return 'NanoClaw';
+      case 'hermes':
+        return 'Hermes';
+      default:
+        return platform;
+    }
+  };
+
+  const getPlatformClasses = (platform: string) => {
+    switch (platform) {
+      case 'openclaw':
+        return 'bg-clawd-accent/20 text-clawd-accent border border-clawd-accent/40';
+      case 'nanoclaw':
+        return 'bg-clawd-secondary/20 text-clawd-secondary border border-clawd-secondary/40';
+      case 'hermes':
+        return 'bg-emerald-500/20 text-emerald-300 border border-emerald-400/40';
+      default:
+        return 'bg-clawd-700 text-gray-300 border border-clawd-600';
+    }
+  };
+
   // Determine source - defaults to "Prompt Security Staff" when absent
   const getSource = (adv: Advisory) => {
     return adv.source || 'Prompt Security Staff';
@@ -154,6 +180,14 @@ export const AdvisoryDetail: React.FC = () => {
           <span className="text-sm text-gray-500">
             Published {formatDate(advisory.published)}
           </span>
+          {advisory.platforms?.map((platform) => (
+            <span
+              key={`${advisory.id}-platform-${platform}`}
+              className={`text-xs px-2 py-1 rounded uppercase tracking-wide ${getPlatformClasses(platform)}`}
+            >
+              {getPlatformLabel(platform)}
+            </span>
+          ))}
         </div>
 
         <h1 className="text-3xl font-bold text-white">{advisory.id}</h1>
@@ -259,6 +293,12 @@ export const AdvisoryDetail: React.FC = () => {
             <dt className="text-gray-500 mb-1">Published</dt>
             <dd className="text-white">{formatDate(advisory.published)}</dd>
           </div>
+          {advisory.platforms && advisory.platforms.length > 0 && (
+            <div className="flex justify-between md:block">
+              <dt className="text-gray-500 mb-1">Platforms</dt>
+              <dd className="text-white">{advisory.platforms.map(getPlatformLabel).join(', ')}</dd>
+            </div>
+          )}
           {/* Reporter info - subtle display for community reports */}
           {advisory.reporter && (
             <>

--- a/pages/AdvisoryDetail.tsx
+++ b/pages/AdvisoryDetail.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, ExternalLink, Shield, AlertTriangle, Github, User, Bot } from 'lucide-react';
+import { AdvisoryPlatformBadge, getPlatformDescriptor } from '../components/AdvisoryPlatformBadge';
 import { Footer } from '../components/Footer';
 import { Advisory, AdvisoryFeed } from '../types';
 import {
@@ -100,32 +101,6 @@ export const AdvisoryDetail: React.FC = () => {
     }
   };
 
-  const getPlatformLabel = (platform: string) => {
-    switch (platform) {
-      case 'openclaw':
-        return 'OpenClaw';
-      case 'nanoclaw':
-        return 'NanoClaw';
-      case 'hermes':
-        return 'Hermes';
-      default:
-        return platform;
-    }
-  };
-
-  const getPlatformClasses = (platform: string) => {
-    switch (platform) {
-      case 'openclaw':
-        return 'bg-clawd-accent/20 text-clawd-accent border border-clawd-accent/40';
-      case 'nanoclaw':
-        return 'bg-clawd-secondary/20 text-clawd-secondary border border-clawd-secondary/40';
-      case 'hermes':
-        return 'bg-emerald-500/20 text-emerald-300 border border-emerald-400/40';
-      default:
-        return 'bg-clawd-700 text-gray-300 border border-clawd-600';
-    }
-  };
-
   // Determine source - defaults to "Prompt Security Staff" when absent
   const getSource = (adv: Advisory) => {
     return adv.source || 'Prompt Security Staff';
@@ -181,12 +156,11 @@ export const AdvisoryDetail: React.FC = () => {
             Published {formatDate(advisory.published)}
           </span>
           {advisory.platforms?.map((platform) => (
-            <span
+            <AdvisoryPlatformBadge
               key={`${advisory.id}-platform-${platform}`}
-              className={`text-xs px-2 py-1 rounded uppercase tracking-wide ${getPlatformClasses(platform)}`}
-            >
-              {getPlatformLabel(platform)}
-            </span>
+              platform={platform}
+              className="text-xs px-2 py-1 rounded"
+            />
           ))}
         </div>
 
@@ -296,7 +270,7 @@ export const AdvisoryDetail: React.FC = () => {
           {advisory.platforms && advisory.platforms.length > 0 && (
             <div className="flex justify-between md:block">
               <dt className="text-gray-500 mb-1">Platforms</dt>
-              <dd className="text-white">{advisory.platforms.map(getPlatformLabel).join(', ')}</dd>
+              <dd className="text-white">{advisory.platforms.map((platform) => getPlatformDescriptor(platform).label).join(', ')}</dd>
             </div>
           )}
           {/* Reporter info - subtle display for community reports */}

--- a/pages/FeedSetup.tsx
+++ b/pages/FeedSetup.tsx
@@ -3,7 +3,7 @@ import { Rss, RefreshCw, Loader2, AlertTriangle, ChevronLeft, ChevronRight, Down
 import { Link } from 'react-router-dom';
 import { Footer } from '../components/Footer';
 import { AdvisoryCard } from '../components/AdvisoryCard';
-import { Advisory, AdvisoryFeed } from '../types';
+import { Advisory, AdvisoryFeed, AdvisoryPlatformFilter, CORE_PLATFORM_SLUGS } from '../types';
 import {
   ADVISORY_FEED_URL,
   LEGACY_ADVISORY_FEED_URL,
@@ -12,26 +12,37 @@ import {
 
 const ITEMS_PER_PAGE = 9;
 
+type SeverityFilter = 'all' | Advisory['severity'];
+type FilterTabOption<T extends string> = { value: T; label: string; active: string; inactive: string };
+
+const KNOWN_PLATFORM_SET = new Set<string>(CORE_PLATFORM_SLUGS);
+const normalizePlatformSlug = (platform: string) => platform.trim().toLowerCase();
+
 const SEVERITY_TABS = [
   { value: 'all',      label: 'All',      active: 'bg-clawd-accent text-white',                                    inactive: 'bg-clawd-800 text-gray-400 border border-clawd-700 hover:border-clawd-accent/50' },
   { value: 'critical', label: 'Critical', active: 'bg-red-500/20 text-red-400 border-2 border-red-400',            inactive: 'bg-clawd-800 text-gray-400 border border-clawd-700 hover:border-red-400/50' },
   { value: 'high',     label: 'High',     active: 'bg-orange-500/20 text-orange-400 border-2 border-orange-400',   inactive: 'bg-clawd-800 text-gray-400 border border-clawd-700 hover:border-orange-400/50' },
   { value: 'medium',   label: 'Medium',   active: 'bg-yellow-500/20 text-yellow-400 border-2 border-yellow-400',   inactive: 'bg-clawd-800 text-gray-400 border border-clawd-700 hover:border-yellow-400/50' },
   { value: 'low',      label: 'Low',      active: 'bg-blue-500/20 text-blue-400 border-2 border-blue-400',         inactive: 'bg-clawd-800 text-gray-400 border border-clawd-700 hover:border-blue-400/50' },
-] as const;
+] as const satisfies ReadonlyArray<FilterTabOption<SeverityFilter>>;
 
 const PLATFORM_TABS = [
   { value: 'all',      label: 'All Platforms', active: 'bg-clawd-accent text-white',                                         inactive: 'bg-clawd-800 text-gray-400 border border-clawd-700 hover:border-clawd-accent/50' },
   { value: 'openclaw', label: 'OpenClaw',      active: 'bg-clawd-accent/20 text-clawd-accent border-2 border-clawd-accent',  inactive: 'bg-clawd-800 text-gray-400 border border-clawd-700 hover:border-clawd-accent/50' },
   { value: 'nanoclaw', label: 'NanoClaw',      active: 'bg-clawd-secondary/20 text-clawd-secondary border-2 border-clawd-secondary', inactive: 'bg-clawd-800 text-gray-400 border border-clawd-700 hover:border-clawd-secondary/50' },
   { value: 'hermes',   label: 'Hermes',        active: 'bg-emerald-500/20 text-emerald-300 border-2 border-emerald-400',      inactive: 'bg-clawd-800 text-gray-400 border border-clawd-700 hover:border-emerald-400/50' },
-] as const;
+  { value: 'other',    label: 'Other',         active: 'bg-clawd-600/40 text-gray-100 border-2 border-clawd-500',            inactive: 'bg-clawd-800 text-gray-400 border border-clawd-700 hover:border-clawd-500/50' },
+] as const satisfies ReadonlyArray<FilterTabOption<AdvisoryPlatformFilter>>;
 
-const FilterTabs: React.FC<{
-  tabs: ReadonlyArray<{ value: string; label: string; active: string; inactive: string }>;
-  selected: string;
-  onSelect: (value: string) => void;
-}> = ({ tabs, selected, onSelect }) => (
+const FilterTabs = <T extends string,>({
+  tabs,
+  selected,
+  onSelect,
+}: {
+  tabs: ReadonlyArray<FilterTabOption<T>>;
+  selected: T;
+  onSelect: (value: T) => void;
+}) => (
   <div className="flex flex-wrap justify-center gap-3 mb-8">
     {tabs.map(({ value, label, active, inactive }) => (
       <button
@@ -53,8 +64,8 @@ export const FeedSetup: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
-  const [selectedSeverity, setSelectedSeverity] = useState<string>('all');
-  const [selectedPlatform, setSelectedPlatform] = useState<string>('all');
+  const [selectedSeverity, setSelectedSeverity] = useState<SeverityFilter>('all');
+  const [selectedPlatform, setSelectedPlatform] = useState<AdvisoryPlatformFilter>('all');
 
   useEffect(() => {
     const fetchAdvisories = async () => {
@@ -93,10 +104,25 @@ export const FeedSetup: React.FC = () => {
   }, []);
 
   const filteredAdvisories = useMemo(
-    () => advisories.filter((a) =>
-      (selectedSeverity === 'all' || a.severity === selectedSeverity) &&
-      (selectedPlatform === 'all' || !a.platforms?.length || a.platforms.includes(selectedPlatform))
-    ),
+    () => advisories.filter((a) => {
+      if (selectedSeverity !== 'all' && a.severity !== selectedSeverity) {
+        return false;
+      }
+
+      if (selectedPlatform === 'all') {
+        return true;
+      }
+
+      const advisoryPlatforms = (a.platforms ?? [])
+        .map(normalizePlatformSlug)
+        .filter(Boolean);
+
+      if (selectedPlatform === 'other') {
+        return advisoryPlatforms.some((platform) => !KNOWN_PLATFORM_SET.has(platform));
+      }
+
+      return advisoryPlatforms.length === 0 || advisoryPlatforms.includes(selectedPlatform);
+    }),
     [advisories, selectedSeverity, selectedPlatform],
   );
 

--- a/pages/FeedSetup.tsx
+++ b/pages/FeedSetup.tsx
@@ -24,6 +24,7 @@ const PLATFORM_TABS = [
   { value: 'all',      label: 'All Platforms', active: 'bg-clawd-accent text-white',                                         inactive: 'bg-clawd-800 text-gray-400 border border-clawd-700 hover:border-clawd-accent/50' },
   { value: 'openclaw', label: 'OpenClaw',      active: 'bg-clawd-accent/20 text-clawd-accent border-2 border-clawd-accent',  inactive: 'bg-clawd-800 text-gray-400 border border-clawd-700 hover:border-clawd-accent/50' },
   { value: 'nanoclaw', label: 'NanoClaw',      active: 'bg-clawd-secondary/20 text-clawd-secondary border-2 border-clawd-secondary', inactive: 'bg-clawd-800 text-gray-400 border border-clawd-700 hover:border-clawd-secondary/50' },
+  { value: 'hermes',   label: 'Hermes',        active: 'bg-emerald-500/20 text-emerald-300 border-2 border-emerald-400',      inactive: 'bg-clawd-800 text-gray-400 border border-clawd-700 hover:border-emerald-400/50' },
 ] as const;
 
 const FilterTabs: React.FC<{
@@ -132,7 +133,7 @@ export const FeedSetup: React.FC = () => {
         <h1 className="text-3xl md:text-4xl text-white">Security Hardening Feed</h1>
         <p className="text-gray-400 max-w-2xl mx-auto">
           A continuous stream of security advisories from NVD CVE data and staff-approved community reports. 
-          This feed is automatically updated with OpenClaw and NanoClaw-related vulnerabilities and verified security incidents.
+          This feed is automatically updated with OpenClaw, NanoClaw, and Hermes-related vulnerabilities and verified security incidents.
         </p>
         {lastUpdated && (
           <p className="text-xs text-gray-500">

--- a/pages/FeedSetup.tsx
+++ b/pages/FeedSetup.tsx
@@ -3,7 +3,8 @@ import { Rss, RefreshCw, Loader2, AlertTriangle, ChevronLeft, ChevronRight, Down
 import { Link } from 'react-router-dom';
 import { Footer } from '../components/Footer';
 import { AdvisoryCard } from '../components/AdvisoryCard';
-import { Advisory, AdvisoryFeed, AdvisoryPlatformFilter, CORE_PLATFORM_SLUGS } from '../types';
+import { Advisory, AdvisoryFeed, AdvisoryPlatformFilter } from '../types';
+import { isCorePlatformSlug, normalizePlatformSlug } from '../utils/advisoryPlatforms';
 import {
   ADVISORY_FEED_URL,
   LEGACY_ADVISORY_FEED_URL,
@@ -14,9 +15,6 @@ const ITEMS_PER_PAGE = 9;
 
 type SeverityFilter = 'all' | Advisory['severity'];
 type FilterTabOption<T extends string> = { value: T; label: string; active: string; inactive: string };
-
-const KNOWN_PLATFORM_SET = new Set<string>(CORE_PLATFORM_SLUGS);
-const normalizePlatformSlug = (platform: string) => platform.trim().toLowerCase();
 
 const SEVERITY_TABS = [
   { value: 'all',      label: 'All',      active: 'bg-clawd-accent text-white',                                    inactive: 'bg-clawd-800 text-gray-400 border border-clawd-700 hover:border-clawd-accent/50' },
@@ -118,7 +116,7 @@ export const FeedSetup: React.FC = () => {
         .filter(Boolean);
 
       if (selectedPlatform === 'other') {
-        return advisoryPlatforms.some((platform) => !KNOWN_PLATFORM_SET.has(platform));
+        return advisoryPlatforms.some((platform) => !isCorePlatformSlug(platform));
       }
 
       return advisoryPlatforms.length === 0 || advisoryPlatforms.includes(selectedPlatform);
@@ -169,8 +167,16 @@ export const FeedSetup: React.FC = () => {
       </section>
 
       <section>
-        <FilterTabs tabs={SEVERITY_TABS} selected={selectedSeverity} onSelect={setSelectedSeverity} />
-        <FilterTabs tabs={PLATFORM_TABS} selected={selectedPlatform} onSelect={setSelectedPlatform} />
+        <FilterTabs
+          tabs={SEVERITY_TABS}
+          selected={selectedSeverity}
+          onSelect={(value) => setSelectedSeverity(value as SeverityFilter)}
+        />
+        <FilterTabs
+          tabs={PLATFORM_TABS}
+          selected={selectedPlatform}
+          onSelect={(value) => setSelectedPlatform(value as AdvisoryPlatformFilter)}
+        />
 
         {loading ? (
           <div className="flex items-center justify-center py-12">

--- a/scripts/populate-local-feed.sh
+++ b/scripts/populate-local-feed.sh
@@ -158,17 +158,16 @@ echo "Filtered CVEs (matching criteria): $FILTERED"
 # Get existing advisory IDs (unless force mode)
 if [ "$FORCE" = "true" ]; then
   echo "Force mode: ignoring existing advisory IDs during transform"
-  EXISTING_IDS=""
+  echo '[]' > "$TEMP_DIR/existing_ids.json"
 elif [ -f "$FEED_PATH" ]; then
-  EXISTING_IDS=$(jq -r '.advisories[]?.id // empty' "$FEED_PATH" | sort -u)
+  jq -r '.advisories[]?.id // empty' "$FEED_PATH" | sort -u | \
+    jq -R -s 'split("\n") | map(select(length > 0))' > "$TEMP_DIR/existing_ids.json"
 else
-  EXISTING_IDS=""
+  echo '[]' > "$TEMP_DIR/existing_ids.json"
 fi
 
 # Transform CVEs to our advisory format (same logic as pipeline)
-EXISTING_JSON=$(echo "$EXISTING_IDS" | jq -R -s 'split("\n") | map(select(length > 0))')
-
-jq --argjson existing "$EXISTING_JSON" '
+jq --slurpfile existing "$TEMP_DIR/existing_ids.json" '
   def map_severity:
     if . == null then "medium"
     elif . >= 9.0 then "critical"
@@ -308,16 +307,23 @@ jq --argjson existing "$EXISTING_JSON" '
           | if ($from_targets | length) > 0 then $from_targets else ["openclaw", "nanoclaw", "hermes"] end
         end
     );
+
+  def preferred_description:
+    (
+      (.cve.descriptions[]? | select(.lang == "en") | .value)
+      // .cve.descriptions[0]?.value
+      // "No description provided by NVD."
+    );
   
   [.[] |
-    select(.cve.id as $id | $existing | index($id) | not) |
+    select(.cve.id as $id | (($existing[0] // []) | index($id) | not)) |
     {
       id: .cve.id,
       severity: (get_cvss_score | map_severity),
       type: nvd_category_name,
       nvd_category_id: nvd_category_raw,
-      title: (.cve.descriptions[] | select(.lang == "en") | .value | .[0:100] + (if length > 100 then "..." else "" end)),
-      description: (.cve.descriptions[] | select(.lang == "en") | .value),
+      title: (preferred_description | .[0:100] + (if length > 100 then "..." else "" end)),
+      description: preferred_description,
       affected: normalized_affected,
       platforms: normalized_platforms,
       action: "Review and update affected components. See NVD for remediation details.",
@@ -333,6 +339,11 @@ jq --argjson existing "$EXISTING_JSON" '
 
 NEW_COUNT=$(jq 'length' "$TEMP_DIR/new_advisories.json")
 echo "New advisories to add: $NEW_COUNT"
+
+if [ "$FORCE" = "true" ] && [ "$NEW_COUNT" -ne "$FILTERED" ]; then
+  echo "Error: full rebuild transform mismatch (filtered=$FILTERED, transformed=$NEW_COUNT)"
+  exit 1
+fi
 
 if [ "$NEW_COUNT" -eq 0 ]; then
   echo ""
@@ -374,11 +385,11 @@ NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 # Merge new advisories into existing feed
 if [ -f "$FEED_PATH" ]; then
-  jq --argjson new "$(cat "$TEMP_DIR/new_advisories.json")" --arg now "$NOW" '
+  jq --slurpfile new "$TEMP_DIR/new_advisories.json" --arg now "$NOW" '
     .updated = $now |
     # Merge by advisory ID so force mode can refresh existing CVEs without duplicates
     .advisories = (
-      reduce (.advisories + $new)[] as $adv
+      reduce ((.advisories // []) + ($new[0] // []))[] as $adv
         ({};
           if ($adv.id // "") == "" then
             .
@@ -392,11 +403,11 @@ if [ -f "$FEED_PATH" ]; then
     )
   ' "$FEED_PATH" > "$TEMP_DIR/updated_feed.json"
 else
-  jq -n --argjson advisories "$(cat "$TEMP_DIR/new_advisories.json")" --arg now "$NOW" '{
+  jq -n --slurpfile advisories "$TEMP_DIR/new_advisories.json" --arg now "$NOW" '{
     version: "1.0.0",
     updated: $now,
     description: "Community-driven security advisory feed for ClawSec. Automatically updated with OpenClaw, NanoClaw, and Hermes-related CVEs from NVD.",
-    advisories: ($advisories | sort_by(.published) | reverse)
+    advisories: (($advisories[0] // []) | sort_by(.published) | reverse)
   }' > "$TEMP_DIR/updated_feed.json"
 fi
 

--- a/scripts/populate-local-feed.sh
+++ b/scripts/populate-local-feed.sh
@@ -275,23 +275,38 @@ jq --argjson existing "$EXISTING_JSON" '
         )
     );
 
-  def normalized_affected:
+  def matched_targets:
     (
       (cpe_criteria + inferred_targets)
       | unique
       | .[0:5]
+    );
+
+  def platforms_from_targets($targets):
+    (
+      [
+        (if ($targets | map(strings | ascii_downcase | select(startswith("openclaw@") or test("^cpe:2\\.3:[aho]:openclaw:openclaw(?::|$)"))) | length > 0) then "openclaw" else empty end),
+        (if ($targets | map(strings | ascii_downcase | select(startswith("nanoclaw@") or test("^cpe:2\\.3:[aho]:[^:]*:nanoclaw(?::|$)"))) | length > 0) then "nanoclaw" else empty end),
+        (if ($targets | map(strings | ascii_downcase | select(startswith("hermes@") or test("^cpe:2\\.3:[aho]:software-metadata\\.pub:hermes(?::|$)"))) | length > 0) then "hermes" else empty end)
+      ]
+    );
+
+  def normalized_affected:
+    (
+      matched_targets
       | if length == 0 then ["openclaw@*", "nanoclaw@*", "hermes@*"] else . end
     );
 
   def normalized_platforms:
     (
-      inferred_targets as $targets
-      | [
-          (if ($targets | map(select(startswith("openclaw@"))) | length > 0) then "openclaw" else empty end),
-          (if ($targets | map(select(startswith("nanoclaw@"))) | length > 0) then "nanoclaw" else empty end),
-          (if ($targets | map(select(startswith("hermes@"))) | length > 0) then "hermes" else empty end)
-        ]
-      | if length == 0 then ["openclaw", "nanoclaw", "hermes"] else . end
+      inferred_targets as $inferred
+      | platforms_from_targets($inferred) as $from_inferred
+      | if ($from_inferred | length) > 0 then $from_inferred
+        else
+          matched_targets as $targets
+          | platforms_from_targets($targets) as $from_targets
+          | if ($from_targets | length) > 0 then $from_targets else ["openclaw", "nanoclaw", "hermes"] end
+        end
     );
   
   [.[] |

--- a/scripts/populate-local-feed.sh
+++ b/scripts/populate-local-feed.sh
@@ -275,38 +275,23 @@ jq --argjson existing "$EXISTING_JSON" '
         )
     );
 
-  def matched_targets:
+  def normalized_affected:
     (
       (cpe_criteria + inferred_targets)
       | unique
       | .[0:5]
-    );
-
-  def platforms_from_targets($targets):
-    (
-      [
-        (if ($targets | map(strings | ascii_downcase | select(startswith("openclaw@") or test("^cpe:2\\.3:[aho]:openclaw:openclaw(?::|$)"))) | length > 0) then "openclaw" else empty end),
-        (if ($targets | map(strings | ascii_downcase | select(startswith("nanoclaw@") or test("^cpe:2\\.3:[aho]:[^:]*:nanoclaw(?::|$)"))) | length > 0) then "nanoclaw" else empty end),
-        (if ($targets | map(strings | ascii_downcase | select(startswith("hermes@") or test("^cpe:2\\.3:[aho]:software-metadata\\.pub:hermes(?::|$)"))) | length > 0) then "hermes" else empty end)
-      ]
-    );
-
-  def normalized_affected:
-    (
-      matched_targets
       | if length == 0 then ["openclaw@*", "nanoclaw@*", "hermes@*"] else . end
     );
 
   def normalized_platforms:
     (
-      inferred_targets as $inferred
-      | platforms_from_targets($inferred) as $from_inferred
-      | if ($from_inferred | length) > 0 then $from_inferred
-        else
-          matched_targets as $targets
-          | platforms_from_targets($targets) as $from_targets
-          | if ($from_targets | length) > 0 then $from_targets else ["openclaw", "nanoclaw", "hermes"] end
-        end
+      inferred_targets as $targets
+      | [
+          (if ($targets | map(select(startswith("openclaw@"))) | length > 0) then "openclaw" else empty end),
+          (if ($targets | map(select(startswith("nanoclaw@"))) | length > 0) then "nanoclaw" else empty end),
+          (if ($targets | map(select(startswith("hermes@"))) | length > 0) then "hermes" else empty end)
+        ]
+      | if length == 0 then ["openclaw", "nanoclaw", "hermes"] else . end
     );
   
   [.[] |

--- a/types.ts
+++ b/types.ts
@@ -28,6 +28,11 @@ export type AdvisoryType =
   // Keep this open for new categories without requiring type updates.
   | string;
 
+export const CORE_PLATFORM_SLUGS = ['openclaw', 'nanoclaw', 'hermes'] as const;
+export type CorePlatformSlug = (typeof CORE_PLATFORM_SLUGS)[number];
+export type AdvisoryPlatformSlug = CorePlatformSlug | (string & {});
+export type AdvisoryPlatformFilter = 'all' | CorePlatformSlug | 'other';
+
 // Full advisory type from NVD CVE feed or community reports
 export interface Advisory {
   id: string;
@@ -41,7 +46,7 @@ export interface Advisory {
   references?: string[];
   cvss_score?: number | null;
   nvd_url?: string;
-  platforms?: string[];
+  platforms?: AdvisoryPlatformSlug[];
   // Community report fields (source defaults to "Prompt Security Staff" when absent)
   source?: string;
   github_issue_url?: string;

--- a/utils/advisoryPlatforms.ts
+++ b/utils/advisoryPlatforms.ts
@@ -29,13 +29,7 @@ export const isCorePlatformSlug = (platform: string) =>
 
 export const getPlatformDescriptor = (platform: string): PlatformDescriptor => {
   const normalized = normalizePlatformSlug(platform);
-  const descriptor = PLATFORM_DESCRIPTOR_BY_SLUG[normalized];
-
-  if (descriptor) {
-    return descriptor;
-  }
-
-  return {
+  return PLATFORM_DESCRIPTOR_BY_SLUG[normalized] ?? {
     label: platform.trim() || platform,
     classes: 'bg-clawd-700 text-gray-300 border border-clawd-600',
   };

--- a/utils/advisoryPlatforms.ts
+++ b/utils/advisoryPlatforms.ts
@@ -1,0 +1,42 @@
+import { CORE_PLATFORM_SLUGS } from '../types';
+
+export interface PlatformDescriptor {
+  label: string;
+  classes: string;
+}
+
+export const normalizePlatformSlug = (platform: string) => platform.trim().toLowerCase();
+
+const PLATFORM_DESCRIPTOR_BY_SLUG: Record<string, PlatformDescriptor> = {
+  openclaw: {
+    label: 'OpenClaw',
+    classes: 'bg-clawd-accent/20 text-clawd-accent border border-clawd-accent/40',
+  },
+  nanoclaw: {
+    label: 'NanoClaw',
+    classes: 'bg-clawd-secondary/20 text-clawd-secondary border border-clawd-secondary/40',
+  },
+  hermes: {
+    label: 'Hermes',
+    classes: 'bg-emerald-500/20 text-emerald-300 border border-emerald-400/40',
+  },
+};
+
+const CORE_PLATFORM_SET = new Set<string>(CORE_PLATFORM_SLUGS);
+
+export const isCorePlatformSlug = (platform: string) =>
+  CORE_PLATFORM_SET.has(normalizePlatformSlug(platform));
+
+export const getPlatformDescriptor = (platform: string): PlatformDescriptor => {
+  const normalized = normalizePlatformSlug(platform);
+  const descriptor = PLATFORM_DESCRIPTOR_BY_SLUG[normalized];
+
+  if (descriptor) {
+    return descriptor;
+  }
+
+  return {
+    label: platform.trim() || platform,
+    classes: 'bg-clawd-700 text-gray-300 border border-clawd-600',
+  };
+};


### PR DESCRIPTION
# User description
## Summary
- remove large JSON shell-arg passing in NVD pipeline/local script (`--argjson "$(cat ...)"`) and switch to file-based `--slurpfile` usage
- avoid transform drops by using a safe description fallback when an English description is missing
- add a full-rebuild integrity guard: fail if transformed advisory count != filtered CVE count
- add Hermes visibility in frontend feed UI (platform tab + platform badges in card/detail views)

## Why this fixes the crash
Full scans can produce very large advisory arrays. Passing those arrays through command-line args can exceed OS argument size limits. This PR keeps payloads on disk and lets `jq` read them from files, which avoids `ARG_MAX` failures.

## Validation
- `bash -n scripts/populate-local-feed.sh`
- workflow YAML parse (`ruby -e ...`)
- local feed smoke run: `./scripts/populate-local-feed.sh --days 1` with temp feed paths

## Notes
- I also used a subagent to audit frontend platform rendering and applied the minimal Hermes visibility changes.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Replace large JSON shell arguments in the NVD transformation workflow with file-based <code>jq --slurpfile</code> consumption, add a safe English description fallback, and fail full rebuilds if transformed counts differ from filtered CVEs. Add Hermes-aware platform badges and feed filtering so advisory cards and detail views expose platform visibility alongside the updated feed setup logic.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/204?tool=ast&topic=Platform+badges>Platform badges</a>
        </td><td>Expose Hermes-specific filters and badges across advisory cards, detail views, and feed setup so platforms are visible in the UI with normalized descriptors.<details><summary>Modified files (6)</summary><ul><li>components/AdvisoryCard.tsx</li>
<li>components/AdvisoryPlatformBadge.tsx</li>
<li>pages/AdvisoryDetail.tsx</li>
<li>pages/FeedSetup.tsx</li>
<li>types.ts</li>
<li>utils/advisoryPlatforms.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>docs: refresh README, ...</td><td>February 26, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>ClawSec init</td><td>February 05, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/204?tool=ast&topic=Pipeline+integrity>Pipeline integrity</a>
        </td><td>Store advisory payloads on disk for the transform workflow, reuse safe English descriptions, and guard full rebuild counts so <code>jq</code> never receives giant args during the NVD rebuild flow.<details><summary>Modified files (2)</summary><ul><li>.github/workflows/poll-nvd-cves.yml</li>
<li>scripts/populate-local-feed.sh</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>fix(nvd): add hermes q...</td><td>April 21, 2026</td></tr>
<tr><td>david@abutbul.com</td><td>Nanoclaw integration (...</td><td>February 25, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/prompt-security/clawsec/204?tool=ast>(Baz)</a>.