### PR TITLE
fix(traffic): require a traffic-capable PAT for the archive workflow

### DIFF
--- a/.github/workflows/archive-traffic.yml
+++ b/.github/workflows/archive-traffic.yml
@@ -53,9 +53,22 @@ jobs:
 
       - name: Collect traffic
         env:
-          GH_TRAFFIC_TOKEN: ${{ secrets.TRAFFIC_ARCHIVE_TOKEN || github.token }}
+          # Traffic endpoints reject the Actions GITHUB_TOKEN ("Resource not
+          # accessible by integration") — a PAT with push access is required.
+          # POLL_NVD_CVES_PAT is a stopgap fallback until a dedicated
+          # TRAFFIC_ARCHIVE_TOKEN secret (fine-grained, Administration:read)
+          # is provisioned.
+          GH_TRAFFIC_TOKEN: ${{ secrets.TRAFFIC_ARCHIVE_TOKEN || secrets.POLL_NVD_CVES_PAT }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: node scripts/archive-github-traffic.mjs --archive-dir "${TRAFFIC_ARCHIVE_DIR}"
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TRAFFIC_TOKEN}" ]; then
+            echo "::error::No traffic-capable token configured. Set the TRAFFIC_ARCHIVE_TOKEN secret to a PAT with push access (classic: repo scope; fine-grained: Administration read)."
+            exit 1
+          fi
+
+          node scripts/archive-github-traffic.mjs --archive-dir "${TRAFFIC_ARCHIVE_DIR}"
 
       - name: Commit archive
         run: |

--- a/.github/workflows/archive-traffic.yml
+++ b/.github/workflows/archive-traffic.yml
@@ -54,11 +54,10 @@ jobs:
       - name: Collect traffic
         env:
           # Traffic endpoints reject the Actions GITHUB_TOKEN ("Resource not
