### PR TITLE
fix(workflow): select newly dispatched CodeQL run

### DIFF
--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -1055,7 +1055,10 @@ jobs:
             exit 1
           fi
 
-          echo "Dispatching CodeQL for branch: $BRANCH"
+          EXPECTED_HEAD_SHA="$(git rev-parse HEAD)"
+          DISPATCHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          echo "Dispatching CodeQL for branch: $BRANCH (head: $EXPECTED_HEAD_SHA, dispatched_at: $DISPATCHED_AT)"
           gh workflow run codeql.yml --ref "$BRANCH"
 
           RUN_ID=""
@@ -1064,8 +1067,13 @@ jobs:
               --workflow "CodeQL" \
               --branch "$BRANCH" \
               --event workflow_dispatch \
-              --json databaseId,createdAt \
-              --jq 'sort_by(.createdAt) | last | .databaseId // empty')
+              --limit 50 \
+              --json databaseId,createdAt,headSha \
+              --jq --arg since "$DISPATCHED_AT" --arg sha "$EXPECTED_HEAD_SHA" '
+                map(select(.createdAt >= $since and .headSha == $sha))
+                | sort_by(.createdAt)
+                | last
+                | .databaseId // empty')
             if [ -n "$RUN_ID" ]; then
               break
             fi
@@ -1073,7 +1081,13 @@ jobs:
           done
 
           if [ -z "$RUN_ID" ]; then
-            echo "::error::Unable to locate dispatched CodeQL run for branch $BRANCH"
+            echo "::error::Unable to locate dispatched CodeQL run for branch $BRANCH after $DISPATCHED_AT (head: $EXPECTED_HEAD_SHA)"
+            gh run list \
+              --workflow "CodeQL" \
+              --branch "$BRANCH" \
+              --event workflow_dispatch \
+              --limit 5 \
+              --json databaseId,createdAt,headSha,status,conclusion || true
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- fix the CodeQL wait step in .github/workflows/poll-nvd-cves.yml so it cannot attach to an older successful run on the same branch
- capture dispatch timestamp and expected head SHA before dispatching CodeQL
- wait only for a workflow_dispatch CodeQL run whose createdAt is after dispatch and whose headSha matches the expected commit
- print recent run metadata when no match is found to improve debugging

## Why
Recent advisory pipeline runs showed the workflow waiting on stale CodeQL runs (for example run 26369833959) instead of the newly dispatched run for the current advisory commit.

## Validation
- reviewed generated workflow diff and ensured only the run-selection logic changed
- manual live verification in prior run demonstrated the stale-selection failure mode this patch addresses