### PR TITLE
fix(deps): bump react-router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.5",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.13.1",
+        "react-router-dom": "^7.16.0",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -5075,9 +5075,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -5097,12 +5097,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
-      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
+      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.1"
+        "react-router": "7.16.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.5",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.13.1",
+    "react-router-dom": "^7.16.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Bumps `react-router-dom` from `^7.13.1` to `^7.16.0`.
- Updates the lockfile so transitive `react-router` resolves to `7.16.0`.
- Remediates the open Dependabot `react-router` alerts requiring patched versions up to `7.15.0`: GHSA-8x6r-g9mw-2r78, GHSA-2j2x-hqr9-3h42, GHSA-49rj-9fvp-4h2h, GHSA-f22v-gfqf-p8f3, and GHSA-8646-j5j9-6r62.

## Notes
- Dependabot also opened #255 for the same package bump, but this branch is based on current `main`.

## Testing
- `NPM_CONFIG_USERCONFIG=/dev/null npm ci --registry=https://registry.npmjs.org`
- `NPM_CONFIG_USERCONFIG=/dev/null npm audit --audit-level=high --registry=https://registry.npmjs.org`
- `npm ls react-router react-router-dom --all`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint . --ext .ts,.tsx,.js,.jsx,.mjs --max-warnings 0 --ignore-pattern '.worktrees/**'`\n- `npm run build`