### PR TITLE
chore(release): bump skill metadata for republish

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -833,7 +833,6 @@ jobs:
       actions: read
       contents: read
       issues: write
-      pull-requests: write
     steps:
       - name: Download SkillSpector reports
         continue-on-error: true

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -833,7 +833,7 @@ jobs:
       actions: read
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Download SkillSpector reports
         continue-on-error: true
@@ -843,6 +843,7 @@ jobs:
           path: skillspector-pr-reports
 
       - name: Comment SkillSpector reports
+        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -250,7 +250,7 @@ assert.match(
 
 assert.match(
   workflow,
-  /comment-skillspector-report:[\s\S]*needs: release[\s\S]*issues: write[\s\S]*actions\/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8\.0\.1/,
+  /comment-skillspector-report:[\s\S]*needs: release[\s\S]*issues: write[\s\S]*pull-requests: write[\s\S]*actions\/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8\.0\.1/,
   'Skill release workflow must download generated SkillSpector reports in a separate PR comment job with comment permissions',
 );
 
@@ -258,6 +258,12 @@ assert.match(
   workflow,
   /comment-skillspector-report:[\s\S]*if: always\(\) && github\.event_name == 'pull_request' && needs\.release\.result != 'cancelled'[\s\S]*Download SkillSpector reports[\s\S]*continue-on-error: true/,
   'SkillSpector PR comments must still run when the release dry-run produced reports but the release job failed later',
+);
+
+assert.match(
+  workflow,
+  /Comment SkillSpector reports[\s\S]*continue-on-error: true[\s\S]*actions\/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9\.0\.0/,
+  'SkillSpector PR comment publishing must not fail the release dry-run check',
 );
 
 assert.match(

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -250,8 +250,15 @@ assert.match(
 
 assert.match(
   workflow,
-  /comment-skillspector-report:[\s\S]*needs: release[\s\S]*issues: write[\s\S]*pull-requests: write[\s\S]*actions\/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8\.0\.1/,
+  /comment-skillspector-report:[\s\S]*needs: release[\s\S]*issues: write[\s\S]*actions\/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8\.0\.1/,
   'Skill release workflow must download generated SkillSpector reports in a separate PR comment job with comment permissions',
+);
+
+const commentJob = workflow.match(/[ ]{2}comment-skillspector-report:[\s\S]*?\n[ ]{2}[a-z][^:\n]*:/)?.[0] || "";
+assert.doesNotMatch(
+  commentJob,
+  /pull-requests: write/,
+  'SkillSpector PR comment publishing should not request redundant pull-requests write permissions',
 );
 
 assert.match(

--- a/scripts/test-skill-tag-release-simulation.mjs
+++ b/scripts/test-skill-tag-release-simulation.mjs
@@ -140,16 +140,16 @@ writeFileSync(process.argv[outputIndex + 1], "# Fake SkillSpector Report\\n\\nNo
   await runSimulation({
     skillDir: "skills/clawsec-suite",
     outputDir: path.join(tempRoot, "stable"),
-    expectedOriginal: "0.1.10",
-    expectedSimulated: "0.1.11",
+    expectedOriginal: "0.1.11",
+    expectedSimulated: "0.1.12",
     expectedAgent: "openclaw",
   });
 
   await runSimulation({
     skillDir: "skills/hermes-traffic-guardian",
     outputDir: path.join(tempRoot, "beta"),
-    expectedOriginal: "0.0.1-beta3",
-    expectedSimulated: "0.0.1-beta4",
+    expectedOriginal: "0.0.1-beta4",
+    expectedSimulated: "0.0.1-beta5",
     expectedAgent: "hermes-agent",
   });
 

--- a/scripts/test-skill-trust-packet.mjs
+++ b/scripts/test-skill-trust-packet.mjs
@@ -62,7 +62,7 @@ try {
   const hermesResult = runTrustPacket(
     "skills/hermes-attestation-guardian",
     hermesOutputDir,
-    "hermes-attestation-guardian-v0.1.4",
+    "hermes-attestation-guardian-v0.1.5",
   );
   assert.equal(
     hermesResult.status,

--- a/scripts/test-skill-trust-packet.mjs
+++ b/scripts/test-skill-trust-packet.mjs
@@ -25,7 +25,7 @@ function runTrustPacket(skillDir, targetDir, tag) {
 }
 
 try {
-  const result = runTrustPacket("skills/clawsec-suite", outputDir, "clawsec-suite-v0.1.10");
+  const result = runTrustPacket("skills/clawsec-suite", outputDir, "clawsec-suite-v0.1.11");
 
   assert.equal(
     result.status,
@@ -41,10 +41,10 @@ try {
   assert.match(skillCard, /## License\/Terms of Use/);
   assert.match(skillCard, /AGPL-3\.0-or-later/);
   assert.match(skillCard, /skillspector-report\.md/);
-  assert.match(skillCard, /clawsec-suite-v0\.1\.10/);
+  assert.match(skillCard, /clawsec-suite-v0\.1\.11/);
 
   assert.equal(permissions.skill, "clawsec-suite");
-  assert.equal(permissions.version, "0.1.10");
+  assert.equal(permissions.version, "0.1.11");
   assert.equal(permissions.platform, "openclaw");
   assert.deepEqual(
     permissions.required_binaries,

--- a/skills/clawsec-clawhub-checker/CHANGELOG.md
+++ b/skills/clawsec-clawhub-checker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.7] - 2026-06-22
+
+### Changed
+
+- Re-released skill metadata to publish through the updated ClawHub pipeline without runtime changes.
+
 ## [0.0.6] - 2026-06-10
 
 ### Changed

--- a/skills/clawsec-clawhub-checker/SKILL.md
+++ b/skills/clawsec-clawhub-checker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawsec-clawhub-checker
-version: 0.0.6
+version: 0.0.7
 description: ClawHub reputation checker for clawsec-suite. Adds a standalone reputation gate before guarded skill installation.
 homepage: https://clawsec.prompt.security
 clawdis:

--- a/skills/clawsec-clawhub-checker/skill.json
+++ b/skills/clawsec-clawhub-checker/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawsec-clawhub-checker",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "ClawHub reputation checker for clawsec-suite. Adds a standalone reputation gate before guarded skill installation.",
   "author": "abutbul",
   "license": "AGPL-3.0-or-later",

--- a/skills/clawsec-feed/CHANGELOG.md
+++ b/skills/clawsec-feed/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.10] - 2026-06-22
+
+### Changed
+
+- Re-released skill metadata to publish through the updated ClawHub pipeline without runtime changes.
+
 ## [0.0.9] - 2026-06-10
 
 ### Changed

--- a/skills/clawsec-feed/SKILL.md
+++ b/skills/clawsec-feed/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawsec-feed
-version: 0.0.9
+version: 0.0.10
 description: Security advisory feed package for OpenClaw-related threats and vulnerabilities. The upstream feed is updated daily; local automation is handled by clawsec-suite or the operator.
 homepage: https://clawsec.prompt.security
 metadata: {"openclaw":{"emoji":"📡","category":"security"}}

--- a/skills/clawsec-feed/skill.json
+++ b/skills/clawsec-feed/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawsec-feed",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Security advisory feed monitoring for AI agents. Subscribe to community-driven threat intelligence.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/clawsec-nanoclaw/CHANGELOG.md
+++ b/skills/clawsec-nanoclaw/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.9] - 2026-06-22
+
+### Changed
+
+- Re-released skill metadata to publish through the updated ClawHub pipeline without runtime changes.
+
 ## [0.0.8] - 2026-06-10
 
 ### Changed

--- a/skills/clawsec-nanoclaw/SKILL.md
+++ b/skills/clawsec-nanoclaw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawsec-nanoclaw
-version: 0.0.8
+version: 0.0.9
 description: Use when checking for security vulnerabilities in NanoClaw skills, before installing new skills, or when asked about security advisories affecting the bot
 ---
 

--- a/skills/clawsec-nanoclaw/skill.json
+++ b/skills/clawsec-nanoclaw/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawsec-nanoclaw",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "ClawSec security suite for NanoClaw - Advisory feed monitoring, MCP tools for vulnerability checking, and Ed25519 signature verification for containerized WhatsApp bot agents",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/clawsec-scanner/CHANGELOG.md
+++ b/skills/clawsec-scanner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.6] - 2026-06-22
+
+### Changed
+
+- Re-released skill metadata to publish through the updated ClawHub pipeline without runtime changes.
+
 ## [0.0.5] - 2026-06-10
 
 ### Changed

--- a/skills/clawsec-scanner/SKILL.md
+++ b/skills/clawsec-scanner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawsec-scanner
-version: 0.0.5
+version: 0.0.6
 description: Automated vulnerability scanner for agent platforms. Performs dependency scanning (npm audit, pip-audit), multi-database CVE lookup (OSV, NVD, GitHub Advisory), SAST analysis (Semgrep, Bandit), and agent-specific static hook inspection for OpenClaw hooks.
 homepage: https://clawsec.prompt.security
 clawdis:

--- a/skills/clawsec-scanner/skill.json
+++ b/skills/clawsec-scanner/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawsec-scanner",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Automated vulnerability scanner for agent platforms. Performs dependency scanning (npm audit, pip-audit), multi-database CVE lookup (OSV, NVD, GitHub Advisory), SAST analysis (Semgrep, Bandit), and agent-specific static hook inspection for OpenClaw hooks.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/clawsec-suite/CHANGELOG.md
+++ b/skills/clawsec-suite/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.11] - 2026-06-22
+
+### Changed
+
+- Re-released skill metadata to publish through the updated ClawHub pipeline without runtime changes.
+
 ## [0.1.10] - 2026-06-10
 
 ### Changed

--- a/skills/clawsec-suite/SKILL.md
+++ b/skills/clawsec-suite/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawsec-suite
-version: 0.1.10
+version: 0.1.11
 description: ClawSec suite manager with embedded advisory-feed monitoring, cryptographic signature verification, approval-gated malicious-skill response, and guided setup for additional security skills.
 homepage: https://clawsec.prompt.security
 clawdis:

--- a/skills/clawsec-suite/skill.json
+++ b/skills/clawsec-suite/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawsec-suite",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "ClawSec suite manager with embedded advisory-feed monitoring, cryptographic signature verification, approval-gated malicious-skill response, and guided setup for additional security skills.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/clawtributor/CHANGELOG.md
+++ b/skills/clawtributor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.8] - 2026-06-22
+
+### Changed
+
+- Re-released skill metadata to publish through the updated ClawHub pipeline without runtime changes.
+
 ## [0.0.7] - 2026-06-10
 
 ### Changed

--- a/skills/clawtributor/SKILL.md
+++ b/skills/clawtributor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawtributor
-version: 0.0.7
+version: 0.0.8
 description: Harness-neutral community incident reporting for AI agents. Contribute to collective security by reporting threats.
 homepage: https://clawsec.prompt.security
 platforms:

--- a/skills/clawtributor/skill.json
+++ b/skills/clawtributor/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawtributor",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Harness-neutral community incident reporting for AI agents. Contribute to collective security by reporting threats.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/hermes-attestation-guardian/CHANGELOG.md
+++ b/skills/hermes-attestation-guardian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.5] - 2026-06-22
+
+### Changed
+
+- Re-released skill metadata to publish through the updated ClawHub pipeline without runtime changes.
+
 ## [0.1.4] - 2026-06-10
 
 ### Changed

--- a/skills/hermes-attestation-guardian/SKILL.md
+++ b/skills/hermes-attestation-guardian/SKILL.md
@@ -31,7 +31,7 @@ For standalone installs, verify the signed release manifest before trusting `SKI
 set -euo pipefail
 
 SKILL_NAME="hermes-attestation-guardian"
-VERSION="0.1.4"
+VERSION="0.1.5"
 REPO="prompt-security/clawsec"
 TAG="${SKILL_NAME}-v${VERSION}"
 BASE="https://github.com/${REPO}/releases/download/${TAG}"

--- a/skills/hermes-attestation-guardian/SKILL.md
+++ b/skills/hermes-attestation-guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hermes-attestation-guardian
-version: 0.1.4
+version: 0.1.5
 description: Hermes-only runtime security attestation and drift detection skill for operator-managed Hermes infrastructure.
 homepage: https://clawsec.prompt.security
 hermes:

--- a/skills/hermes-attestation-guardian/skill.json
+++ b/skills/hermes-attestation-guardian/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-attestation-guardian",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Hermes-only runtime security attestation and drift detection skill. Generates deterministic posture artifacts, verifies integrity fail-closed, and classifies baseline drift severity.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/hermes-traffic-guardian/CHANGELOG.md
+++ b/skills/hermes-traffic-guardian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.1-beta4] - 2026-06-22
+
+### Changed
+
+- Re-released skill metadata to publish through the updated ClawHub pipeline without runtime changes.
+
 ## [0.0.1-beta3] - 2026-06-10
 
 ### Changed

--- a/skills/hermes-traffic-guardian/SKILL.md
+++ b/skills/hermes-traffic-guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hermes-traffic-guardian
-version: 0.0.1-beta3
+version: 0.0.1-beta4
 description: Hermes runtime traffic monitoring baseline for opt-in proxy inspection, egress detection, and attestation-aware traffic posture.
 homepage: https://clawsec.prompt.security
 author: prompt-security

--- a/skills/hermes-traffic-guardian/skill.json
+++ b/skills/hermes-traffic-guardian/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-traffic-guardian",
-  "version": "0.0.1-beta3",
+  "version": "0.0.1-beta4",
   "description": "Hermes runtime traffic monitoring baseline for opt-in proxy inspection, egress detection, and attestation-aware traffic posture.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/nanoclaw-traffic-guardian/CHANGELOG.md
+++ b/skills/nanoclaw-traffic-guardian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.1-beta4] - 2026-06-22
+
+### Changed
+
+- Re-released skill metadata to publish through the updated ClawHub pipeline without runtime changes.
+
 ## [0.0.1-beta3] - 2026-06-10
 
 ### Changed

--- a/skills/nanoclaw-traffic-guardian/SKILL.md
+++ b/skills/nanoclaw-traffic-guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nanoclaw-traffic-guardian
-version: 0.0.1-beta3
+version: 0.0.1-beta4
 description: NanoClaw runtime traffic monitoring baseline for host-side proxy inspection with container-safe MCP and IPC status surfaces.
 homepage: https://clawsec.prompt.security
 author: prompt-security

--- a/skills/nanoclaw-traffic-guardian/skill.json
+++ b/skills/nanoclaw-traffic-guardian/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoclaw-traffic-guardian",
-  "version": "0.0.1-beta3",
+  "version": "0.0.1-beta4",
   "description": "NanoClaw runtime traffic monitoring baseline for host-side proxy inspection with container-safe MCP and IPC status surfaces.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/openclaw-audit-watchdog/CHANGELOG.md
+++ b/skills/openclaw-audit-watchdog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.8] - 2026-06-22
+
+### Changed
+
+- Re-released skill metadata to publish through the updated ClawHub pipeline without runtime changes.
+
 ## [0.1.7] - 2026-06-10
 
 ### Changed

--- a/skills/openclaw-audit-watchdog/SKILL.md
+++ b/skills/openclaw-audit-watchdog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openclaw-audit-watchdog
-version: 0.1.7
+version: 0.1.8
 description: Automated daily security audits for OpenClaw agents with DM delivery and optional email reporting. Runs deep audits, creates or updates a recurring cron job, and sends formatted reports to configured recipients.
 homepage: https://clawsec.prompt.security
 metadata:

--- a/skills/openclaw-audit-watchdog/skill.json
+++ b/skills/openclaw-audit-watchdog/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-audit-watchdog",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Automated daily security audits for OpenClaw agents with DM delivery and optional email reporting. Creates or updates an unattended cron job and sends formatted reports to configured recipients.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/openclaw-traffic-guardian/CHANGELOG.md
+++ b/skills/openclaw-traffic-guardian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.1-beta4] - 2026-06-22
+
+### Changed
+
+- Re-released skill metadata to publish through the updated ClawHub pipeline without runtime changes.
+
 ## [0.0.1-beta3] - 2026-06-10
 
 ### Security

--- a/skills/openclaw-traffic-guardian/SKILL.md
+++ b/skills/openclaw-traffic-guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openclaw-traffic-guardian
-version: 0.0.1-beta3
+version: 0.0.1-beta4
 description: OpenClaw runtime traffic monitoring baseline for opt-in HTTP/HTTPS proxy inspection, egress detection, inbound injection detection, and social-account policy review.
 homepage: https://clawsec.prompt.security
 author: prompt-security

--- a/skills/openclaw-traffic-guardian/skill.json
+++ b/skills/openclaw-traffic-guardian/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-traffic-guardian",
-  "version": "0.0.1-beta3",
+  "version": "0.0.1-beta4",
   "description": "OpenClaw runtime traffic monitoring baseline for opt-in HTTP/HTTPS proxy inspection, egress detection, inbound injection detection, and social-account policy review.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/picoclaw-security-guardian/CHANGELOG.md
+++ b/skills/picoclaw-security-guardian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.5] - 2026-06-22
+
+### Changed
+
+- Re-released skill metadata to publish through the updated ClawHub pipeline without runtime changes.
+
 ## [0.0.4] - 2026-06-10
 
 ### Changed

--- a/skills/picoclaw-security-guardian/SKILL.md
+++ b/skills/picoclaw-security-guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: picoclaw-security-guardian
-version: 0.0.4
+version: 0.0.5
 description: Picoclaw security posture skill with advisory awareness, configuration drift detection, and supply-chain verification guidance.
 homepage: https://clawsec.prompt.security
 author: prompt-security

--- a/skills/picoclaw-security-guardian/skill.json
+++ b/skills/picoclaw-security-guardian/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "picoclaw-security-guardian",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Picoclaw security posture skill with advisory awareness, configuration drift detection, and supply-chain verification guidance.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/picoclaw-self-pen-testing/CHANGELOG.md
+++ b/skills/picoclaw-self-pen-testing/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.4] - 2026-06-22
+
+### Changed
+
+- Re-released skill metadata to publish through the updated ClawHub pipeline without runtime changes.
+
 ## [0.0.3] - 2026-06-10
 
 ### Changed

--- a/skills/picoclaw-self-pen-testing/SKILL.md
+++ b/skills/picoclaw-self-pen-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: picoclaw-self-pen-testing
-version: 0.0.3
+version: 0.0.4
 description: Picoclaw-only local posture-review skill focused on read-only findings and safe operator remediation guidance.
 homepage: https://clawsec.prompt.security
 author: prompt-security

--- a/skills/picoclaw-self-pen-testing/skill.json
+++ b/skills/picoclaw-self-pen-testing/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "picoclaw-self-pen-testing",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Picoclaw-only local posture-review skill focused on read-only findings and safe operator remediation guidance.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/picoclaw-traffic-guardian/CHANGELOG.md
+++ b/skills/picoclaw-traffic-guardian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.1-beta4] - 2026-06-22
+
+### Changed
+
+- Re-released skill metadata to publish through the updated ClawHub pipeline without runtime changes.
+
 ## [0.0.1-beta3] - 2026-06-10
 
 ### Changed

--- a/skills/picoclaw-traffic-guardian/SKILL.md
+++ b/skills/picoclaw-traffic-guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: picoclaw-traffic-guardian
-version: 0.0.1-beta3
+version: 0.0.1-beta4
 description: Picoclaw runtime traffic monitoring baseline for lightweight AI gateway proxy inspection, egress detection, and posture integration.
 homepage: https://clawsec.prompt.security
 author: prompt-security

--- a/skills/picoclaw-traffic-guardian/skill.json
+++ b/skills/picoclaw-traffic-guardian/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "picoclaw-traffic-guardian",
-  "version": "0.0.1-beta3",
+  "version": "0.0.1-beta4",
   "description": "Picoclaw runtime traffic monitoring baseline for lightweight AI gateway proxy inspection, egress detection, and posture integration.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/soul-guardian/CHANGELOG.md
+++ b/skills/soul-guardian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.8] - 2026-06-22
+
+### Changed
+
+- Re-released skill metadata to publish through the updated ClawHub pipeline without runtime changes.
+
 ## [0.0.7] - 2026-06-10
 
 ### Changed

--- a/skills/soul-guardian/SKILL.md
+++ b/skills/soul-guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: soul-guardian
-version: 0.0.7
+version: 0.0.8
 description: Drift detection + baseline integrity guard for agent workspace files with automatic alerting support
 homepage: https://clawsec.prompt.security
 metadata: {"openclaw":{"emoji":"👻","category":"security"}}

--- a/skills/soul-guardian/skill.json
+++ b/skills/soul-guardian/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-guardian",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Drift detection and baseline integrity guard for agent workspace prompt files. Auto-restore critical files with tamper-evident audit logging.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
# User description
### Summary
- Bumps release metadata for 15 ClawHub-publishable skills so they can be re-released through the updated ClawHub pipeline.
- Leaves `claw-release` unchanged because it is marked internal and is not ClawHub-publishable.
- Updates version-coupled release test fixtures for `clawsec-suite` and `hermes-traffic-guardian`.

### Bumped Skills
- `clawsec-clawhub-checker`: `0.0.6` -> `0.0.7`
- `clawsec-feed`: `0.0.9` -> `0.0.10`
- `clawsec-nanoclaw`: `0.0.8` -> `0.0.9`
- `clawsec-scanner`: `0.0.5` -> `0.0.6`
- `clawsec-suite`: `0.1.10` -> `0.1.11`
- `clawtributor`: `0.0.7` -> `0.0.8`
- `hermes-attestation-guardian`: `0.1.4` -> `0.1.5`
- `hermes-traffic-guardian`: `0.0.1-beta3` -> `0.0.1-beta4`
- `nanoclaw-traffic-guardian`: `0.0.1-beta3` -> `0.0.1-beta4`
- `openclaw-audit-watchdog`: `0.1.7` -> `0.1.8`
- `openclaw-traffic-guardian`: `0.0.1-beta3` -> `0.0.1-beta4`
- `picoclaw-security-guardian`: `0.0.4` -> `0.0.5`
- `picoclaw-self-pen-testing`: `0.0.3` -> `0.0.4`
- `picoclaw-traffic-guardian`: `0.0.1-beta3` -> `0.0.1-beta4`
- `soul-guardian`: `0.0.7` -> `0.0.8`

### Post-Merge Tag Plan
Tags are intentionally not pushed in this PR. After merge, push these one at a time from latest `main`:

```bash
git tag -a clawsec-clawhub-checker-v0.0.7 -m "clawsec-clawhub-checker version 0.0.7"
git push origin clawsec-clawhub-checker-v0.0.7

git tag -a clawsec-feed-v0.0.10 -m "clawsec-feed version 0.0.10"
git push origin clawsec-feed-v0.0.10

git tag -a clawsec-nanoclaw-v0.0.9 -m "clawsec-nanoclaw version 0.0.9"
git push origin clawsec-nanoclaw-v0.0.9

git tag -a clawsec-scanner-v0.0.6 -m "clawsec-scanner version 0.0.6"
git push origin clawsec-scanner-v0.0.6

git tag -a clawsec-suite-v0.1.11 -m "clawsec-suite version 0.1.11"
git push origin clawsec-suite-v0.1.11

git tag -a clawtributor-v0.0.8 -m "clawtributor version 0.0.8"
git push origin clawtributor-v0.0.8

git tag -a hermes-attestation-guardian-v0.1.5 -m "hermes-attestation-guardian version 0.1.5"
git push origin hermes-attestation-guardian-v0.1.5

git tag -a hermes-traffic-guardian-v0.0.1-beta4 -m "hermes-traffic-guardian version 0.0.1-beta4"
git push origin hermes-traffic-guardian-v0.0.1-beta4

git tag -a nanoclaw-traffic-guardian-v0.0.1-beta4 -m "nanoclaw-traffic-guardian version 0.0.1-beta4"
git push origin nanoclaw-traffic-guardian-v0.0.1-beta4

git tag -a openclaw-audit-watchdog-v0.1.8 -m "openclaw-audit-watchdog version 0.1.8"
git push origin openclaw-audit-watchdog-v0.1.8

git tag -a openclaw-traffic-guardian-v0.0.1-beta4 -m "openclaw-traffic-guardian version 0.0.1-beta4"
git push origin openclaw-traffic-guardian-v0.0.1-beta4

git tag -a picoclaw-security-guardian-v0.0.5 -m "picoclaw-security-guardian version 0.0.5"
git push origin picoclaw-security-guardian-v0.0.5

git tag -a picoclaw-self-pen-testing-v0.0.4 -m "picoclaw-self-pen-testing version 0.0.4"
git push origin picoclaw-self-pen-testing-v0.0.4

git tag -a picoclaw-traffic-guardian-v0.0.1-beta4 -m "picoclaw-traffic-guardian version 0.0.1-beta4"
git push origin picoclaw-traffic-guardian-v0.0.1-beta4

git tag -a soul-guardian-v0.0.8 -m "soul-guardian version 0.0.8"
git push origin soul-guardian-v0.0.8
```

### Testing
- `for d in skills/*; do ... python3 utils/validate_skill.py "$d"; done` for all publishable skills
- `for test_file in scripts/test-skill-*.mjs; do node "$test_file"; done`
- `npx eslint scripts/test-skill-tag-release-simulation.mjs scripts/test-skill-trust-packet.mjs --max-warnings 0`
- Local tag-release simulation for all 15 bumped skills using `scripts/ci/simulate_skill_tag_release.mjs`
- `npx tsc --noEmit`
- `npm ci`
- `npm run build`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align the ClawHub release pipeline by updating the metadata manifests, changelogs, and skill descriptors for all 15 renewed security skills so they can be republished through the refreshed pipeline. Harden the Skill release workflow validation by tightening the SkillSpector comment job permissions, allowing it to tolerate failures, and refreshing the version-sensitive simulations and trust-packet assertions that drive release confidence.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/278?tool=ast&topic=Skill+Metadata>Skill Metadata</a>
        </td><td>Update the metadata manifests, <code>SKILL.md</code>, and <code>CHANGELOG.md</code> files for every ClawHub-publishable skill (clawsec-clawhub-checker, clawsec-feed, clawsec-nanoclaw, clawsec-scanner, clawsec-suite, clawtributor, hermes-attestation-guardian, hermes-traffic-guardian, nanoclaw-traffic-guardian, openclaw-audit-watchdog, openclaw-traffic-guardian, picoclaw-security-guardian, picoclaw-self-pen-testing, picoclaw-traffic-guardian, and soul-guardian) so each component reflects its new version and is ready for the updated pipeline.<details><summary>Modified files (45)</summary><ul><li>skills/clawsec-clawhub-checker/CHANGELOG.md</li>
<li>skills/clawsec-clawhub-checker/SKILL.md</li>
<li>skills/clawsec-clawhub-checker/skill.json</li>
<li>skills/clawsec-feed/CHANGELOG.md</li>
<li>skills/clawsec-feed/SKILL.md</li>
<li>skills/clawsec-feed/skill.json</li>
<li>skills/clawsec-nanoclaw/CHANGELOG.md</li>
<li>skills/clawsec-nanoclaw/SKILL.md</li>
<li>skills/clawsec-nanoclaw/skill.json</li>
<li>skills/clawsec-scanner/CHANGELOG.md</li>
<li>skills/clawsec-scanner/SKILL.md</li>
<li>skills/clawsec-scanner/skill.json</li>
<li>skills/clawsec-suite/CHANGELOG.md</li>
<li>skills/clawsec-suite/SKILL.md</li>
<li>skills/clawsec-suite/skill.json</li>
<li>skills/clawtributor/CHANGELOG.md</li>
<li>skills/clawtributor/SKILL.md</li>
<li>skills/clawtributor/skill.json</li>
<li>skills/hermes-attestation-guardian/CHANGELOG.md</li>
<li>skills/hermes-attestation-guardian/SKILL.md</li>
<li>skills/hermes-attestation-guardian/skill.json</li>
<li>skills/hermes-traffic-guardian/CHANGELOG.md</li>
<li>skills/hermes-traffic-guardian/SKILL.md</li>
<li>skills/hermes-traffic-guardian/skill.json</li>
<li>skills/nanoclaw-traffic-guardian/CHANGELOG.md</li>
<li>skills/nanoclaw-traffic-guardian/SKILL.md</li>
<li>skills/nanoclaw-traffic-guardian/skill.json</li>
<li>skills/openclaw-audit-watchdog/CHANGELOG.md</li>
<li>skills/openclaw-audit-watchdog/SKILL.md</li>
<li>skills/openclaw-audit-watchdog/skill.json</li>
<li>skills/openclaw-traffic-guardian/CHANGELOG.md</li>
<li>skills/openclaw-traffic-guardian/SKILL.md</li>
<li>skills/openclaw-traffic-guardian/skill.json</li>
<li>skills/picoclaw-security-guardian/CHANGELOG.md</li>
<li>skills/picoclaw-security-guardian/SKILL.md</li>
<li>skills/picoclaw-security-guardian/skill.json</li>
<li>skills/picoclaw-self-pen-testing/CHANGELOG.md</li>
<li>skills/picoclaw-self-pen-testing/SKILL.md</li>
<li>skills/picoclaw-self-pen-testing/skill.json</li>
<li>skills/picoclaw-traffic-guardian/CHANGELOG.md</li>
<li>skills/picoclaw-traffic-guardian/SKILL.md</li>
<li>skills/picoclaw-traffic-guardian/skill.json</li>
<li>skills/soul-guardian/CHANGELOG.md</li>
<li>skills/soul-guardian/SKILL.md</li>
<li>skills/soul-guardian/skill.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>chore(release): bump s...</td><td>June 22, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>ci(skills): publish re...</td><td>June 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/278?tool=ast&topic=Release+Workflow>Release Workflow</a>
        </td><td>Harden the Skill release workflow by trimming redundant <code>pull-requests: read</code> permissions from the SkillSpector comment job, ensuring the job tolerates report download failures, and aligning the workflow simulation and trust-packet scripts with the bumped <code>clawsec-suite</code>, <code>hermes-traffic-guardian</code>, and <code>hermes-attestation-guardian</code> versions so the validation flow accurately mirrors the new release metadata.<details><summary>Modified files (4)</summary><ul><li>.github/workflows/skill-release.yml</li>
<li>scripts/test-skill-release-workflow.mjs</li>
<li>scripts/test-skill-tag-release-simulation.mjs</li>
<li>scripts/test-skill-trust-packet.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(release): resolve ...</td><td>June 22, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(release): update C...</td><td>June 22, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/278?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>