### PR TITLE
fix(codeql): exclude generated dist artifacts from analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "ClawSec CodeQL Config"
+
+paths-ignore:
+  - dist/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ jobs:
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- add a CodeQL config file in .github/codeql/codeql-config.yml
- ignore generated dist artifacts from code scanning
- wire the config into the CodeQL workflow init step

## Security Benefit
- reduces false positives from minified generated bundles
- keeps CodeQL findings focused on maintained source files

## Testing
- verified git diff and PR file list
- no runtime code changes
