### PR TITLE
docs: add citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,8 @@
 cff-version: 1.2.0
 message: "If you use ClawSec in research or security tooling, please cite it as below."
 title: "ClawSec"
+version: "0.1.0"
+date-released: "2026-05-26"
 abstract: >-
   ClawSec is a security skill suite for AI agent platforms. It provides
   advisory monitoring, cryptographic signature verification, guarded skill
@@ -26,5 +28,3 @@ authors:
     family-names: Abutbul
     affiliation: "Prompt Security"
     orcid: "https://orcid.org/0009-0001-7883-3593"
-  - name: "Prompt Security"
-    website: "https://prompt.security/"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,30 @@
+cff-version: 1.2.0
+message: "If you use ClawSec in research or security tooling, please cite it as below."
+title: "ClawSec"
+abstract: >-
+  ClawSec is a security skill suite for AI agent platforms. It provides
+  advisory monitoring, cryptographic signature verification, guarded skill
+  installation, file integrity checks, and platform-specific security
+  capabilities for OpenClaw, NanoClaw, Hermes, and Picoclaw deployments.
+type: software
+license: "AGPL-3.0-or-later"
+url: "https://clawsec.prompt.security/"
+repository-code: "https://github.com/prompt-security/clawsec"
+keywords:
+  - ai-security
+  - agent-security
+  - prompt-injection
+  - security-advisories
+  - software-supply-chain
+  - integrity-verification
+  - openclaw
+  - nanoclaw
+  - hermes
+  - picoclaw
+authors:
+  - given-names: David
+    family-names: Abutbul
+    affiliation: "Prompt Security"
+    orcid: "https://orcid.org/0009-0001-7883-3593"
+  - name: "Prompt Security"
+    website: "https://prompt.security/"


### PR DESCRIPTION
# User description
## Summary
- Adds a project-level `CITATION.cff` for ClawSec.
- Uses the formal title `ClawSec` and describes the broader security skill suite in the abstract.
- Includes David Abutbul's ORCID so GitHub/Zenodo citation metadata can connect cleanly to ORCID.

## Zenodo DOI follow-up
After this merges, enable the repository in Zenodo's GitHub integration and archive a project-level GitHub release, for example `clawsec-v0.1.0` or another canonical ClawSec release tag. Zenodo will mint the DOI from that release metadata. Do not use the existing `clawsec-suite-*` skill tag for the project DOI unless the intent is to cite only that subpackage.

Zenodo currently supports `CITATION.cff` for GitHub software releases, and GitHub also uses the file to display citation guidance on the repository page.

## Testing
- Parsed `CITATION.cff` with Ruby YAML loader.
- Ran `git diff --cached --check`.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Document citation guidance for ClawSec by adding a full <code>CITATION.cff</code> that captures the project title, abstract, version, keywords, and licensing details. Include David Abutbul’s affiliation and ORCID so GitHub/Zenodo can map the project-level metadata to his profile.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>docs: add project rele...</td><td>May 26, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/246?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>