### PR TITLE
chore(release): bump all public skills

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -861,7 +861,6 @@ jobs:
       actions: read
       contents: read
       issues: write
-      pull-requests: write
     steps:
       - name: Download SkillSpector reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -828,21 +828,19 @@ jobs:
     if: always() && github.event_name == 'pull_request' && needs.release.result != 'cancelled'
     needs: release
     runs-on: ubuntu-latest
-    continue-on-error: true
     permissions:
       actions: read
       contents: read
       issues: write
+      pull-requests: write
     steps:
       - name: Download SkillSpector reports
-        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: skillspector-pr-reports
           path: skillspector-pr-reports
 
       - name: Comment SkillSpector reports
-        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -775,6 +775,35 @@ jobs:
               cp "${skill_dir}/README.md" "${out_assets}/README.md"
             fi
 
+            if ! add_release_asset_checksum "${out_assets}" "skill.json"; then
+              failures=$((failures + 1))
+              rm -rf "${staging_dir}"
+              echo "::endgroup::"
+              continue
+            fi
+
+            if ! add_release_asset_checksum "${out_assets}" "SKILL.md"; then
+              failures=$((failures + 1))
+              rm -rf "${staging_dir}"
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [ -f "${out_assets}/README.md" ] && ! add_release_asset_checksum "${out_assets}" "README.md"; then
+              failures=$((failures + 1))
+              rm -rf "${staging_dir}"
+              echo "::endgroup::"
+              continue
+            fi
+
+            if ! jq -e . "${out_assets}/checksums.json" >/dev/null 2>&1; then
+              echo "::error::Generated checksums.json is invalid JSON after adding standalone release assets."
+              failures=$((failures + 1))
+              rm -rf "${staging_dir}"
+              echo "::endgroup::"
+              continue
+            fi
+
             rm -rf "${staging_dir}"
 
             echo "Prepared dry-run assets for ${tag}:"
@@ -1422,6 +1451,17 @@ jobs:
           fi
           if [ -f "$SKILL_PATH/README.md" ]; then
             cp "$SKILL_PATH/README.md" release-assets/
+          fi
+
+          add_release_asset_checksum "skill.json"
+          add_release_asset_checksum "SKILL.md"
+          if [ -f release-assets/README.md ]; then
+            add_release_asset_checksum "README.md"
+          fi
+
+          if ! jq -e . "release-assets/checksums.json" >/dev/null 2>&1; then
+            echo "::error::Generated checksums.json is invalid JSON after adding standalone release assets."
+            exit 1
           fi
 
           rm -rf "$STAGING_DIR"

--- a/scripts/ci/simulate_skill_tag_release.mjs
+++ b/scripts/ci/simulate_skill_tag_release.mjs
@@ -484,6 +484,13 @@ async function main() {
       await cp(path.join(tempSkillDir, "README.md"), path.join(releaseAssetsDir, "README.md"));
     }
 
