### PR TITLE
fix(release): preserve republish slug helper dependency

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -1829,7 +1829,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Prepare ClawHub slug helper
-        run: cp scripts/ci/resolve_clawhub_slug.mjs "$RUNNER_TEMP/resolve_clawhub_slug.mjs"
+        run: |
+          cp scripts/ci/resolve_clawhub_slug.mjs "$RUNNER_TEMP/resolve_clawhub_slug.mjs"
+          cp scripts/ci/skill_platforms.mjs "$RUNNER_TEMP/skill_platforms.mjs"
 
       - name: Checkout tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -330,8 +330,8 @@ assert.match(
 
 assert.match(
   workflow,
-  /cp scripts\/ci\/resolve_clawhub_slug\.mjs "\$RUNNER_TEMP\/resolve_clawhub_slug\.mjs"/,
-  'Manual ClawHub republish must preserve the current slug helper before checking out an older release tag',
+  /cp scripts\/ci\/resolve_clawhub_slug\.mjs "\$RUNNER_TEMP\/resolve_clawhub_slug\.mjs"[\s\S]*cp scripts\/ci\/skill_platforms\.mjs "\$RUNNER_TEMP\/skill_platforms\.mjs"/,
+  'Manual ClawHub republish must preserve the current slug helper and its local module dependency before checking out an older release tag',
 );
 
 assert.match(


### PR DESCRIPTION
# User description
## Summary
- Fixes manual ClawHub republish by copying the slug helper dependency into RUNNER_TEMP before checking out the release tag.
- Updates the release workflow regression test so this exact failure mode is covered.

## Root Cause
The manual republish job preserved scripts/ci/resolve_clawhub_slug.mjs before checking out an older tag, but that helper imports ./skill_platforms.mjs. After checkout switched to the tag, the temp copy could not resolve that sibling module, causing workflow_dispatch republish to fail before ClawHub publish.

Failed run: https://github.com/prompt-security/clawsec/actions/runs/28008872655

## Testing
- node scripts/test-skill-release-workflow.mjs
- for test_file in scripts/test-skill-*.mjs; do node ""; done
- npx eslint scripts/test-skill-release-workflow.mjs --max-warnings 0
- git diff --check

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Extend the release workflow prep to stash the ClawHub slug helper and its sibling platform resolver into <code>RUNNER_TEMP</code> so the manual republish job can run after checking out an older tag. Update the release workflow regression test to assert that both helper files are preserved during the checkout sequence.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/282?tool=ast&topic=Release+prep>Release prep</a>
        </td><td>Preserve the slug helper and its <code>skill_platforms.mjs</code> dependency in the release workflow prep so manual ClawHub republish can run after checking out an older tag.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/skill-release.yml</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/282?tool=ast&topic=Release+test>Release test</a>
        </td><td>Assert the workflow log now includes copying both helper files before the tag checkout to cover the regression.<details><summary>Modified files (1)</summary><ul><li>scripts/test-skill-release-workflow.mjs</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/282?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>