### PR TITLE
fix(release): install pinned clawhub CLI from npm

### DIFF
--- a/.github/clawhub-cli/package-lock.json
+++ b/.github/clawhub-cli/package-lock.json
@@ -11,7 +11,7 @@
     },
     "node_modules/@ark/schema": {
       "version": "0.56.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/@ark/schema/-/schema-0.56.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ark/schema/-/schema-0.56.0.tgz",
       "integrity": "sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==",
       "dependencies": {
         "@ark/util": "0.56.0"
@@ -19,12 +19,12 @@
     },
     "node_modules/@ark/util": {
       "version": "0.56.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/@ark/util/-/util-0.56.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ark/util/-/util-0.56.0.tgz",
       "integrity": "sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA=="
     },
     "node_modules/@clack/core": {
       "version": "0.5.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/@clack/core/-/core-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
       "integrity": "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==",
       "dependencies": {
         "picocolors": "^1.0.0",
@@ -33,7 +33,7 @@
     },
     "node_modules/@clack/prompts": {
       "version": "0.11.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/@clack/prompts/-/prompts-0.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.11.0.tgz",
       "integrity": "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==",
       "dependencies": {
         "@clack/core": "0.5.0",
@@ -43,7 +43,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "engines": {
         "node": ">=12"
@@ -54,7 +54,7 @@
     },
     "node_modules/arkregex": {
       "version": "0.0.5",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/arkregex/-/arkregex-0.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/arkregex/-/arkregex-0.0.5.tgz",
       "integrity": "sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==",
       "dependencies": {
         "@ark/util": "0.56.0"
@@ -62,7 +62,7 @@
     },
     "node_modules/arktype": {
       "version": "2.2.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/arktype/-/arktype-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/arktype/-/arktype-2.2.0.tgz",
       "integrity": "sha512-t54MZ7ti5BhOEvzEkgKnWvqj+UbDfWig+DHr5I34xatymPusKLS0lQpNJd8M6DzmIto2QGszHfNKoFIT8tMCZQ==",
       "dependencies": {
         "@ark/schema": "0.56.0",
@@ -72,7 +72,7 @@
     },
     "node_modules/chalk": {
       "version": "5.6.2",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/chalk/-/chalk-5.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -83,7 +83,7 @@
     },
     "node_modules/clawhub": {
       "version": "0.7.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/clawhub/-/clawhub-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/clawhub/-/clawhub-0.7.0.tgz",
       "integrity": "sha512-volW6SbX8PawlnRxxCoUTKv5Pi+N3MrBi3hlO5/m9bVaO43UFciEeYti9+01c2U5n/SKhUkw7ASvnleyNmcoSA==",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
@@ -108,7 +108,7 @@
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
       "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "dependencies": {
         "restore-cursor": "^5.0.0"
@@ -122,7 +122,7 @@
     },
     "node_modules/cli-spinners": {
       "version": "3.4.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
       "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
       "engines": {
         "node": ">=18.20"
@@ -133,7 +133,7 @@
     },
     "node_modules/commander": {
       "version": "14.0.3",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/commander/-/commander-14.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "engines": {
         "node": ">=20"
@@ -141,12 +141,12 @@
     },
     "node_modules/fflate": {
       "version": "0.8.3",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/fflate/-/fflate-0.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
       "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="
     },
     "node_modules/get-east-asian-width": {
       "version": "1.6.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
       "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "engines": {
         "node": ">=18"
@@ -157,7 +157,7 @@
     },
     "node_modules/ignore": {
       "version": "7.0.5",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/ignore/-/ignore-7.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "engines": {
         "node": ">= 4"
@@ -165,7 +165,7 @@
     },
     "node_modules/is-interactive": {
       "version": "2.0.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/is-interactive/-/is-interactive-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
       "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
       "engines": {
         "node": ">=12"
@@ -176,7 +176,7 @@
     },
     "node_modules/is-network-error": {
       "version": "1.3.2",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/is-network-error/-/is-network-error-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
       "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
       "engines": {
         "node": ">=16"
@@ -187,7 +187,7 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "engines": {
         "node": ">=18"
@@ -198,7 +198,7 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/json5/-/json5-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
@@ -209,7 +209,7 @@
     },
     "node_modules/log-symbols": {
       "version": "7.0.1",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/log-symbols/-/log-symbols-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
       "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
       "dependencies": {
         "is-unicode-supported": "^2.0.0",
@@ -224,7 +224,7 @@
     },
     "node_modules/mime": {
       "version": "4.1.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/mime/-/mime-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
       "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
       "funding": [
         "https://github.com/sponsors/broofa"
@@ -238,7 +238,7 @@
     },
     "node_modules/mimic-function": {
       "version": "5.0.1",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/mimic-function/-/mimic-function-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
       "engines": {
         "node": ">=18"
@@ -249,7 +249,7 @@
     },
     "node_modules/onetime": {
       "version": "7.0.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/onetime/-/onetime-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
       "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
       "dependencies": {
         "mimic-function": "^5.0.0"
@@ -263,7 +263,7 @@
     },
     "node_modules/ora": {
       "version": "9.4.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/ora/-/ora-9.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.0.tgz",
       "integrity": "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -284,7 +284,7 @@
     },
     "node_modules/p-retry": {
       "version": "7.1.1",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/p-retry/-/p-retry-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
       "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
       "dependencies": {
         "is-network-error": "^1.1.0"
@@ -298,12 +298,12 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
       "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "dependencies": {
         "onetime": "^7.0.0",
@@ -318,7 +318,7 @@
     },
     "node_modules/semver": {
       "version": "7.8.4",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/semver/-/semver-7.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
       "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "bin": {
         "semver": "bin/semver.js"
@@ -329,7 +329,7 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/signal-exit/-/signal-exit-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "engines": {
         "node": ">=14"
@@ -340,12 +340,12 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/sisteransi/-/sisteransi-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "node_modules/stdin-discarder": {
       "version": "0.3.2",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
       "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
       "engines": {
         "node": ">=18"
@@ -356,7 +356,7 @@
     },
     "node_modules/string-width": {
       "version": "8.2.1",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/string-width/-/string-width-8.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
       "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dependencies": {
         "get-east-asian-width": "^1.5.0",
@@ -371,7 +371,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -385,7 +385,7 @@
     },
     "node_modules/undici": {
       "version": "7.28.0",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/undici/-/undici-7.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
       "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "engines": {
         "node": ">=20.18.1"
@@ -393,7 +393,7 @@
     },
     "node_modules/yoctocolors": {
       "version": "2.1.2",
-      "resolved": "https://prompt-security-443370709039.d.codeartifact.eu-north-1.amazonaws.com/npm/npm-proxy/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
       "engines": {
         "node": ">=18"

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -21,7 +21,7 @@ on:
 
 permissions: read-all
 
-# The clawhub CLI version is pinned (with integrity hashes) in
+# The ClawHub CLI version is pinned (with integrity hashes) in
 # .github/clawhub-cli/package-lock.json — bump it there.
 
 concurrency:
@@ -1691,10 +1691,6 @@ jobs:
       contents: read
     env:
       CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
-      AWS_REGION: eu-north-1
     steps:
       - name: Check if publishable
         if: needs.release-tag.outputs.publish_clawhub != 'true'
@@ -1813,10 +1809,6 @@ jobs:
       contents: read
     env:
       CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
-      AWS_REGION: eu-north-1
     steps:
       - name: Parse tag
         id: parse

--- a/scripts/ci/install_clawhub_cli.sh
+++ b/scripts/ci/install_clawhub_cli.sh
@@ -2,9 +2,8 @@
 set -euo pipefail
 
 CLI_PREFIX="${CLAWHUB_CLI_PREFIX:-.github/clawhub-cli}"
-NPM_REGISTRY="${CLAWHUB_NPM_REGISTRY:-https://registry.npmjs.org}"
 
-npm ci --prefix "$CLI_PREFIX" --registry="$NPM_REGISTRY"
+npm ci --prefix "$CLI_PREFIX"
 
 if [ -n "${GITHUB_PATH:-}" ]; then
   workspace="${GITHUB_WORKSPACE:-$(pwd)}"

--- a/scripts/ci/install_clawhub_cli.sh
+++ b/scripts/ci/install_clawhub_cli.sh
@@ -2,29 +2,9 @@
 set -euo pipefail
 
 CLI_PREFIX="${CLAWHUB_CLI_PREFIX:-.github/clawhub-cli}"
-CODEARTIFACT_DOMAIN="${CODEARTIFACT_DOMAIN:-prompt-security}"
-CODEARTIFACT_DOMAIN_OWNER="${CODEARTIFACT_DOMAIN_OWNER:-443370709039}"
-CODEARTIFACT_REPOSITORY="${CODEARTIFACT_REPOSITORY:-npm-proxy}"
-AWS_REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-eu-north-1}}"
+NPM_REGISTRY="${CLAWHUB_NPM_REGISTRY:-https://registry.npmjs.org}"
 
-if ! command -v aws >/dev/null 2>&1; then
-  echo "::error::aws CLI is required to authenticate npm against CodeArtifact"
-  exit 1
-fi
-
-if ! aws sts get-caller-identity >/dev/null 2>&1; then
-  echo "::error::AWS credentials are required before installing the CodeArtifact-pinned clawhub CLI"
-  exit 1
-fi
-
-aws codeartifact login \
-  --tool npm \
-  --domain "$CODEARTIFACT_DOMAIN" \
-  --domain-owner "$CODEARTIFACT_DOMAIN_OWNER" \
-  --repository "$CODEARTIFACT_REPOSITORY" \
-  --region "$AWS_REGION"
-
-npm ci --prefix "$CLI_PREFIX"
+npm ci --prefix "$CLI_PREFIX" --registry="$NPM_REGISTRY"
 
 if [ -n "${GITHUB_PATH:-}" ]; then
   workspace="${GITHUB_WORKSPACE:-$(pwd)}"

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -3,12 +3,14 @@ import { readFile } from 'node:fs/promises';
 
 const workflowPath = new URL('../.github/workflows/skill-release.yml', import.meta.url);
 const ciWorkflowPath = new URL('../.github/workflows/ci.yml', import.meta.url);
+const clawhubLockPath = new URL('../.github/clawhub-cli/package-lock.json', import.meta.url);
 const validateSkillInstallDocsPath = new URL('./ci/validate_skill_install_docs.mjs', import.meta.url);
 const installClawhubCliPath = new URL('./ci/install_clawhub_cli.sh', import.meta.url);
 const patchClawhubPayloadPath = new URL('./ci/patch_clawhub_publish_payload.mjs', import.meta.url);
 const guardClawhubSlugOwnerPath = new URL('./ci/guard_clawhub_slug_owner.sh', import.meta.url);
 const workflow = await readFile(workflowPath, 'utf8');
 const ciWorkflow = await readFile(ciWorkflowPath, 'utf8');
+const clawhubLock = JSON.parse(await readFile(clawhubLockPath, 'utf8'));
 const validateSkillInstallDocs = await readFile(validateSkillInstallDocsPath, 'utf8');
 const installClawhubCli = await readFile(installClawhubCliPath, 'utf8');
 const patchClawhubPayload = await readFile(patchClawhubPayloadPath, 'utf8');
@@ -394,13 +396,7 @@ assert.doesNotMatch(
 
 assert.match(
   installClawhubCli,
-  /NPM_REGISTRY="\$\{CLAWHUB_NPM_REGISTRY:-https:\/\/registry\.npmjs\.org\}"/,
-  'ClawHub CLI installer must default to the public npm registry',
-);
-
-assert.match(
-  installClawhubCli,
-  /npm ci --prefix "\$CLI_PREFIX" --registry="\$NPM_REGISTRY"/,
+  /npm ci --prefix "\$CLI_PREFIX"/,
   'ClawHub CLI installer must install from the committed lockfile prefix',
 );
 
@@ -408,6 +404,15 @@ assert.doesNotMatch(
   installClawhubCli,
   /aws codeartifact login|AWS credentials are required/,
   'ClawHub CLI installer must not require AWS secrets that are not configured for release workflows',
+);
+
+const clawhubLockResolvedUrls = Object.values(clawhubLock.packages ?? {})
+  .map((entry) => entry.resolved)
+  .filter(Boolean);
+assert.ok(clawhubLockResolvedUrls.length > 0, 'ClawHub CLI lockfile must contain resolved tarball URLs');
+assert.ok(
+  clawhubLockResolvedUrls.every((url) => url.startsWith('https://registry.npmjs.org/')),
+  'ClawHub CLI lockfile must use public npm tarballs because release workflows do not have AWS CodeArtifact secrets',
 );
 
 assert.match(

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -392,24 +392,22 @@ assert.doesNotMatch(
   'ClawHub payload patching must not be duplicated inline in the workflow',
 );
 
-for (const secret of ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN']) {
-  assert.match(
-    workflow,
-    new RegExp(`${secret}: \\$\\{\\{ secrets\\.${secret} \\}\\}`),
-    `ClawHub jobs must expose ${secret} for CodeArtifact npm authentication`,
-  );
-}
-
 assert.match(
   installClawhubCli,
-  /aws codeartifact login[\s\S]*--domain "\$CODEARTIFACT_DOMAIN"[\s\S]*--domain-owner "\$CODEARTIFACT_DOMAIN_OWNER"[\s\S]*--repository "\$CODEARTIFACT_REPOSITORY"[\s\S]*--region "\$AWS_REGION"/,
-  'ClawHub CLI installer must authenticate npm against CodeArtifact before npm ci',
+  /NPM_REGISTRY="\$\{CLAWHUB_NPM_REGISTRY:-https:\/\/registry\.npmjs\.org\}"/,
+  'ClawHub CLI installer must default to the public npm registry',
 );
 
 assert.match(
   installClawhubCli,
-  /npm ci --prefix "\$CLI_PREFIX"/,
+  /npm ci --prefix "\$CLI_PREFIX" --registry="\$NPM_REGISTRY"/,
   'ClawHub CLI installer must install from the committed lockfile prefix',
+);
+
+assert.doesNotMatch(
+  installClawhubCli,
+  /aws codeartifact login|AWS credentials are required/,
+  'ClawHub CLI installer must not require AWS secrets that are not configured for release workflows',
 );
 
 assert.match(


### PR DESCRIPTION
# User description
## Summary
- switches the pinned ClawHub CLI install from CodeArtifact-only tarballs to public npm tarballs while keeping the committed lockfile and integrity hashes
- removes unused AWS secret env wiring from ClawHub publish jobs
- keeps the shared installer and workflow regression tests aligned with the repository's actual configured secrets

## Why
The first post-merge skill tag, `clawsec-clawhub-checker-v0.0.7`, created the GitHub release successfully but failed in `publish-clawhub` because this repository has `CLAWHUB_TOKEN` configured but no AWS CodeArtifact credentials. The release loop is paused until ClawHub publishing can run green.

## Testing
- `bash scripts/ci/install_clawhub_cli.sh`
- `node scripts/test-skill-release-workflow.mjs`
- `for test_file in scripts/test-skill-*.mjs; do node ""; done`
- `npx eslint scripts/test-skill-release-workflow.mjs --max-warnings 0`
- `git diff --check`

## Follow-up after merge
- run Skill Release workflow_dispatch for `clawsec-clawhub-checker-v0.0.7` to publish the already-created GitHub release to ClawHub
- resume one-by-one tag pushes for the remaining skill tags

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the skill release workflow, ClawHub CLI installer, and lockfile to rely solely on the committed npm metadata and configured GitHub secrets so releases can publish without AWS credentials. Add regression checks that confirm the CLI installer no longer demands AWS secrets and that the lockfile resolves from public npm tarballs.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/281?tool=ast&topic=Release+workflow>Release workflow</a>
        </td><td>Remove the unused AWS secret wiring from the skill release workflow so it only exposes the <code>CLAWHUB_TOKEN</code> already configured for publishing.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/skill-release.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(release): install ...</td><td>June 23, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>chore(release): bump s...</td><td>June 23, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/281?tool=ast&topic=CLI+install>CLI install</a>
        </td><td>Switch ClawHub CLI installation to use the committed npm metadata, drop the CodeArtifact login path, and validate via regression tests that the lockfile resolves from public npm tarballs without requiring AWS secrets.<details><summary>Modified files (3)</summary><ul><li>.github/clawhub-cli/package-lock.json</li>
<li>scripts/ci/install_clawhub_cli.sh</li>
<li>scripts/test-skill-release-workflow.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>test(release): assert ...</td><td>June 23, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>chore(release): bump s...</td><td>June 23, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/281?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>