-          # accessible by integration") — a PAT with push access is required.
-          # POLL_NVD_CVES_PAT is a stopgap fallback until a dedicated
-          # TRAFFIC_ARCHIVE_TOKEN secret (fine-grained, Administration:read)
-          # is provisioned.
-          GH_TRAFFIC_TOKEN: ${{ secrets.TRAFFIC_ARCHIVE_TOKEN || secrets.POLL_NVD_CVES_PAT }}
+          # accessible by integration") — a PAT from a user with push access
+          # is required: classic with repo scope, or fine-grained with read
+          # access to Administration on this repository.
+          GH_TRAFFIC_TOKEN: ${{ secrets.TRAFFIC_ARCHIVE_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/scripts/archive-github-traffic.mjs
+++ b/scripts/archive-github-traffic.mjs
@@ -321,7 +321,14 @@ const fetchJson = async ({ repo, token, pathname, fetchImpl }) => {
   if (!response.ok) {
     const body = await response.text().catch(() => '');
     const suffix = body ? ` ${body.slice(0, 500)}` : '';
-    throw new Error(`GitHub traffic API request failed for ${repo}: ${url.pathname}${url.search} returned ${response.status}.${suffix}`);
+    const lacksPushAccess = response.status === 403
+      && /resource not accessible|must have push access/i.test(body);
+    const hint = lacksPushAccess
+      ? ' Traffic endpoints require a token with push access to the repository; the Actions GITHUB_TOKEN is always rejected. Use a classic PAT with the repo scope or a fine-grained PAT with read access to Administration.'
+      : response.status === 401
+        ? ' The token was rejected as invalid — it may be expired or revoked. Rotate the TRAFFIC_ARCHIVE_TOKEN secret.'
+        : '';
+    throw new Error(`GitHub traffic API request failed for ${repo}: ${url.pathname}${url.search} returned ${response.status}.${suffix}${hint}`);
   }
 
   return response.json();

--- a/scripts/test-github-traffic-archive.mjs
+++ b/scripts/test-github-traffic-archive.mjs
@@ -76,6 +76,40 @@ test('fetchGitHubTraffic requests the daily GitHub traffic endpoints with auth',
   assert.deepEqual(snapshot.clones.clones, responses[`/repos/${TEST_REPOSITORY}/traffic/clones?per=day`].clones);
 });
 
+test('fetchGitHubTraffic explains traffic token requirements on 403', async () => {
+  const fetchImpl = async () => new globalThis.Response(
+    JSON.stringify({ message: 'Resource not accessible by integration' }),
+    { status: 403 },
+  );
+
+  await assert.rejects(
+    fetchGitHubTraffic({
+      repo: TEST_REPOSITORY,
+      token: 'installation-token',
+      capturedAt,
+      fetchImpl,
+    }),
+    /returned 403\..*push access/,
+  );
+});
+
+test('fetchGitHubTraffic flags invalid tokens on 401', async () => {
+  const fetchImpl = async () => new globalThis.Response(
+    JSON.stringify({ message: 'Bad credentials' }),
+    { status: 401 },
+  );
+
+  await assert.rejects(
+    fetchGitHubTraffic({
+      repo: TEST_REPOSITORY,
+      token: 'expired-token',
+      capturedAt,
+      fetchImpl,
+    }),
+    /returned 401\..*expired or revoked/,
+  );
+});
+
 test('mergeTrafficArchive upserts daily views and clones without double-counting overlapping windows', () => {
   const archive = mergeTrafficArchive(
     {
@@ -232,7 +266,8 @@ test('traffic archive workflow uses a daily schedule and a dedicated archive bra
 
   assert.match(workflow, /cron:\s+'17 3 \* \* \*'/);
   assert.match(workflow, /TRAFFIC_ARCHIVE_BRANCH:\s+traffic-archive/);
-  assert.match(workflow, /TRAFFIC_ARCHIVE_TOKEN/);
+  assert.match(workflow, /GH_TRAFFIC_TOKEN:\s*\$\{\{\s*secrets\.TRAFFIC_ARCHIVE_TOKEN\b/);
+  assert.doesNotMatch(workflow, /GH_TRAFFIC_TOKEN:[^\n]*github\.token/);
   assert.match(workflow, /node scripts\/archive-github-traffic\.mjs/);
   assert.match(workflow, /git add traffic\/archive\.json traffic\/summary\.json/);
   assert.match(workflow, /git rm --ignore-unmatch traffic\/README\.md/);


### PR DESCRIPTION
# User description
## Summary

The daily **Archive GitHub Traffic** workflow ([example failure](https://github.com/prompt-security/clawsec/actions/runs/27253957910)) has failed on every scheduled run since it was added in #252, so no traffic history has been captured yet. Root cause: the `TRAFFIC_ARCHIVE_TOKEN` secret was never provisioned, and the `|| github.token` fallback can never work — GitHub rejects the Actions installation token on all traffic endpoints (`403 Resource not accessible by integration`). Traffic endpoints require a PAT from a user with push access.

## Changes

- **`.github/workflows/archive-traffic.yml`** — `GH_TRAFFIC_TOKEN` now uses `secrets.TRAFFIC_ARCHIVE_TOKEN` only (the `github.token` fallback was guaranteed to 403). When the secret is missing, the step fails fast with an actionable `::error` annotation instead of a cryptic API error.
- **`scripts/archive-github-traffic.mjs`** — 403 push-access failures and 401 invalid-token failures now append a hint explaining the token requirements.
- **`scripts/test-github-traffic-archive.mjs`** — new tests for the 401/403 hints; the workflow-shape test now asserts `GH_TRAFFIC_TOKEN` binds to `secrets.TRAFFIC_ARCHIVE_TOKEN` and never to `github.token`.

## Live verification (workflow_dispatch from this branch)

- An [intermediate commit](https://github.com/prompt-security/clawsec/actions/runs/27288140374) tried falling back to the existing `POLL_NVD_CVES_PAT` — it returned **401 Bad credentials**, i.e. that PAT (set 2026-02-05) is expired or revoked, so the fallback was dropped.
- [Second dispatch](https://github.com/prompt-security/clawsec/actions/runs/27288278085) confirms the fail-fast guard: the run now stops with *“No traffic-capable token configured. Set the TRAFFIC_ARCHIVE_TOKEN secret to a PAT with push access (classic: repo scope; fine-grained: Administration read).”*
- A classic `repo`-scoped token from a maintainer was confirmed to read `/traffic/views` successfully (834 views / 378 uniques in the current 14-day window).

## Required follow-up after merge (ops)

1. Create a PAT — recommended: **fine-grained**, scoped to this repository only, with **Administration: read** (a classic PAT with `repo` scope also works), owned by a user with push access.
2. `gh secret set TRAFFIC_ARCHIVE_TOKEN --repo prompt-security/clawsec`
3. `gh workflow run archive-traffic.yml --repo prompt-security/clawsec` — the first green run creates the `traffic-archive` branch and seeds it with the current 14-day window.

⏳ GitHub only retains ~14 days of traffic data; each day without the secret permanently loses a day of history.

## Heads-up (separate issue)

`POLL_NVD_CVES_PAT` returning 401 also means the `community-advisory.yml` automation will fail the next time an issue is labeled `advisory-approved` — that PAT needs rotation regardless of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify the archive workflow token requirements by binding <code>GH_TRAFFIC_TOKEN</code> exclusively to <code>secrets.TRAFFIC_ARCHIVE_TOKEN</code> and failing fast with guidance when the secret is missing. Enhance <code>archive-github-traffic.mjs</code> and its tests to append specific hints for 403/401 errors so operators know to provide a push-capable PAT.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/265?tool=ast&topic=Workflow+token+guard>Workflow token guard</a>
        </td><td>Enforce the traffic archive workflow to require a configured PAT via <code>secrets.TRAFFIC_ARCHIVE_TOKEN</code>, report an actionable error when absent, and only run <code>archive-github-traffic</code> once the token guard passes.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/archive-traffic.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(traffic): require ...</td><td>June 10, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>feat(traffic): archive...</td><td>June 04, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/265?tool=ast&topic=Token+error+hints>Token error hints</a>
        </td><td>Clarify <code>scripts/archive-github-traffic.mjs</code> and its tests to append push-access or rotation hints on 403/401 responses so failures point to the required PAT credentials.<details><summary>Modified files (2)</summary><ul><li>scripts/archive-github-traffic.mjs</li>
<li>scripts/test-github-traffic-archive.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(traffic): use a tr...</td><td>June 10, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>feat(traffic): archive...</td><td>June 04, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/265?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>