+    for (const artifact of ["skill.json", "SKILL.md", "README.md"]) {
+      if (existsSync(path.join(releaseAssetsDir, artifact))) {
+        await addReleaseAssetChecksum({ releaseAssetsDir, manifest, asset: artifact });
+      }
+    }
+    await writeJson(path.join(releaseAssetsDir, "checksums.json"), manifest);
+
     const { privateKeyPath, publicKeyPath } = await createSigningKeyPair(tempRoot);
     await signFileBase64({
       keyPath: privateKeyPath,

--- a/scripts/release-skill.sh
+++ b/scripts/release-skill.sh
@@ -141,6 +141,23 @@ if [ -f "$SKILL_PATH/SKILL.md" ]; then
 
   echo "  ✓ Version updated to $VERSION"
 
+  echo "Updating release verification VERSION assignments in SKILL.md..."
+  VERSION_ASSIGNMENT_PATTERN='^VERSION="[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?"$'
+  if grep -qE "$VERSION_ASSIGNMENT_PATTERN" "$TEMP_DIR/SKILL.md"; then
+    sed -E "s|$VERSION_ASSIGNMENT_PATTERN|VERSION=\"$VERSION\"|g" "$TEMP_DIR/SKILL.md" > "$TEMP_DIR/SKILL.md.tmp"
+
+    if ! grep -qF "VERSION=\"$VERSION\"" "$TEMP_DIR/SKILL.md.tmp"; then
+      echo "Warning: VERSION assignment found but substitution may have failed" >&2
+    else
+      VERSION_ASSIGNMENT_COUNT=$(grep -cF "VERSION=\"$VERSION\"" "$TEMP_DIR/SKILL.md.tmp")
+      echo "  ✓ Updated $VERSION_ASSIGNMENT_COUNT VERSION assignment(s)"
+    fi
+
+    mv "$TEMP_DIR/SKILL.md.tmp" "$TEMP_DIR/SKILL.md"
+  else
+    echo "  ℹ No hardcoded release verification VERSION assignments found"
+  fi
+
   echo "Updating hardcoded version URLs in SKILL.md to use tag $TAG..."
   # Replace all hardcoded version URLs: download/SKILLNAME-vX.Y.Z(-prerelease)?/ -> download/TAG/
   # This handles patterns like: download/clawsec-feed-v1.0.0/ or download/prompt-agent-v1.0.0-beta1/

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -8,6 +8,7 @@ const validateSkillInstallDocsPath = new URL('./ci/validate_skill_install_docs.m
 const installClawhubCliPath = new URL('./ci/install_clawhub_cli.sh', import.meta.url);
 const patchClawhubPayloadPath = new URL('./ci/patch_clawhub_publish_payload.mjs', import.meta.url);
 const guardClawhubSlugOwnerPath = new URL('./ci/guard_clawhub_slug_owner.sh', import.meta.url);
+const releaseSkillScriptPath = new URL('./release-skill.sh', import.meta.url);
 const workflow = await readFile(workflowPath, 'utf8');
 const ciWorkflow = await readFile(ciWorkflowPath, 'utf8');
 const clawhubLock = JSON.parse(await readFile(clawhubLockPath, 'utf8'));
@@ -15,6 +16,7 @@ const validateSkillInstallDocs = await readFile(validateSkillInstallDocsPath, 'u
 const installClawhubCli = await readFile(installClawhubCliPath, 'utf8');
 const patchClawhubPayload = await readFile(patchClawhubPayloadPath, 'utf8');
 const guardClawhubSlugOwner = await readFile(guardClawhubSlugOwnerPath, 'utf8');
+const releaseSkillScript = await readFile(releaseSkillScriptPath, 'utf8');
 
 assert.match(
   workflow,
@@ -320,6 +322,16 @@ assert.match(
 assert.ok(
   workflow.includes('simulated_version | test("^[0-9]+\\\\.[0-9]+\\\\.[0-9]+(-[a-zA-Z0-9]+)?$")'),
   'Skill release workflow must accept every prerelease version format that release-skill.sh accepts',
+);
+
+assert.ok(
+  releaseSkillScript.includes(`VERSION_ASSIGNMENT_PATTERN='^VERSION="[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9.]+)?"$'`),
+  'release-skill.sh must detect hardcoded release verification VERSION assignments in SKILL.md',
+);
+
+assert.ok(
+  releaseSkillScript.includes('sed -E "s|$VERSION_ASSIGNMENT_PATTERN|VERSION=\\"$VERSION\\"|g"'),
+  'release-skill.sh must update hardcoded release verification VERSION assignments when bumping a skill',
 );
 
 assert.match(

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -277,15 +277,21 @@ assert.match(
 
 assert.match(
   workflow,
-  /comment-skillspector-report:[\s\S]*needs: release[\s\S]*issues: write[\s\S]*pull-requests: write[\s\S]*actions\/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8\.0\.1/,
-  'Skill release workflow must download generated SkillSpector reports in a separate PR comment job with comment permissions',
+  /comment-skillspector-report:[\s\S]*needs: release[\s\S]*issues: write[\s\S]*actions\/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8\.0\.1/,
+  'Skill release workflow must download generated SkillSpector reports in a separate PR comment job with issue-comment permissions',
 );
 
 const commentJob = workflow.match(/[ ]{2}comment-skillspector-report:[\s\S]*?\n[ ]{2}[a-z][^:\n]*:/)?.[0] || "";
 assert.match(
   commentJob,
+  /issues: write/,
+  'SkillSpector PR comment publishing must request issues write permissions so report comments can be created',
+);
+
+assert.doesNotMatch(
+  commentJob,
   /pull-requests: write/,
-  'SkillSpector PR comment publishing must request pull-requests write permissions so new report comments can be created',
+  'SkillSpector PR comment publishing must not broaden the token with pull-requests write permissions',
 );
 
 assert.match(

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -252,27 +252,33 @@ assert.match(
 
 assert.match(
   workflow,
-  /comment-skillspector-report:[\s\S]*needs: release[\s\S]*issues: write[\s\S]*actions\/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8\.0\.1/,
+  /comment-skillspector-report:[\s\S]*needs: release[\s\S]*issues: write[\s\S]*pull-requests: write[\s\S]*actions\/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8\.0\.1/,
   'Skill release workflow must download generated SkillSpector reports in a separate PR comment job with comment permissions',
 );
 
 const commentJob = workflow.match(/[ ]{2}comment-skillspector-report:[\s\S]*?\n[ ]{2}[a-z][^:\n]*:/)?.[0] || "";
-assert.doesNotMatch(
+assert.match(
   commentJob,
   /pull-requests: write/,
-  'SkillSpector PR comment publishing should not request redundant pull-requests write permissions',
+  'SkillSpector PR comment publishing must request pull-requests write permissions so new report comments can be created',
 );
 
 assert.match(
   workflow,
-  /comment-skillspector-report:[\s\S]*if: always\(\) && github\.event_name == 'pull_request' && needs\.release\.result != 'cancelled'[\s\S]*Download SkillSpector reports[\s\S]*continue-on-error: true/,
+  /comment-skillspector-report:[\s\S]*if: always\(\) && github\.event_name == 'pull_request' && needs\.release\.result != 'cancelled'[\s\S]*Download SkillSpector reports/,
   'SkillSpector PR comments must still run when the release dry-run produced reports but the release job failed later',
 );
 
 assert.match(
   workflow,
-  /Comment SkillSpector reports[\s\S]*continue-on-error: true[\s\S]*actions\/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9\.0\.0/,
-  'SkillSpector PR comment publishing must not fail the release dry-run check',
+  /Comment SkillSpector reports[\s\S]*actions\/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9\.0\.0/,
+  'SkillSpector PR comment publishing must use the pinned GitHub script action',
+);
+
+assert.doesNotMatch(
+  commentJob,
+  /continue-on-error: true/,
+  'SkillSpector PR comment publishing must fail visibly when report artifacts or PR comments cannot be created',
 );
 
 assert.match(

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -222,6 +222,29 @@ for (const artifact of ['skill-card.md', 'permissions.json', 'install.md', 'skil
   );
 }
 
+for (const artifact of ['skill.json', 'SKILL.md']) {
+  assert.match(
+    workflow,
+    new RegExp(
+      String.raw`cp [\s\S]*? "\$\{out_assets\}/${escapeRegExp(artifact)}"[\s\S]*?` +
+        String.raw`if ! add_release_asset_checksum "\$\{out_assets\}" "${escapeRegExp(artifact)}"; then`,
+    ),
+    `PR dry-run validation must checksum standalone downloadable ${artifact} after copying it to release assets`,
+  );
+}
+
+assert.match(
+  workflow,
+  /if \[ -f "\$\{out_assets\}\/README\.md" \] && ! add_release_asset_checksum "\$\{out_assets\}" "README\.md"; then/,
+  'PR dry-run validation must checksum standalone downloadable README.md when it is shipped',
+);
+
+assert.match(
+  workflow,
+  /cp "\$SKILL_PATH\/skill\.json" release-assets\/skill\.json[\s\S]*add_release_asset_checksum "skill\.json"[\s\S]*add_release_asset_checksum "SKILL\.md"[\s\S]*add_release_asset_checksum "README\.md"/,
+  'Tag release validation must checksum standalone downloadable skill files before signing checksums.json',
+);
+
 assert.match(
   workflow,
   /add_release_asset_checksum "skill-card\.md"/,

--- a/scripts/test-skill-tag-release-simulation.mjs
+++ b/scripts/test-skill-tag-release-simulation.mjs
@@ -1,11 +1,17 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { chmod, cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
 const tempRoot = await mkdtemp(path.join(tmpdir(), "clawsec-tag-release-sim-"));
 const fakeSkillspector = path.join(tempRoot, "skillspector");
+
+function sha256(buffer) {
+  return createHash("sha256").update(buffer).digest("hex");
+}
 
 async function prereleaseFixture(sourceSkillDir, version, fixtureGroup) {
   const fixtureDir = path.join(tempRoot, fixtureGroup, path.basename(sourceSkillDir));
@@ -75,6 +81,24 @@ async function runSimulation({ skillDir, outputDir, expectedOriginal, expectedSi
     );
     const file = await readFile(path.join(releaseAssetsDir, artifact));
     assert.ok(file.length > 0, `${artifact} should not be empty`);
+  }
+
+  for (const artifact of ["skill.json", "SKILL.md", "skillspector-report.md"]) {
+    const file = await readFile(path.join(releaseAssetsDir, artifact));
+    assert.equal(
+      checksums.files[artifact]?.sha256,
+      sha256(file),
+      `${artifact} must be downloadable and covered by checksums.json`,
+    );
+  }
+
+  if (existsSync(path.join(releaseAssetsDir, "README.md"))) {
+    const file = await readFile(path.join(releaseAssetsDir, "README.md"));
+    assert.equal(
+      checksums.files["README.md"]?.sha256,
+      sha256(file),
+      "README.md must be downloadable and covered by checksums.json when shipped",
+    );
   }
 
   const archive = await readFile(path.join(releaseAssetsDir, `${expectedTag}.zip`));

--- a/scripts/test-skill-tag-release-simulation.mjs
+++ b/scripts/test-skill-tag-release-simulation.mjs
@@ -140,16 +140,16 @@ writeFileSync(process.argv[outputIndex + 1], "# Fake SkillSpector Report\\n\\nNo
   await runSimulation({
     skillDir: "skills/clawsec-suite",
     outputDir: path.join(tempRoot, "stable"),
-    expectedOriginal: "0.1.11",
-    expectedSimulated: "0.1.12",
+    expectedOriginal: "0.1.12",
+    expectedSimulated: "0.1.13",
     expectedAgent: "openclaw",
   });
 
   await runSimulation({
     skillDir: "skills/hermes-traffic-guardian",
     outputDir: path.join(tempRoot, "beta"),
-    expectedOriginal: "0.0.1-beta4",
-    expectedSimulated: "0.0.1-beta5",
+    expectedOriginal: "0.0.1-beta5",
+    expectedSimulated: "0.0.1-beta6",
     expectedAgent: "hermes-agent",
   });
 

--- a/scripts/test-skill-trust-packet.mjs
+++ b/scripts/test-skill-trust-packet.mjs
@@ -25,7 +25,7 @@ function runTrustPacket(skillDir, targetDir, tag) {
 }
 
 try {
-  const result = runTrustPacket("skills/clawsec-suite", outputDir, "clawsec-suite-v0.1.11");
+  const result = runTrustPacket("skills/clawsec-suite", outputDir, "clawsec-suite-v0.1.12");
 
   assert.equal(
     result.status,
@@ -41,10 +41,10 @@ try {
   assert.match(skillCard, /## License\/Terms of Use/);
   assert.match(skillCard, /AGPL-3\.0-or-later/);
   assert.match(skillCard, /skillspector-report\.md/);
-  assert.match(skillCard, /clawsec-suite-v0\.1\.11/);
+  assert.match(skillCard, /clawsec-suite-v0\.1\.12/);
 
   assert.equal(permissions.skill, "clawsec-suite");
-  assert.equal(permissions.version, "0.1.11");
+  assert.equal(permissions.version, "0.1.12");
   assert.equal(permissions.platform, "openclaw");
   assert.deepEqual(
     permissions.required_binaries,
@@ -62,7 +62,7 @@ try {
   const hermesResult = runTrustPacket(
     "skills/hermes-attestation-guardian",
     hermesOutputDir,
-    "hermes-attestation-guardian-v0.1.5",
+    "hermes-attestation-guardian-v0.1.6",
   );
   assert.equal(
     hermesResult.status,

--- a/skills/clawsec-clawhub-checker/CHANGELOG.md
+++ b/skills/clawsec-clawhub-checker/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Re-released skill metadata to run through the normal tag publish path after the earlier `0.0.7` ClawHub publish failed before upload.
+- Re-released skill metadata to run through the corrected normal tag publish pipeline without runtime changes.
 
 ## [0.0.7] - 2026-06-22
 

--- a/skills/clawsec-clawhub-checker/CHANGELOG.md
+++ b/skills/clawsec-clawhub-checker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.8] - 2026-06-23
+
+### Changed
+
+- Re-released skill metadata to run through the normal tag publish path after the earlier `0.0.7` ClawHub publish failed before upload.
+
 ## [0.0.7] - 2026-06-22
 
 ### Changed

--- a/skills/clawsec-clawhub-checker/SKILL.md
+++ b/skills/clawsec-clawhub-checker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawsec-clawhub-checker
-version: 0.0.7
+version: 0.0.8
 description: ClawHub reputation checker for clawsec-suite. Adds a standalone reputation gate before guarded skill installation.
 homepage: https://clawsec.prompt.security
 clawdis:

--- a/skills/clawsec-clawhub-checker/SKILL.md
+++ b/skills/clawsec-clawhub-checker/SKILL.md
@@ -61,7 +61,7 @@ For standalone installs, verify the signed release manifest before trusting `SKI
 set -euo pipefail
 
 SKILL_NAME="clawsec-clawhub-checker"
-VERSION="0.0.4"
+VERSION="0.0.8"
 REPO="prompt-security/clawsec"
 TAG="${SKILL_NAME}-v${VERSION}"
 BASE="https://github.com/${REPO}/releases/download/${TAG}"

--- a/skills/clawsec-clawhub-checker/skill.json
+++ b/skills/clawsec-clawhub-checker/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawsec-clawhub-checker",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "ClawHub reputation checker for clawsec-suite. Adds a standalone reputation gate before guarded skill installation.",
   "author": "abutbul",
   "license": "AGPL-3.0-or-later",

--- a/skills/clawsec-feed/CHANGELOG.md
+++ b/skills/clawsec-feed/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.11] - 2026-06-23
+
+### Changed
+
+- Re-released skill metadata to run through the corrected normal tag publish pipeline without runtime changes.
+
 ## [0.0.10] - 2026-06-22
 
 ### Changed

--- a/skills/clawsec-feed/SKILL.md
+++ b/skills/clawsec-feed/SKILL.md
@@ -96,7 +96,7 @@ For standalone installs, verify the signed release manifest before trusting `SKI
 set -euo pipefail
 
 SKILL_NAME="clawsec-feed"
-VERSION="0.0.9"
+VERSION="0.0.11"
 REPO="prompt-security/clawsec"
 TAG="${SKILL_NAME}-v${VERSION}"
 BASE="https://github.com/${REPO}/releases/download/${TAG}"

--- a/skills/clawsec-feed/SKILL.md
+++ b/skills/clawsec-feed/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawsec-feed
-version: 0.0.10
+version: 0.0.11
 description: Security advisory feed package for OpenClaw-related threats and vulnerabilities. The upstream feed is updated daily; local automation is handled by clawsec-suite or the operator.
 homepage: https://clawsec.prompt.security
 metadata: {"openclaw":{"emoji":"📡","category":"security"}}

--- a/skills/clawsec-feed/skill.json
+++ b/skills/clawsec-feed/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawsec-feed",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Security advisory feed monitoring for AI agents. Subscribe to community-driven threat intelligence.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/clawsec-nanoclaw/CHANGELOG.md
+++ b/skills/clawsec-nanoclaw/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.10] - 2026-06-23
+
+### Changed
+
+- Re-released skill metadata to run through the corrected normal tag publish pipeline without runtime changes.
+
 ## [0.0.9] - 2026-06-22
 
 ### Changed

--- a/skills/clawsec-nanoclaw/SKILL.md
+++ b/skills/clawsec-nanoclaw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawsec-nanoclaw
-version: 0.0.9
+version: 0.0.10
 description: Use when checking for security vulnerabilities in NanoClaw skills, before installing new skills, or when asked about security advisories affecting the bot
 ---
 

--- a/skills/clawsec-nanoclaw/SKILL.md
+++ b/skills/clawsec-nanoclaw/SKILL.md
@@ -217,7 +217,7 @@ For standalone installs, verify the signed release manifest before trusting `SKI
 set -euo pipefail
 
 SKILL_NAME="clawsec-nanoclaw"
-VERSION="0.0.6"
+VERSION="0.0.10"
 REPO="prompt-security/clawsec"
 TAG="${SKILL_NAME}-v${VERSION}"
 BASE="https://github.com/${REPO}/releases/download/${TAG}"

--- a/skills/clawsec-nanoclaw/skill.json
+++ b/skills/clawsec-nanoclaw/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawsec-nanoclaw",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "ClawSec security suite for NanoClaw - Advisory feed monitoring, MCP tools for vulnerability checking, and Ed25519 signature verification for containerized WhatsApp bot agents",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/clawsec-scanner/CHANGELOG.md
+++ b/skills/clawsec-scanner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.7] - 2026-06-23
+
+### Changed
+
+- Re-released skill metadata to run through the corrected normal tag publish pipeline without runtime changes.
+
 ## [0.0.6] - 2026-06-22
 
 ### Changed

--- a/skills/clawsec-scanner/SKILL.md
+++ b/skills/clawsec-scanner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawsec-scanner
-version: 0.0.6
+version: 0.0.7
 description: Automated vulnerability scanner for agent platforms. Performs dependency scanning (npm audit, pip-audit), multi-database CVE lookup (OSV, NVD, GitHub Advisory), SAST analysis (Semgrep, Bandit), and agent-specific static hook inspection for OpenClaw hooks.
 homepage: https://clawsec.prompt.security
 clawdis:

--- a/skills/clawsec-scanner/skill.json
+++ b/skills/clawsec-scanner/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawsec-scanner",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Automated vulnerability scanner for agent platforms. Performs dependency scanning (npm audit, pip-audit), multi-database CVE lookup (OSV, NVD, GitHub Advisory), SAST analysis (Semgrep, Bandit), and agent-specific static hook inspection for OpenClaw hooks.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/clawsec-suite/CHANGELOG.md
+++ b/skills/clawsec-suite/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.12] - 2026-06-23
+
+### Changed
+
+- Re-released skill metadata to run through the corrected normal tag publish pipeline without runtime changes.
+
 ## [0.1.11] - 2026-06-22
 
 ### Changed

--- a/skills/clawsec-suite/SKILL.md
+++ b/skills/clawsec-suite/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawsec-suite
-version: 0.1.11
+version: 0.1.12
 description: ClawSec suite manager with embedded advisory-feed monitoring, cryptographic signature verification, approval-gated malicious-skill response, and guided setup for additional security skills.
 homepage: https://clawsec.prompt.security
 clawdis:

--- a/skills/clawsec-suite/skill.json
+++ b/skills/clawsec-suite/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawsec-suite",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "ClawSec suite manager with embedded advisory-feed monitoring, cryptographic signature verification, approval-gated malicious-skill response, and guided setup for additional security skills.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/clawtributor/CHANGELOG.md
+++ b/skills/clawtributor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.9] - 2026-06-23
+
+### Changed
+
+- Re-released skill metadata to run through the corrected normal tag publish pipeline without runtime changes.
+
 ## [0.0.8] - 2026-06-22
 
 ### Changed

--- a/skills/clawtributor/SKILL.md
+++ b/skills/clawtributor/SKILL.md
@@ -79,7 +79,7 @@ For standalone installs, verify the signed release manifest before trusting `SKI
 set -euo pipefail
 
 SKILL_NAME="clawtributor"
-VERSION="0.0.7"
+VERSION="0.0.9"
 REPO="prompt-security/clawsec"
 TAG="${SKILL_NAME}-v${VERSION}"
 BASE="https://github.com/${REPO}/releases/download/${TAG}"

--- a/skills/clawtributor/SKILL.md
+++ b/skills/clawtributor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawtributor
-version: 0.0.8
+version: 0.0.9
 description: Harness-neutral community incident reporting for AI agents. Contribute to collective security by reporting threats.
 homepage: https://clawsec.prompt.security
 platforms:

--- a/skills/clawtributor/skill.json
+++ b/skills/clawtributor/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawtributor",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Harness-neutral community incident reporting for AI agents. Contribute to collective security by reporting threats.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/hermes-attestation-guardian/CHANGELOG.md
+++ b/skills/hermes-attestation-guardian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.6] - 2026-06-23
+
+### Changed
+
+- Re-released skill metadata to run through the corrected normal tag publish pipeline without runtime changes.
+
 ## [0.1.5] - 2026-06-22
 
 ### Changed

--- a/skills/hermes-attestation-guardian/SKILL.md
+++ b/skills/hermes-attestation-guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hermes-attestation-guardian
-version: 0.1.5
+version: 0.1.6
 description: Hermes-only runtime security attestation and drift detection skill for operator-managed Hermes infrastructure.
 homepage: https://clawsec.prompt.security
 hermes:

--- a/skills/hermes-attestation-guardian/SKILL.md
+++ b/skills/hermes-attestation-guardian/SKILL.md
@@ -31,7 +31,7 @@ For standalone installs, verify the signed release manifest before trusting `SKI
 set -euo pipefail
 
 SKILL_NAME="hermes-attestation-guardian"
-VERSION="0.1.5"
+VERSION="0.1.6"
 REPO="prompt-security/clawsec"
 TAG="${SKILL_NAME}-v${VERSION}"
 BASE="https://github.com/${REPO}/releases/download/${TAG}"

--- a/skills/hermes-attestation-guardian/skill.json
+++ b/skills/hermes-attestation-guardian/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-attestation-guardian",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Hermes-only runtime security attestation and drift detection skill. Generates deterministic posture artifacts, verifies integrity fail-closed, and classifies baseline drift severity.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/hermes-traffic-guardian/CHANGELOG.md
+++ b/skills/hermes-traffic-guardian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.1-beta5] - 2026-06-23
+
+### Changed
+
+- Re-released skill metadata to run through the corrected normal tag publish pipeline without runtime changes.
+
 ## [0.0.1-beta4] - 2026-06-22
 
 ### Changed

--- a/skills/hermes-traffic-guardian/SKILL.md
+++ b/skills/hermes-traffic-guardian/SKILL.md
@@ -31,7 +31,7 @@ For standalone installs, verify the signed release manifest before trusting `SKI
 set -euo pipefail
 
 SKILL_NAME="hermes-traffic-guardian"
-VERSION="0.0.1-beta3"
+VERSION="0.0.1-beta5"
 REPO="prompt-security/clawsec"
 TAG="${SKILL_NAME}-v${VERSION}"
 BASE="https://github.com/${REPO}/releases/download/${TAG}"

--- a/skills/hermes-traffic-guardian/SKILL.md
+++ b/skills/hermes-traffic-guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hermes-traffic-guardian
-version: 0.0.1-beta4
+version: 0.0.1-beta5
 description: Hermes runtime traffic monitoring baseline for opt-in proxy inspection, egress detection, and attestation-aware traffic posture.
 homepage: https://clawsec.prompt.security
 author: prompt-security

--- a/skills/hermes-traffic-guardian/skill.json
+++ b/skills/hermes-traffic-guardian/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-traffic-guardian",
-  "version": "0.0.1-beta4",
+  "version": "0.0.1-beta5",
   "description": "Hermes runtime traffic monitoring baseline for opt-in proxy inspection, egress detection, and attestation-aware traffic posture.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/nanoclaw-traffic-guardian/CHANGELOG.md
+++ b/skills/nanoclaw-traffic-guardian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.1-beta5] - 2026-06-23
+
+### Changed
+
+- Re-released skill metadata to run through the corrected normal tag publish pipeline without runtime changes.
+
 ## [0.0.1-beta4] - 2026-06-22
 
 ### Changed

--- a/skills/nanoclaw-traffic-guardian/SKILL.md
+++ b/skills/nanoclaw-traffic-guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nanoclaw-traffic-guardian
-version: 0.0.1-beta4
+version: 0.0.1-beta5
 description: NanoClaw runtime traffic monitoring baseline for host-side proxy inspection with container-safe MCP and IPC status surfaces.
 homepage: https://clawsec.prompt.security
 author: prompt-security

--- a/skills/nanoclaw-traffic-guardian/SKILL.md
+++ b/skills/nanoclaw-traffic-guardian/SKILL.md
@@ -30,7 +30,7 @@ For standalone installs, verify the signed release manifest before trusting `SKI
 set -euo pipefail
 
 SKILL_NAME="nanoclaw-traffic-guardian"
-VERSION="0.0.1-beta3"
+VERSION="0.0.1-beta5"
 REPO="prompt-security/clawsec"
 TAG="${SKILL_NAME}-v${VERSION}"
 BASE="https://github.com/${REPO}/releases/download/${TAG}"

--- a/skills/nanoclaw-traffic-guardian/skill.json
+++ b/skills/nanoclaw-traffic-guardian/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoclaw-traffic-guardian",
-  "version": "0.0.1-beta4",
+  "version": "0.0.1-beta5",
   "description": "NanoClaw runtime traffic monitoring baseline for host-side proxy inspection with container-safe MCP and IPC status surfaces.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/openclaw-audit-watchdog/CHANGELOG.md
+++ b/skills/openclaw-audit-watchdog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.9] - 2026-06-23
+
+### Changed
+
+- Re-released skill metadata to run through the corrected normal tag publish pipeline without runtime changes.
+
 ## [0.1.8] - 2026-06-22
 
 ### Changed

--- a/skills/openclaw-audit-watchdog/SKILL.md
+++ b/skills/openclaw-audit-watchdog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openclaw-audit-watchdog
-version: 0.1.8
+version: 0.1.9
 description: Automated daily security audits for OpenClaw agents with DM delivery and optional email reporting. Runs deep audits, creates or updates a recurring cron job, and sends formatted reports to configured recipients.
 homepage: https://clawsec.prompt.security
 metadata:

--- a/skills/openclaw-audit-watchdog/SKILL.md
+++ b/skills/openclaw-audit-watchdog/SKILL.md
@@ -81,7 +81,7 @@ For standalone installs, verify the signed release manifest before trusting `SKI
 set -euo pipefail
 
 SKILL_NAME="openclaw-audit-watchdog"
-VERSION="0.1.7"
+VERSION="0.1.9"
 REPO="prompt-security/clawsec"
 TAG="${SKILL_NAME}-v${VERSION}"
 BASE="https://github.com/${REPO}/releases/download/${TAG}"

--- a/skills/openclaw-audit-watchdog/skill.json
+++ b/skills/openclaw-audit-watchdog/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-audit-watchdog",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Automated daily security audits for OpenClaw agents with DM delivery and optional email reporting. Creates or updates an unattended cron job and sends formatted reports to configured recipients.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/openclaw-traffic-guardian/CHANGELOG.md
+++ b/skills/openclaw-traffic-guardian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.1-beta5] - 2026-06-23
+
+### Changed
+
+- Re-released skill metadata to run through the corrected normal tag publish pipeline without runtime changes.
+
 ## [0.0.1-beta4] - 2026-06-22
 
 ### Changed

--- a/skills/openclaw-traffic-guardian/SKILL.md
+++ b/skills/openclaw-traffic-guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openclaw-traffic-guardian
-version: 0.0.1-beta4
+version: 0.0.1-beta5
 description: OpenClaw runtime traffic monitoring baseline for opt-in HTTP/HTTPS proxy inspection, egress detection, inbound injection detection, and social-account policy review.
 homepage: https://clawsec.prompt.security
 author: prompt-security

--- a/skills/openclaw-traffic-guardian/SKILL.md
+++ b/skills/openclaw-traffic-guardian/SKILL.md
@@ -31,7 +31,7 @@ For standalone installs, verify the signed release manifest before trusting `SKI
 set -euo pipefail
 
 SKILL_NAME="openclaw-traffic-guardian"
-VERSION="0.0.1-beta3"
+VERSION="0.0.1-beta5"
 REPO="prompt-security/clawsec"
 TAG="${SKILL_NAME}-v${VERSION}"
 BASE="https://github.com/${REPO}/releases/download/${TAG}"

--- a/skills/openclaw-traffic-guardian/skill.json
+++ b/skills/openclaw-traffic-guardian/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-traffic-guardian",
-  "version": "0.0.1-beta4",
+  "version": "0.0.1-beta5",
   "description": "OpenClaw runtime traffic monitoring baseline for opt-in HTTP/HTTPS proxy inspection, egress detection, inbound injection detection, and social-account policy review.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/picoclaw-security-guardian/CHANGELOG.md
+++ b/skills/picoclaw-security-guardian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.6] - 2026-06-23
+
+### Changed
+
+- Re-released skill metadata to run through the corrected normal tag publish pipeline without runtime changes.
+
 ## [0.0.5] - 2026-06-22
 
 ### Changed

--- a/skills/picoclaw-security-guardian/SKILL.md
+++ b/skills/picoclaw-security-guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: picoclaw-security-guardian
-version: 0.0.5
+version: 0.0.6
 description: Picoclaw security posture skill with advisory awareness, configuration drift detection, and supply-chain verification guidance.
 homepage: https://clawsec.prompt.security
 author: prompt-security

--- a/skills/picoclaw-security-guardian/SKILL.md
+++ b/skills/picoclaw-security-guardian/SKILL.md
@@ -34,7 +34,7 @@ For standalone installs, verify the signed release manifest before trusting `SKI
 set -euo pipefail
 
 SKILL_NAME="picoclaw-security-guardian"
-VERSION="0.0.4"
+VERSION="0.0.6"
 REPO="prompt-security/clawsec"
 TAG="${SKILL_NAME}-v${VERSION}"
 BASE="https://github.com/${REPO}/releases/download/${TAG}"

--- a/skills/picoclaw-security-guardian/skill.json
+++ b/skills/picoclaw-security-guardian/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "picoclaw-security-guardian",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Picoclaw security posture skill with advisory awareness, configuration drift detection, and supply-chain verification guidance.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/picoclaw-self-pen-testing/CHANGELOG.md
+++ b/skills/picoclaw-self-pen-testing/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.5] - 2026-06-23
+
+### Changed
+
+- Re-released skill metadata to run through the corrected normal tag publish pipeline without runtime changes.
+
 ## [0.0.4] - 2026-06-22
 
 ### Changed

--- a/skills/picoclaw-self-pen-testing/SKILL.md
+++ b/skills/picoclaw-self-pen-testing/SKILL.md
@@ -34,7 +34,7 @@ For standalone installs, verify the signed release manifest before trusting `SKI
 set -euo pipefail
 
 SKILL_NAME="picoclaw-self-pen-testing"
-VERSION="0.0.3"
+VERSION="0.0.5"
 REPO="prompt-security/clawsec"
 TAG="${SKILL_NAME}-v${VERSION}"
 BASE="https://github.com/${REPO}/releases/download/${TAG}"

--- a/skills/picoclaw-self-pen-testing/SKILL.md
+++ b/skills/picoclaw-self-pen-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: picoclaw-self-pen-testing
-version: 0.0.4
+version: 0.0.5
 description: Picoclaw-only local posture-review skill focused on read-only findings and safe operator remediation guidance.
 homepage: https://clawsec.prompt.security
 author: prompt-security

--- a/skills/picoclaw-self-pen-testing/skill.json
+++ b/skills/picoclaw-self-pen-testing/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "picoclaw-self-pen-testing",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Picoclaw-only local posture-review skill focused on read-only findings and safe operator remediation guidance.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/picoclaw-traffic-guardian/CHANGELOG.md
+++ b/skills/picoclaw-traffic-guardian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.1-beta5] - 2026-06-23
+
+### Changed
+
+- Re-released skill metadata to run through the corrected normal tag publish pipeline without runtime changes.
+
 ## [0.0.1-beta4] - 2026-06-22
 
 ### Changed

--- a/skills/picoclaw-traffic-guardian/SKILL.md
+++ b/skills/picoclaw-traffic-guardian/SKILL.md
@@ -31,7 +31,7 @@ For standalone installs, verify the signed release manifest before trusting `SKI
 set -euo pipefail
 
 SKILL_NAME="picoclaw-traffic-guardian"
-VERSION="0.0.1-beta3"
+VERSION="0.0.1-beta5"
 REPO="prompt-security/clawsec"
 TAG="${SKILL_NAME}-v${VERSION}"
 BASE="https://github.com/${REPO}/releases/download/${TAG}"

--- a/skills/picoclaw-traffic-guardian/SKILL.md
+++ b/skills/picoclaw-traffic-guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: picoclaw-traffic-guardian
-version: 0.0.1-beta4
+version: 0.0.1-beta5
 description: Picoclaw runtime traffic monitoring baseline for lightweight AI gateway proxy inspection, egress detection, and posture integration.
 homepage: https://clawsec.prompt.security
 author: prompt-security

--- a/skills/picoclaw-traffic-guardian/skill.json
+++ b/skills/picoclaw-traffic-guardian/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "picoclaw-traffic-guardian",
-  "version": "0.0.1-beta4",
+  "version": "0.0.1-beta5",
   "description": "Picoclaw runtime traffic monitoring baseline for lightweight AI gateway proxy inspection, egress detection, and posture integration.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",

--- a/skills/soul-guardian/CHANGELOG.md
+++ b/skills/soul-guardian/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.9] - 2026-06-23
+
+### Changed
+
+- Re-released skill metadata to run through the corrected normal tag publish pipeline without runtime changes.
+
 ## [0.0.8] - 2026-06-22
 
 ### Changed

--- a/skills/soul-guardian/SKILL.md
+++ b/skills/soul-guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: soul-guardian
-version: 0.0.8
+version: 0.0.9
 description: Drift detection + baseline integrity guard for agent workspace files with automatic alerting support
 homepage: https://clawsec.prompt.security
 metadata: {"openclaw":{"emoji":"👻","category":"security"}}

--- a/skills/soul-guardian/SKILL.md
+++ b/skills/soul-guardian/SKILL.md
@@ -38,7 +38,7 @@ For standalone installs, verify the signed release manifest before trusting `SKI
 set -euo pipefail
 
 SKILL_NAME="soul-guardian"
-VERSION="0.0.7"
+VERSION="0.0.9"
 REPO="prompt-security/clawsec"
 TAG="${SKILL_NAME}-v${VERSION}"
 BASE="https://github.com/${REPO}/releases/download/${TAG}"

--- a/skills/soul-guardian/skill.json
+++ b/skills/soul-guardian/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-guardian",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Drift detection and baseline integrity guard for agent workspace prompt files. Auto-restore critical files with tamper-evident audit logging.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
# User description
## Summary
- Bumps all 15 public skills touched by #278 again so their next release tags are cut from the corrected normal publish pipeline.
- Keeps the internal claw-release skill untouched.
- Updates release simulation/trust-packet fixture expectations for the new source versions.

## Version Pattern
- Stable skills: patch +1.
- Beta skills: beta number +1.

## Why
The earlier #278 metadata bump created versions whose tags would not all pass through the now-corrected ClawHub publish path. This PR creates fresh next versions so we can tag and push each skill through the updated pipeline one by one.

## Testing
- python3 utils/validate_skill.py for every public skill
- for test_file in scripts/test-skill-*.mjs; do node ""; done
- npx eslint scripts/test-skill-tag-release-simulation.mjs scripts/test-skill-trust-packet.mjs --max-warnings 0
- git diff --check

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the release pipeline, helper scripts, and validation suites to checksum every downloadable artifact (standalone docs, skill metadata, rollout zips, SkillSpector reports) so dry-run and tag-release assets remain covered by <code>checksums.json</code> while respecting the tightened SkillSpector comment permissions and release-version handling. Bump each affected public skill’s metadata (changelog entries, <code>skill.json</code>, and <code>SKILL.md</code> version constants) so their next patch or beta tags can be cut through the corrected publish pipeline without touching the internal claw-release skill.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/283?tool=ast&topic=Skill+metadata>Skill metadata</a>
        </td><td>Re-release every public skill touched by this PR by incrementing the versions in their changelog, <code>skill.json</code>, and <code>SKILL.md</code> (including embedded release constants) so each patch or beta package can be tagged and pushed through the corrected normal publish path without modifying the internal claw-release skill.<details><summary>Modified files (45)</summary><ul><li>skills/clawsec-clawhub-checker/CHANGELOG.md</li>
<li>skills/clawsec-clawhub-checker/SKILL.md</li>
<li>skills/clawsec-clawhub-checker/skill.json</li>
<li>skills/clawsec-feed/CHANGELOG.md</li>
<li>skills/clawsec-feed/SKILL.md</li>
<li>skills/clawsec-feed/skill.json</li>
<li>skills/clawsec-nanoclaw/CHANGELOG.md</li>
<li>skills/clawsec-nanoclaw/SKILL.md</li>
<li>skills/clawsec-nanoclaw/skill.json</li>
<li>skills/clawsec-scanner/CHANGELOG.md</li>
<li>skills/clawsec-scanner/SKILL.md</li>
<li>skills/clawsec-scanner/skill.json</li>
<li>skills/clawsec-suite/CHANGELOG.md</li>
<li>skills/clawsec-suite/SKILL.md</li>
<li>skills/clawsec-suite/skill.json</li>
<li>skills/clawtributor/CHANGELOG.md</li>
<li>skills/clawtributor/SKILL.md</li>
<li>skills/clawtributor/skill.json</li>
<li>skills/hermes-attestation-guardian/CHANGELOG.md</li>
<li>skills/hermes-attestation-guardian/SKILL.md</li>
<li>skills/hermes-attestation-guardian/skill.json</li>
<li>skills/hermes-traffic-guardian/CHANGELOG.md</li>
<li>skills/hermes-traffic-guardian/SKILL.md</li>
<li>skills/hermes-traffic-guardian/skill.json</li>
<li>skills/nanoclaw-traffic-guardian/CHANGELOG.md</li>
<li>skills/nanoclaw-traffic-guardian/SKILL.md</li>
<li>skills/nanoclaw-traffic-guardian/skill.json</li>
<li>skills/openclaw-audit-watchdog/CHANGELOG.md</li>
<li>skills/openclaw-audit-watchdog/SKILL.md</li>
<li>skills/openclaw-audit-watchdog/skill.json</li>
<li>skills/openclaw-traffic-guardian/CHANGELOG.md</li>
<li>skills/openclaw-traffic-guardian/SKILL.md</li>
<li>skills/openclaw-traffic-guardian/skill.json</li>
<li>skills/picoclaw-security-guardian/CHANGELOG.md</li>
<li>skills/picoclaw-security-guardian/SKILL.md</li>
<li>skills/picoclaw-security-guardian/skill.json</li>
<li>skills/picoclaw-self-pen-testing/CHANGELOG.md</li>
<li>skills/picoclaw-self-pen-testing/SKILL.md</li>
<li>skills/picoclaw-self-pen-testing/skill.json</li>
<li>skills/picoclaw-traffic-guardian/CHANGELOG.md</li>
<li>skills/picoclaw-traffic-guardian/SKILL.md</li>
<li>skills/picoclaw-traffic-guardian/skill.json</li>
<li>skills/soul-guardian/CHANGELOG.md</li>
<li>skills/soul-guardian/SKILL.md</li>
<li>skills/soul-guardian/skill.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(release): align sk...</td><td>June 23, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>chore(release): bump s...</td><td>June 23, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/283?tool=ast&topic=Release+validation>Release validation</a>
        </td><td>Harden the release workflow and verification tooling so every asset that ships from dry-run/tag-release—including the release zip, standalone docs, SkillSpector reports, and release metadata—gets checksummed, release-version constants get refreshed, and the SkillSpector comment job requests only the necessary issue-write permission while failing loudly when reports/artifacts are missing.<details><summary>Modified files (6)</summary><ul><li>.github/workflows/skill-release.yml</li>
<li>scripts/ci/simulate_skill_tag_release.mjs</li>
<li>scripts/release-skill.sh</li>
<li>scripts/test-skill-release-workflow.mjs</li>
<li>scripts/test-skill-tag-release-simulation.mjs</li>
<li>scripts/test-skill-trust-packet.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(release): narrow s...</td><td>June 23, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(release): preserve...</td><td>June 23, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/283?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>