### PR TITLE
fix(skills-catalog): resolve platform metadata fallbacks

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -183,16 +183,23 @@ jobs:
                 done
 
                 # Build skill entry for index
-                SKILL_DATA=$(jq -c --arg tag "$TAG" '{
-                  id: .name,
-                  name: .name,
-                  version: .version,
-                  description: .description,
-                  emoji: .openclaw.emoji,
-                  category: .openclaw.category,
-                  trust: .trust.level,
-                  tag: $tag
-                }' "$MIRROR_DIR/skill.json")
+                SKILL_DATA=$(jq -c --arg tag "$TAG" '
+                  def platform_meta:
+                    (.platform as $platform
+                      | if ($platform != null and .[$platform]? != null) then .[$platform]
+                        else (.openclaw // .hermes // .nanoclaw // .picoclaw // {})
+                        end);
+                  {
+                    id: .name,
+                    name: .name,
+                    version: .version,
+                    description: .description,
+                    emoji: (platform_meta.emoji // .openclaw.emoji // .hermes.emoji // .nanoclaw.emoji // .picoclaw.emoji // "📦"),
+                    category: (platform_meta.category // .openclaw.category // .hermes.category // .nanoclaw.category // .picoclaw.category // "utility"),
+                    trust: .trust.level,
+                    tag: $tag
+                  }
+                ' "$MIRROR_DIR/skill.json")
 
                 # Append to index (handle first entry without comma)
                 if [ -f "public/skills/.first_done" ]; then

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -184,18 +184,22 @@ jobs:
 
                 # Build skill entry for index
                 SKILL_DATA=$(jq -c --arg tag "$TAG" '
+                  def object_or_empty($value):
+                    if ($value | type) == "object" then $value else {} end;
+                  def object_field($name):
+                    object_or_empty(.[$name]?);
                   def platform_meta:
                     (.platform as $platform
-                      | if ($platform != null and .[$platform]? != null) then .[$platform]
-                        else (.openclaw // .hermes // .nanoclaw // .picoclaw // {})
+                      | if ($platform | type) == "string" then object_or_empty(.[$platform]?)
+                        else {}
                         end);
                   {
                     id: .name,
                     name: .name,
                     version: .version,
                     description: .description,
-                    emoji: (platform_meta.emoji // .openclaw.emoji // .hermes.emoji // .nanoclaw.emoji // .picoclaw.emoji // "📦"),
-                    category: (platform_meta.category // .openclaw.category // .hermes.category // .nanoclaw.category // .picoclaw.category // "utility"),
+                    emoji: (platform_meta.emoji // object_field("openclaw").emoji // object_field("hermes").emoji // object_field("nanoclaw").emoji // object_field("picoclaw").emoji // "📦"),
+                    category: (platform_meta.category // object_field("openclaw").category // object_field("hermes").category // object_field("nanoclaw").category // object_field("picoclaw").category // "utility"),
                     trust: .trust.level,
                     tag: $tag
                   }

--- a/pages/SkillDetail.tsx
+++ b/pages/SkillDetail.tsx
@@ -8,26 +8,35 @@ import type { SkillJson, SkillChecksums, SkillPlatformMetadata } from '../types'
 import { defaultMarkdownComponents } from '../utils/markdownComponents';
 import { stripFrontmatter } from '../utils/markdownHelpers.mjs';
 
+const PLATFORM_METADATA_KEYS = ['openclaw', 'hermes', 'nanoclaw', 'picoclaw'] as const;
+
 const isProbablyHtmlDocument = (text: string): boolean => {
   const start = text.trimStart().slice(0, 200).toLowerCase();
   return start.startsWith('<!doctype html') || start.startsWith('<html');
 };
 
+const isPlatformMetadataObject = (value: unknown): value is SkillPlatformMetadata => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const maybe = value as Record<string, unknown>;
+  return 'emoji' in maybe || 'category' in maybe || 'triggers' in maybe;
+};
+
 const resolvePlatformMetadata = (skill: SkillJson): SkillPlatformMetadata => {
   const platform = skill.platform;
-  const platformBlock =
-    typeof platform === 'string' && platform in skill
-      ? (skill[platform as keyof SkillJson] as SkillPlatformMetadata | null | undefined)
-      : undefined;
+  if (
+    typeof platform === 'string' &&
+    (PLATFORM_METADATA_KEYS as readonly string[]).includes(platform)
+  ) {
+    const platformBlock = skill[platform as (typeof PLATFORM_METADATA_KEYS)[number]];
+    if (isPlatformMetadataObject(platformBlock)) return platformBlock;
+  }
 
-  return (
-    platformBlock ??
-    skill.openclaw ??
-    skill.hermes ??
-    skill.nanoclaw ??
-    skill.picoclaw ??
-    {}
-  );
+  for (const key of PLATFORM_METADATA_KEYS) {
+    const fallbackBlock = skill[key];
+    if (isPlatformMetadataObject(fallbackBlock)) return fallbackBlock;
+  }
+
+  return {};
 };
 
 export const SkillDetail: React.FC = () => {

--- a/pages/SkillDetail.tsx
+++ b/pages/SkillDetail.tsx
@@ -4,13 +4,30 @@ import { ArrowLeft, Copy, Check, Download, ExternalLink, FileText, Shield } from
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Footer } from '../components/Footer';
-import type { SkillJson, SkillChecksums } from '../types';
+import type { SkillJson, SkillChecksums, SkillPlatformMetadata } from '../types';
 import { defaultMarkdownComponents } from '../utils/markdownComponents';
 import { stripFrontmatter } from '../utils/markdownHelpers.mjs';
 
 const isProbablyHtmlDocument = (text: string): boolean => {
   const start = text.trimStart().slice(0, 200).toLowerCase();
   return start.startsWith('<!doctype html') || start.startsWith('<html');
+};
+
+const resolvePlatformMetadata = (skill: SkillJson): SkillPlatformMetadata => {
+  const platform = skill.platform;
+  const platformBlock =
+    typeof platform === 'string' && platform in skill
+      ? (skill[platform as keyof SkillJson] as SkillPlatformMetadata | null | undefined)
+      : undefined;
+
+  return (
+    platformBlock ??
+    skill.openclaw ??
+    skill.hermes ??
+    skill.nanoclaw ??
+    skill.picoclaw ??
+    {}
+  );
 };
 
 export const SkillDetail: React.FC = () => {
@@ -144,6 +161,16 @@ export const SkillDetail: React.FC = () => {
     return skillData.homepage;
   }, [skillData]);
 
+  const platformMetadata = useMemo(
+    () => (skillData ? resolvePlatformMetadata(skillData) : null),
+    [skillData]
+  );
+
+  const triggers = useMemo(() => {
+    if (!platformMetadata || !Array.isArray(platformMetadata.triggers)) return [];
+    return platformMetadata.triggers;
+  }, [platformMetadata]);
+
   if (loading) {
     return (
       <div className="py-16 text-center">
@@ -180,14 +207,14 @@ export const SkillDetail: React.FC = () => {
       {/* Header */}
       <section className="flex flex-col md:flex-row md:items-start md:justify-between gap-6">
         <div className="flex items-start gap-4">
-          <span className="text-4xl">{skillData.openclaw?.emoji || '📦'}</span>
+          <span className="text-4xl">{platformMetadata?.emoji || '📦'}</span>
           <div>
             <h1 className="text-3xl font-bold text-white mb-1">{skillData.name}</h1>
             <div className="flex items-center gap-3 text-sm">
               <span className="text-gray-500 font-mono">v{skillData.version}</span>
               {/* Category badge - hidden for now, uncomment when we have multiple categories
               <span className="text-gray-500 bg-clawd-800 px-2 py-0.5 rounded">
-                {skillData.openclaw?.category || 'utility'}
+                {platformMetadata?.category || 'utility'}
               </span>
               */}
             </div>
@@ -339,16 +366,16 @@ export const SkillDetail: React.FC = () => {
             </div>
             <div className="flex justify-between">
               <dt className="text-gray-500">Category</dt>
-              <dd className="text-white">{skillData.openclaw?.category}</dd>
+              <dd className="text-white">{platformMetadata?.category || 'utility'}</dd>
             </div>
           </dl>
         </div>
 
-        {skillData.openclaw?.triggers && skillData.openclaw.triggers.length > 0 && (
+        {triggers.length > 0 && (
           <div className="bg-clawd-800/50 border border-clawd-700 rounded-xl p-6 space-y-4">
             <h3 className="font-bold text-white">Trigger Phrases</h3>
             <div className="flex flex-wrap gap-2">
-              {skillData.openclaw.triggers.slice(0, 8).map((trigger) => (
+              {triggers.slice(0, 8).map((trigger) => (
                 <span
                   key={trigger}
                   className="text-xs bg-clawd-700 text-gray-300 px-2 py-1 rounded"

--- a/scripts/populate-local-skills.sh
+++ b/scripts/populate-local-skills.sh
@@ -168,15 +168,22 @@ EOF
   echo "  ✓ Generated: checksums.json"
   
   # Build skill entry for index
-  SKILL_DATA=$(jq -c --arg tag "$TAG" '{
-    id: .name,
-    name: .name,
-    version: .version,
-    description: .description,
-    emoji: .openclaw.emoji,
-    category: .openclaw.category,
-    tag: $tag
-  }' "$SKILL_JSON")
+  SKILL_DATA=$(jq -c --arg tag "$TAG" '
+    def platform_meta:
+      (.platform as $platform
+        | if ($platform != null and .[$platform]? != null) then .[$platform]
+          else (.openclaw // .hermes // .nanoclaw // .picoclaw // {})
+          end);
+    {
+      id: .name,
+      name: .name,
+      version: .version,
+      description: .description,
+      emoji: (platform_meta.emoji // .openclaw.emoji // .hermes.emoji // .nanoclaw.emoji // .picoclaw.emoji // "📦"),
+      category: (platform_meta.category // .openclaw.category // .hermes.category // .nanoclaw.category // .picoclaw.category // "utility"),
+      tag: $tag
+    }
+  ' "$SKILL_JSON")
   
   # Append to index
   if [ "$FIRST_SKILL" = "true" ]; then

--- a/scripts/populate-local-skills.sh
+++ b/scripts/populate-local-skills.sh
@@ -169,18 +169,22 @@ EOF
   
   # Build skill entry for index
   SKILL_DATA=$(jq -c --arg tag "$TAG" '
+    def object_or_empty($value):
+      if ($value | type) == "object" then $value else {} end;
+    def object_field($name):
+      object_or_empty(.[$name]?);
     def platform_meta:
       (.platform as $platform
-        | if ($platform != null and .[$platform]? != null) then .[$platform]
-          else (.openclaw // .hermes // .nanoclaw // .picoclaw // {})
+        | if ($platform | type) == "string" then object_or_empty(.[$platform]?)
+          else {}
           end);
     {
       id: .name,
       name: .name,
       version: .version,
       description: .description,
-      emoji: (platform_meta.emoji // .openclaw.emoji // .hermes.emoji // .nanoclaw.emoji // .picoclaw.emoji // "📦"),
-      category: (platform_meta.category // .openclaw.category // .hermes.category // .nanoclaw.category // .picoclaw.category // "utility"),
+      emoji: (platform_meta.emoji // object_field("openclaw").emoji // object_field("hermes").emoji // object_field("nanoclaw").emoji // object_field("picoclaw").emoji // "📦"),
+      category: (platform_meta.category // object_field("openclaw").category // object_field("hermes").category // object_field("nanoclaw").category // object_field("picoclaw").category // "utility"),
       tag: $tag
     }
   ' "$SKILL_JSON")

--- a/types.ts
+++ b/types.ts
@@ -101,6 +101,19 @@ export interface SkillChecksums {
   }>;
 }
 
+export interface SkillPlatformMetadata {
+  emoji?: string;
+  category?: string;
+  feed_url?: string;
+  requires?: {
+    bins?: string[];
+    [key: string]: unknown;
+  };
+  triggers?: string[];
+  internal?: boolean;
+  [key: string]: unknown;
+}
+
 export interface SkillJson {
   name: string;
   version: string;
@@ -116,13 +129,9 @@ export interface SkillJson {
       description: string;
     }>;
   };
-  openclaw: {
-    emoji: string;
-    category: string;
-    feed_url?: string;
-    requires?: {
-      bins?: string[];
-    };
-    triggers: string[];
-  };
+  platform?: CorePlatformSlug | (string & {});
+  openclaw?: SkillPlatformMetadata | null;
+  hermes?: SkillPlatformMetadata | null;
+  nanoclaw?: SkillPlatformMetadata | null;
+  picoclaw?: SkillPlatformMetadata | null;
 }


### PR DESCRIPTION
# User description
## Summary
- fix local and deploy catalog builders to resolve `emoji`/`category` from the declared `platform` block instead of only `.openclaw`
- add safe defaults (`📦`, `utility`) so index generation never publishes null metadata
- update `SkillDetail` to render emoji/category/triggers from resolved platform metadata
- align `SkillJson` typing with platform-specific manifests (`openclaw`/`hermes`/`nanoclaw`/`picoclaw` optional)

## Why
Merged traffic-guardian skills include non-openclaw metadata blocks. Before this change, catalog generation produced null `emoji`/`category` values for those skills.

## Validation
- `./scripts/populate-local-skills.sh`
- `jq '.skills[] | select(.id|test("hermes-traffic-guardian|nanoclaw-traffic-guardian|picoclaw-traffic-guardian")) | {id,emoji,category}' public/skills/index.json`
- `npx tsc --noEmit`
- `npx eslint pages/SkillDetail.tsx types.ts --max-warnings 0`
- `npm run build`

## Notes
- No skill manifests were changed in this PR, so no beta tag bump is required.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the catalog builders and <code>types.ts</code> so each release’s index entry resolves emoji/category from declared platform metadata (with safe defaults) using <code>SkillPlatformMetadata</code>. Update <code>SkillDetail</code> to render emoji, category, and triggers from the resolved platform metadata instead of assuming <code>openclaw</code> values.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/229?tool=ast&topic=Catalog+metadata>Catalog metadata</a>
        </td><td>Resolve platform metadata fallbacks for catalog index generation to keep emoji/category non-null even for non-<code>openclaw</code> manifests.<details><summary>Modified files (3)</summary><ul><li>.github/workflows/deploy-pages.yml</li>
<li>scripts/populate-local-skills.sh</li>
<li>types.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(skills-catalog): h...</td><td>May 10, 2026</td></tr>
<tr><td>david@abutbul.com</td><td>Add Picoclaw guardian ...</td><td>April 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/229?tool=ast&topic=Skill+detail+view>Skill detail view</a>
        </td><td>Render resolved platform metadata (emoji/category/triggers) in <code>SkillDetail</code> alongside the updated resolver logic.<details><summary>Modified files (1)</summary><ul><li>pages/SkillDetail.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(skills-catalog): h...</td><td>May 10, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>feat(wiki): add full i...</td><td>February 26, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/prompt-security/clawsec/229?tool=ast>(Baz)</a>.