### PR TITLE
fix(workflow): repair CodeQL run lookup in advisory poller

### DIFF
--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -1069,7 +1069,7 @@ jobs:
               --event workflow_dispatch \
               --limit 50 \
               --json databaseId,createdAt,headSha \
-              --jq --arg since "$DISPATCHED_AT" --arg sha "$EXPECTED_HEAD_SHA" '
+              | jq -r --arg since "$DISPATCHED_AT" --arg sha "$EXPECTED_HEAD_SHA" '
                 map(select(.createdAt >= $since and .headSha == $sha))
                 | sort_by(.createdAt)
                 | last

--- a/scripts/test-nvd-ghsa-consolidation-workflow.mjs
+++ b/scripts/test-nvd-ghsa-consolidation-workflow.mjs
@@ -47,6 +47,16 @@ assert.match(
   /git add "\$FEED_PATH" "\$FEED_SIG_PATH" "\$GHSA_FEED_PATH" "\$GHSA_FEED_SIG_PATH" "\$SKILL_FEED_PATH" "\$SKILL_FEED_SIG_PATH"/,
   'NVD workflow PR must include both NVD and GHSA feed artifacts',
 );
+assert.doesNotMatch(
+  workflow,
+  /gh run list[\s\S]*--jq --arg/,
+  'CodeQL run lookup must not pass jq CLI flags through gh --jq',
+);
+assert.match(
+  workflow,
+  /gh run list[\s\S]*--json databaseId,createdAt,headSha \\\s*\n\s+\| jq -r --arg since "\$DISPATCHED_AT" --arg sha "\$EXPECTED_HEAD_SHA"/,
+  'CodeQL run lookup must filter the gh JSON output with jq variables',
+);
 assert.match(
   ciWorkflow,
   /name: NVD \+ GHSA Pipeline Dry Run[\s\S]*node scripts\/test-nvd-ghsa-pipeline-dry-run\.mjs/,


### PR DESCRIPTION
# User description
## Summary
- fix the advisory poller CodeQL wait step by piping gh run list JSON into jq when using jq variables
- keep the existing head SHA and dispatch-time filtering behavior
- add a workflow regression assertion so gh --jq is not used with jq CLI flags again

## Why
Recent scheduled Poll NVD CVEs runs create/update the automated advisory PR, then fail because gh run list treats --arg as an unknown gh flag. That leaves advisory updates in PR #257 instead of cleanly completing the workflow.

## Validation
- node scripts/test-nvd-ghsa-consolidation-workflow.mjs
- node scripts/test-ghsa-without-cve-feed.mjs
- node scripts/test-nvd-ghsa-pipeline-dry-run.mjs
- git diff --check

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Correct the poll-nvd-cves workflow's CodeQL wait step to pipe <code>gh run list</code> JSON into <code>jq -r --arg</code> filters so dispatch-time and head SHA checks run without passing jq flags to <code>gh</code>. Add regression assertions in the NVD GHSA consolidation tests to ban <code>--jq --arg</code> usage and require the expected <code>jq -r --arg</code> filtering pattern for the CodeQL run lookup.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/260?tool=ast&topic=CodeQL+run+lookup>CodeQL run lookup</a>
        </td><td>Fix the CodeQL run lookup in the poll-nvd-cves workflow by piping the <code>gh run list</code> JSON output through <code>jq -r --arg</code> filters to maintain the existing dispatch-time and head SHA selection without passing jq flags to <code>gh</code>.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/poll-nvd-cves.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(workflow): filter ...</td><td>June 09, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(workflow): wait fo...</td><td>May 27, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/260?tool=ast&topic=Regression+assertions>Regression assertions</a>
        </td><td>Add regression assertions in the NVD GHSA consolidation tests to forbid <code>--jq --arg</code> usage and verify the new <code>jq -r --arg</code> filtering pattern for the CodeQL run lookup.<details><summary>Modified files (1)</summary><ul><li>scripts/test-nvd-ghsa-consolidation-workflow.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(workflow): filter ...</td><td>June 09, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>feat(advisories): add ...</td><td>May 24, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/260?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>