### PR TITLE
fix(skills): scan staged payload with SkillSpector

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -1403,6 +1403,16 @@ jobs:
             echo "INSTALL_EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Prepare SkillSpector report for release notes
+        id: skillspector_report
+        run: |
+          set -euo pipefail
+          {
+            echo "body<<SKILLSPECTOR_REPORT_EOF"
+            cat release-assets/skillspector-report.md
+            echo "SKILLSPECTOR_REPORT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
@@ -1418,7 +1428,9 @@ jobs:
 
             ### SkillSpector Security Report
 
-            Review the generated release-payload scan: [skillspector-report.md](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/skillspector-report.md)
+            ${{ steps.skillspector_report.outputs.body }}
+
+            Download the generated release-payload scan: [skillspector-report.md](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/skillspector-report.md)
 
             ### Verification
 

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -1403,15 +1403,55 @@ jobs:
             echo "INSTALL_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Prepare SkillSpector report for release notes
-        id: skillspector_report
+      - name: Prepare GitHub release body
+        env:
+          SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          VERSION: ${{ steps.parse.outputs.version }}
+          CHANGELOG: ${{ steps.changelog.outputs.changelog }}
+          QUICK_INSTALL: ${{ steps.install.outputs.quick_install }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          {
-            echo "body<<SKILLSPECTOR_REPORT_EOF"
-            cat release-assets/skillspector-report.md
-            echo "SKILLSPECTOR_REPORT_EOF"
-          } >> "$GITHUB_OUTPUT"
+          node -e '
+          const { readFileSync, writeFileSync } = require("node:fs");
+          const bodyPath = `${process.env.RUNNER_TEMP}/skill-release-body.md`;
+          const report = readFileSync("release-assets/skillspector-report.md", "utf8").trimEnd();
+          const body = [
+            `## ${process.env.SKILL_NAME} ${process.env.VERSION}`,
+            "",
+            process.env.CHANGELOG || "",
+            "",
+            process.env.QUICK_INSTALL || "",
+            "",
+            "### SkillSpector Security Report",
+            "",
+            report,
+            "",
+            `Download the generated release-payload scan: [skillspector-report.md](https://github.com/${process.env.REPO}/releases/download/${process.env.TAG}/skillspector-report.md)`,
+            "",
+            "### Verification",
+            "",
+            "`checksums.json` is cryptographically signed (`checksums.sig`) using the ClawSec CI signing key.",
+            "Verify the signature first, then trust hashes from `checksums.json`:",
+            "```bash",
+            `curl -sLO https://github.com/${process.env.REPO}/releases/download/${process.env.TAG}/checksums.json`,
+            `curl -sLO https://github.com/${process.env.REPO}/releases/download/${process.env.TAG}/checksums.sig`,
+            `curl -sLO https://github.com/${process.env.REPO}/releases/download/${process.env.TAG}/signing-public.pem`,
+            "openssl base64 -d -A -in checksums.sig -out checksums.sig.bin",
+            "openssl pkeyutl -verify -rawin -pubin -inkey signing-public.pem -sigfile checksums.sig.bin -in checksums.json",
+            "```",
+            "",
+            "### Files",
+            "",
+            "See `checksums.json` for the complete file manifest with SHA256 hashes.",
+            "The zip archive preserves the full directory structure of the skill.",
+            "",
+            "---",
+            "*Released by ClawSec skill distribution pipeline*",
+          ].join("\n");
+          writeFileSync(bodyPath, `${body}\n`);
+          '
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
@@ -1419,38 +1459,7 @@ jobs:
           name: "${{ steps.parse.outputs.skill_name }} ${{ steps.parse.outputs.version }}"
           tag_name: ${{ github.ref_name }}
           files: release-assets/*
-          body: |
-            ## ${{ steps.parse.outputs.skill_name }} ${{ steps.parse.outputs.version }}
-
-            ${{ steps.changelog.outputs.changelog }}
-
-            ${{ steps.install.outputs.quick_install }}
-
-            ### SkillSpector Security Report
-
-            ${{ steps.skillspector_report.outputs.body }}
-
-            Download the generated release-payload scan: [skillspector-report.md](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/skillspector-report.md)
-
-            ### Verification
-
-            `checksums.json` is cryptographically signed (`checksums.sig`) using the ClawSec CI signing key.
-            Verify the signature first, then trust hashes from `checksums.json`:
-            ```bash
-            curl -sLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/checksums.json
-            curl -sLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/checksums.sig
-            curl -sLO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/signing-public.pem
-            openssl base64 -d -A -in checksums.sig -out checksums.sig.bin
-            openssl pkeyutl -verify -rawin -pubin -inkey signing-public.pem -sigfile checksums.sig.bin -in checksums.json
-            ```
-
-            ### Files
-
-            See `checksums.json` for the complete file manifest with SHA256 hashes.
-            The zip archive preserves the full directory structure of the skill.
-
-            ---
-            *Released by ClawSec skill distribution pipeline*
+          body_path: ${{ runner.temp }}/skill-release-body.md
           draft: false
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
         env:

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -710,7 +710,7 @@ jobs:
               --source-ref "${HEAD_SHA}"
 
             # --- Generate SkillSpector report ---
-            if ! generate_skillspector_report "${skill_dir}" "${out_assets}/skillspector-report.md"; then
+            if ! generate_skillspector_report "${inner_dir}" "${out_assets}/skillspector-report.md"; then
               failures=$((failures + 1))
               rm -rf "${staging_dir}"
               echo "::endgroup::"
@@ -1221,7 +1221,7 @@ jobs:
             --source-ref "$TAG"
 
           # --- Generate SkillSpector report ---
-          generate_skillspector_report "$SKILL_PATH" "release-assets/skillspector-report.md"
+          generate_skillspector_report "$INNER_DIR" "release-assets/skillspector-report.md"
 
           test -s release-assets/skill-card.md
           test -s release-assets/permissions.json
@@ -1415,6 +1415,10 @@ jobs:
             ${{ steps.changelog.outputs.changelog }}
 
             ${{ steps.install.outputs.quick_install }}
+
+            ### SkillSpector Security Report
+
+            Review the generated release-payload scan: [skillspector-report.md](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/skillspector-report.md)
 
             ### Verification
 

--- a/scripts/ci/simulate_skill_tag_release.mjs
+++ b/scripts/ci/simulate_skill_tag_release.mjs
@@ -469,7 +469,7 @@ async function main() {
 
     await runSkillSpector({
       skillspectorBin: args.skillspectorBin,
-      skillDir: tempSkillDir,
+      skillDir: innerDir,
       reportPath: path.join(releaseAssetsDir, "skillspector-report.md"),
     });
 

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -90,6 +90,36 @@ assert.match(
 
 assert.match(
   workflow,
+  /### SkillSpector Security Report[\s\S]*\[skillspector-report\.md\]\(https:\/\/github\.com\/\$\{\{ github\.repository \}\}\/releases\/download\/\$\{\{ github\.ref_name \}\}\/skillspector-report\.md\)/,
+  'GitHub release notes must display a direct SkillSpector report link',
+);
+
+assert.match(
+  workflow,
+  /generate_skillspector_report "\$\{inner_dir\}" "\$\{out_assets\}\/skillspector-report\.md"/,
+  'PR dry-run SkillSpector scan must target the staged release payload, not the source skill directory',
+);
+
+assert.doesNotMatch(
+  workflow,
+  /generate_skillspector_report "\$\{skill_dir\}" "\$\{out_assets\}\/skillspector-report\.md"/,
+  'PR dry-run SkillSpector scan must not include source-only test directories',
+);
+
+assert.match(
+  workflow,
+  /generate_skillspector_report "\$INNER_DIR" "release-assets\/skillspector-report\.md"/,
+  'Tag release SkillSpector scan must target the staged release payload, not the source skill directory',
+);
+
+assert.doesNotMatch(
+  workflow,
+  /generate_skillspector_report "\$SKILL_PATH" "release-assets\/skillspector-report\.md"/,
+  'Tag release SkillSpector scan must not include source-only test directories',
+);
+
+assert.match(
+  workflow,
   /Generate release trust packet/,
   'Skill release workflow must generate skill cards, permission summaries, and npx install instructions',
 );

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -91,7 +91,19 @@ assert.match(
 assert.match(
   workflow,
   /### SkillSpector Security Report[\s\S]*\[skillspector-report\.md\]\(https:\/\/github\.com\/\$\{\{ github\.repository \}\}\/releases\/download\/\$\{\{ github\.ref_name \}\}\/skillspector-report\.md\)/,
-  'GitHub release notes must display a direct SkillSpector report link',
+  'GitHub release notes must include a direct SkillSpector report link',
+);
+
+assert.match(
+  workflow,
+  /id: skillspector_report[\s\S]*cat release-assets\/skillspector-report\.md[\s\S]*>> "\$GITHUB_OUTPUT"/,
+  'GitHub release notes must load the generated SkillSpector report content',
+);
+
+assert.match(
+  workflow,
+  /### SkillSpector Security Report[\s\S]*\$\{\{ steps\.skillspector_report\.outputs\.body \}\}/,
+  'GitHub release notes must display the generated SkillSpector report content inline',
 );
 
 assert.match(

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -90,20 +90,26 @@ assert.match(
 
 assert.match(
   workflow,
-  /### SkillSpector Security Report[\s\S]*\[skillspector-report\.md\]\(https:\/\/github\.com\/\$\{\{ github\.repository \}\}\/releases\/download\/\$\{\{ github\.ref_name \}\}\/skillspector-report\.md\)/,
+  /### SkillSpector Security Report[\s\S]*\[skillspector-report\.md\]\(https:\/\/github\.com\/\$\{process\.env\.REPO\}\/releases\/download\/\$\{process\.env\.TAG\}\/skillspector-report\.md\)/,
   'GitHub release notes must include a direct SkillSpector report link',
 );
 
 assert.match(
   workflow,
-  /id: skillspector_report[\s\S]*cat release-assets\/skillspector-report\.md[\s\S]*>> "\$GITHUB_OUTPUT"/,
-  'GitHub release notes must load the generated SkillSpector report content',
+  /readFileSync\("release-assets\/skillspector-report\.md", "utf8"\)/,
+  'GitHub release notes must load the generated SkillSpector report content into the release body file',
 );
 
 assert.match(
   workflow,
-  /### SkillSpector Security Report[\s\S]*\$\{\{ steps\.skillspector_report\.outputs\.body \}\}/,
-  'GitHub release notes must display the generated SkillSpector report content inline',
+  /body_path: \$\{\{ runner\.temp \}\}\/skill-release-body\.md/,
+  'GitHub release creation must use body_path for the generated release body file',
+);
+
+assert.doesNotMatch(
+  workflow,
+  /SKILLSPECTOR_REPORT_EOF|\$\{\{ steps\.skillspector_report\.outputs\.body \}\}|cat release-assets\/skillspector-report\.md[\s\S]*>> "\$GITHUB_OUTPUT"/,
+  'SkillSpector report content must not be sent through GitHub Actions step outputs',
 );
 
 assert.match(

--- a/scripts/test-skill-tag-release-simulation.mjs
+++ b/scripts/test-skill-tag-release-simulation.mjs
@@ -94,7 +94,36 @@ try {
   await writeFile(
     fakeSkillspector,
     `#!/usr/bin/env node
-import { writeFileSync } from "node:fs";
+import { readdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const scanIndex = process.argv.indexOf("scan");
+if (scanIndex === -1 || !process.argv[scanIndex + 1]) {
+  console.error("missing scan target");
+  process.exit(2);
+}
+
+function containsTestDirectory(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const lowerName = entry.name.toLowerCase();
+    if (lowerName === "test" || lowerName === "tests") {
+      return true;
+    }
+    if (containsTestDirectory(path.join(dir, entry.name))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const scanTarget = process.argv[scanIndex + 1];
+if (containsTestDirectory(scanTarget)) {
+  console.error("SkillSpector test fixture must scan the staged release payload, not source test directories.");
+  process.exit(42);
+}
 
 const outputIndex = process.argv.indexOf("--output");
 if (outputIndex === -1 || !process.argv[outputIndex + 1]) {


### PR DESCRIPTION
# User description
## Summary
- Run SkillSpector against the staged release payload instead of the source skill directory in both PR dry-runs and tag releases.
- Keep the release simulation aligned with that behavior so source-only test directories cannot leak into scans.
- Embed the generated SkillSpector report content directly in GitHub release notes, while keeping the downloadable `skillspector-report.md` artifact link.

## Security / release benefit
- Prevents SkillSpector findings from source-only test fixtures that are not shipped in skill release archives.
- Makes the generated SkillSpector report visible directly on the skill release page.

## Testing
- `for test_file in scripts/test-skill-*.mjs; do node "$test_file"; done`
- `npx eslint scripts/ci/simulate_skill_tag_release.mjs scripts/test-skill-release-workflow.mjs scripts/test-skill-tag-release-simulation.mjs --max-warnings 0`
- `npx tsc --noEmit`
- `git diff --check`
- `npm run build`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align release workflows to scan the staged release payload by running <code>generate_skillspector_report</code> against the archived output and propagating that behavior through <code>scripts/ci/simulate_skill_tag_release.mjs</code> and its test shim. Embed the generated <code>skillspector-report.md</code> into the GitHub release body via a new preparation step that also provides a release notes link, with tests validating the resulting workflow structure.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/264?tool=ast&topic=SkillSpector+Flow>SkillSpector Flow</a>
        </td><td>Update <code>generate_skillspector_report</code> invocations and the fake SkillSpector helper so the dry-run, tag-release build, and simulation scripts scan the staged payload (<code>inner_dir</code>) rather than the source directory, preventing source-only test fixtures from leaking into the report.<details><summary>Modified files (3)</summary><ul><li>.github/workflows/skill-release.yml</li>
<li>scripts/ci/simulate_skill_tag_release.mjs</li>
<li>scripts/test-skill-tag-release-simulation.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(skills): use body ...</td><td>June 10, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(skills): namespace...</td><td>June 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/264?tool=ast&topic=Release+Notes>Release Notes</a>
        </td><td>Add a GitHub release body preparation step that loads the generated report, embeds it along with verification instructions and the download link, and update workflow tests to assert the new body handling and release note requirements.<details><summary>Modified files (2)</summary><ul><li>.github/workflows/skill-release.yml</li>
<li>scripts/test-skill-release-workflow.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(skills): use body ...</td><td>June 10, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(skills): namespace...</td><td>June 10, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/264?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>