### PR TITLE
Include hermes-agent in NVD queries and export keywords to environment

### DIFF
--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -217,6 +217,9 @@ jobs:
           KEYWORDS_PATTERN="$(nvd_keyword_pattern)"
           GITHUB_PATTERN="$(nvd_github_ref_pattern)"
           CPE_PATTERN="$(nvd_cpe_pattern)"
+          # Export plain keywords for later PR body + workflow summary steps
+          KEYWORDS="$KEYWORDS_PATTERN"
+          echo "KEYWORDS=$KEYWORDS" >> "$GITHUB_ENV"
 
           # Combine all fetched CVEs
           echo '{"vulnerabilities":[]}' > tmp/combined.json
@@ -398,7 +401,7 @@ jobs:
                 | (
                     (if ($blob | test("github\\.com/openclaw/openclaw|\\bopenclaw\\b|\\bclawdbot\\b|\\bmoltbot\\b")) then ["openclaw@*"] else [] end)
                     + (if ($blob | test("github\\.com/qwibitai/nanoclaw|\\bnanoclaw\\b|whatsapp-bot|\\bbaileys\\b")) then ["nanoclaw@*"] else [] end)
-                    + (if ($blob | test("github\\.com/softwarepub/hermes|cpe:2\\.3:a:software-metadata\\.pub:hermes|\\bhermes workflow\\b|software publication with rich metadata")) then ["hermes@*"] else [] end)
+                    + (if ($blob | test("github\\.com/softwarepub/hermes|github\\.com/nousresearch/hermes-agent|cpe:2\\.3:a:software-metadata\\.pub:hermes|\\bhermes workflow\\b|\\bhermes-agent\\b|software publication with rich metadata")) then ["hermes@*"] else [] end)
                     + (if ($blob | test("github\\.com/[^/]+/picoclaw|\\bpicoclaw\\b|cpe:2\\.3:[aho]:[^:]*:picoclaw(?::|$)")) then ["picoclaw@*"] else [] end)
                   )
               );
@@ -640,7 +643,7 @@ jobs:
                 | (
                     (if ($blob | test("github\\.com/openclaw/openclaw|\\bopenclaw\\b|\\bclawdbot\\b|\\bmoltbot\\b")) then ["openclaw@*"] else [] end)
                     + (if ($blob | test("github\\.com/qwibitai/nanoclaw|\\bnanoclaw\\b|whatsapp-bot|\\bbaileys\\b")) then ["nanoclaw@*"] else [] end)
-                    + (if ($blob | test("github\\.com/softwarepub/hermes|cpe:2\\.3:a:software-metadata\\.pub:hermes|\\bhermes workflow\\b|software publication with rich metadata")) then ["hermes@*"] else [] end)
+                    + (if ($blob | test("github\\.com/softwarepub/hermes|github\\.com/nousresearch/hermes-agent|cpe:2\\.3:a:software-metadata\\.pub:hermes|\\bhermes workflow\\b|\\bhermes-agent\\b|software publication with rich metadata")) then ["hermes@*"] else [] end)
                     + (if ($blob | test("github\\.com/[^/]+/picoclaw|\\bpicoclaw\\b|cpe:2\\.3:[aho]:[^:]*:picoclaw(?::|$)")) then ["picoclaw@*"] else [] end)
                   )
               );

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -217,8 +217,8 @@ jobs:
           KEYWORDS_PATTERN="$(nvd_keyword_pattern)"
           GITHUB_PATTERN="$(nvd_github_ref_pattern)"
           CPE_PATTERN="$(nvd_cpe_pattern)"
-          # Export plain keywords for later PR body + workflow summary steps
-          KEYWORDS="$KEYWORDS_PATTERN"
+          # Export concise project keyword groups for PR body + workflow summary steps
+          KEYWORDS="$(nvd_summary_keywords)"
           echo "KEYWORDS=$KEYWORDS" >> "$GITHUB_ENV"
 
           # Combine all fetched CVEs

--- a/scripts/feed-utils.sh
+++ b/scripts/feed-utils.sh
@@ -52,6 +52,10 @@ virtualMatchString|cpe:2.3:a:picoclaw:picoclaw
 EOF
 }
 
+nvd_summary_keywords() {
+  echo 'openclaw, nanoclaw, hermes, picoclaw'
+}
+
 nvd_keyword_pattern() {
   echo 'OpenClaw|clawdbot|Moltbot|openclaw|NanoClaw|nanoclaw|WhatsApp-bot|baileys|HERMES workflow|hermes-agent|software publication with rich metadata|Picoclaw|picoclaw'
 }

--- a/scripts/feed-utils.sh
+++ b/scripts/feed-utils.sh
@@ -45,6 +45,7 @@ keyword|NanoClaw
 keyword|WhatsApp-bot
 keyword|baileys
 keyword|hermes workflow
+keyword|hermes-agent
 keyword|Picoclaw
 virtualMatchString|cpe:2.3:a:software-metadata.pub:hermes
 virtualMatchString|cpe:2.3:a:picoclaw:picoclaw
@@ -52,11 +53,11 @@ EOF
 }
 
 nvd_keyword_pattern() {
-  echo 'OpenClaw|clawdbot|Moltbot|openclaw|NanoClaw|nanoclaw|WhatsApp-bot|baileys|HERMES workflow|software publication with rich metadata|Picoclaw|picoclaw'
+  echo 'OpenClaw|clawdbot|Moltbot|openclaw|NanoClaw|nanoclaw|WhatsApp-bot|baileys|HERMES workflow|hermes-agent|software publication with rich metadata|Picoclaw|picoclaw'
 }
 
 nvd_github_ref_pattern() {
-  echo 'github\.com/openclaw/openclaw|github\.com/qwibitai/nanoclaw|github\.com/softwarepub/hermes|github\.com/[^/]+/picoclaw'
+  echo 'github\.com/openclaw/openclaw|github\.com/qwibitai/nanoclaw|github\.com/softwarepub/hermes|github\.com/nousresearch/hermes-agent|github\.com/[^/]+/picoclaw'
 }
 
 nvd_cpe_pattern() {


### PR DESCRIPTION
# User description
### Motivation

- Extend NVD polling and heuristics to detect the `hermes-agent` project alongside existing targets and make the plain keyword list available for PR bodies and workflow summaries.

### Description

- Added `KEYWORDS` export in the poll workflow by writing `KEYWORDS=$KEYWORDS_PATTERN` to the `GITHUB_ENV` so downstream steps can access the plain keywords.
- Added `hermes-agent` to the NVD query specs in `nvd_query_specs()` and to the keyword pattern returned by `nvd_keyword_pattern()` in `scripts/feed-utils.sh`.
- Updated `nvd_github_ref_pattern()` to include `github.com/nousresearch/hermes-agent` so GitHub reference matching detects that repository.
- Extended the JSON/JQ detection logic in the workflow to recognize `github.com/nousresearch/hermes-agent` and the token `hermes-agent` in the inferred targets checks (changes appear in both detection blocks).

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9c393774c83268e9d401677686826)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable the poll workflow and <code>feed-utils</code> helper functions to treat <code>hermes-agent</code> like other monitored projects so NVD detection, inferred targets, and keyword specs include the new repo, keywords, and CPE references. Export <code>nvd_summary_keywords</code> into <code>GITHUB_ENV</code> so downstream PR body and workflow summary steps can reuse the concise keyword list.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/226?tool=ast&topic=Keyword+Export>Keyword Export</a>
        </td><td>Export <code>nvd_summary_keywords</code> into <code>GITHUB_ENV</code> so downstream steps can reuse the concise keyword list for PR bodies and workflow summaries.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/poll-nvd-cves.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(workflow): export ...</td><td>May 07, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(workflow): expand ...</td><td>May 05, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/226?tool=ast&topic=NVD+Targeting>NVD Targeting</a>
        </td><td>Expand detection flows to include <code>hermes-agent</code> keywords, GitHub ref, and CPE patterns so the poll workflow and <code>feed-utils</code> inferred-target logic normalize the new repo alongside other monitored projects.<details><summary>Modified files (2)</summary><ul><li>.github/workflows/poll-nvd-cves.yml</li>
<li>scripts/feed-utils.sh</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(workflow): export ...</td><td>May 07, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(workflow): expand ...</td><td>May 05, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/prompt-security/clawsec/226?tool=ast>(Baz)</a>.