### PR TITLE
ci(wiki): flatten GitHub Wiki export during sync

### DIFF
--- a/.github/workflows/wiki-export-verify.yml
+++ b/.github/workflows/wiki-export-verify.yml
@@ -43,8 +43,9 @@ jobs:
           node scripts/build-github-wiki-export.mjs --source wiki --output "$EXPORT_DIR"
 
           test -f "${EXPORT_DIR}/Home.md"
-          if find "$EXPORT_DIR" -mindepth 2 -type f -name '*.md' | grep -q .; then
-            echo "::error::Flattened GitHub Wiki export contains nested markdown files"
-            find "$EXPORT_DIR" -mindepth 2 -type f -name '*.md'
-            exit 1
-          fi
+          while IFS= read -r nested_file; do
+            if ! grep -q '<!-- LEGACY-WIKI-ALIAS -->' "$nested_file"; then
+              echo "::error::Nested markdown file is not a generated legacy alias: ${nested_file}"
+              exit 1
+            fi
+          done < <(find "$EXPORT_DIR" -mindepth 2 -type f -name '*.md')

--- a/.github/workflows/wiki-export-verify.yml
+++ b/.github/workflows/wiki-export-verify.yml
@@ -1,0 +1,50 @@
+name: Wiki Export Verify
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'wiki/**'
+      - 'pages/WikiBrowser.tsx'
+      - 'scripts/build-github-wiki-export.mjs'
+      - 'scripts/test-wiki-sync-export.mjs'
+      - 'utils/wikiPathHelpers.mjs'
+      - '.github/workflows/wiki-export-verify.yml'
+      - '.github/workflows/wiki-sync.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wiki-export-verify-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-wiki-export:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+
+      - name: Test wiki export transform
+        run: node scripts/test-wiki-sync-export.mjs
+
+      - name: Build flattened GitHub Wiki export
+        run: |
+          set -euo pipefail
+
+          EXPORT_DIR="${RUNNER_TEMP}/github-wiki-export"
+          node scripts/build-github-wiki-export.mjs --source wiki --output "$EXPORT_DIR"
+
+          test -f "${EXPORT_DIR}/Home.md"
+          if find "$EXPORT_DIR" -mindepth 2 -type f -name '*.md' | grep -q .; then
+            echo "::error::Flattened GitHub Wiki export contains nested markdown files"
+            find "$EXPORT_DIR" -mindepth 2 -type f -name '*.md'
+            exit 1
+          fi

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -5,21 +5,67 @@ on:
     branches: [main]
     paths:
       - 'wiki/**'
+      - 'scripts/build-github-wiki-export.mjs'
+      - '.github/workflows/wiki-sync.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'wiki/**'
+      - 'scripts/build-github-wiki-export.mjs'
+      - 'scripts/test-wiki-sync-export.mjs'
+      - '.github/workflows/wiki-sync.yml'
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: wiki-sync
   cancel-in-progress: false
 
 jobs:
-  sync-wiki:
+  verify-wiki-export:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+
+      - name: Test wiki export transform
+        run: node scripts/test-wiki-sync-export.mjs
+
+      - name: Build flattened GitHub Wiki export
+        run: |
+          set -euo pipefail
+
+          EXPORT_DIR="${RUNNER_TEMP}/github-wiki-export"
+          node scripts/build-github-wiki-export.mjs --source wiki --output "$EXPORT_DIR"
+
+          test -f "${EXPORT_DIR}/Home.md"
+          if find "$EXPORT_DIR" -mindepth 2 -type f -name '*.md' | grep -q .; then
+            echo "::error::Flattened GitHub Wiki export contains nested markdown files"
+            find "$EXPORT_DIR" -mindepth 2 -type f -name '*.md'
+            exit 1
+          fi
+
+  sync-wiki:
+    needs: verify-wiki-export
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
 
       - name: Sync wiki folder to repository wiki
         env:
@@ -32,13 +78,10 @@ jobs:
             exit 1
           fi
 
-          # GitHub Wiki root (/wiki) renders Home.md, not INDEX.md.
-          # INDEX.md is the canonical source; generate Home.md from it.
           if [ ! -f wiki/INDEX.md ]; then
-            echo "::error::wiki/INDEX.md not found. It is required to generate wiki/Home.md."
+            echo "::error::wiki/INDEX.md not found. It is required to generate GitHub Wiki Home.md."
             exit 1
           fi
-          cp wiki/INDEX.md wiki/Home.md
 
           WIKI_REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.wiki.git"
           if ! git ls-remote "$WIKI_REMOTE" >/dev/null 2>&1; then
@@ -47,10 +90,13 @@ jobs:
           fi
 
           WIKI_TMP="$(mktemp -d)"
-          trap 'rm -rf "$WIKI_TMP"' EXIT
+          WIKI_EXPORT="$(mktemp -d)"
+          trap 'rm -rf "$WIKI_TMP" "$WIKI_EXPORT"' EXIT
+
+          node scripts/build-github-wiki-export.mjs --source wiki --output "$WIKI_EXPORT"
 
           git clone --depth 1 "$WIKI_REMOTE" "$WIKI_TMP"
-          rsync -a --delete --exclude '.git/' wiki/ "$WIKI_TMP/"
+          rsync -a --delete --exclude '.git/' "$WIKI_EXPORT/" "$WIKI_TMP/"
 
           cd "$WIKI_TMP"
           if [ -z "$(git status --porcelain)" ]; then

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -6,25 +6,21 @@ on:
     paths:
       - 'wiki/**'
       - 'scripts/build-github-wiki-export.mjs'
-      - '.github/workflows/wiki-sync.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'wiki/**'
-      - 'scripts/build-github-wiki-export.mjs'
       - 'scripts/test-wiki-sync-export.mjs'
+      - 'utils/wikiPathHelpers.mjs'
+      - '.github/workflows/wiki-export-verify.yml'
       - '.github/workflows/wiki-sync.yml'
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: wiki-sync
   cancel-in-progress: false
 
 jobs:
-  verify-wiki-export:
+  sync-wiki:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,35 +33,6 @@ jobs:
 
       - name: Test wiki export transform
         run: node scripts/test-wiki-sync-export.mjs
-
-      - name: Build flattened GitHub Wiki export
-        run: |
-          set -euo pipefail
-
-          EXPORT_DIR="${RUNNER_TEMP}/github-wiki-export"
-          node scripts/build-github-wiki-export.mjs --source wiki --output "$EXPORT_DIR"
-
-          test -f "${EXPORT_DIR}/Home.md"
-          if find "$EXPORT_DIR" -mindepth 2 -type f -name '*.md' | grep -q .; then
-            echo "::error::Flattened GitHub Wiki export contains nested markdown files"
-            find "$EXPORT_DIR" -mindepth 2 -type f -name '*.md'
-            exit 1
-          fi
-
-  sync-wiki:
-    needs: verify-wiki-export
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '20'
 
       - name: Sync wiki folder to repository wiki
         env:

--- a/pages/WikiBrowser.tsx
+++ b/pages/WikiBrowser.tsx
@@ -14,8 +14,7 @@ import {
 import {
   isExternalHref,
   isWikiIndexSlug,
-  resolveWikiPathFromFile,
-  splitWikiHash,
+  resolveWikiLinkTarget,
   toWikiLlmsPath,
   toWikiRoute,
 } from '../utils/wikiPathHelpers.mjs';
@@ -230,24 +229,21 @@ export const WikiBrowser: React.FC = () => {
   });
 
   const resolveWikiRouteFromHref = (href: string): string | null => {
-    if (!href || isExternalHref(href) || href.startsWith('mailto:') || href.startsWith('tel:')) {
-      return null;
-    }
-    const { path, hash } = splitWikiHash(href);
+    const target = resolveWikiLinkTarget(selectedDoc.filePath, href);
+    if (!target) return null;
+
+    const { path, hash } = target;
     if (!path || !path.toLowerCase().endsWith('.md')) return null;
 
-    const resolvedFilePath = resolveWikiPathFromFile(selectedDoc.filePath, path).toLowerCase();
-    const targetDoc = wikiDocByFilePath.get(resolvedFilePath);
+    const targetDoc = wikiDocByFilePath.get(path.toLowerCase());
     if (!targetDoc) return null;
     return `${toWikiRoute(targetDoc.slug)}${hash}`;
   };
 
   const resolveAssetUrl = (srcOrHref: string): string | null => {
-    if (!srcOrHref || isExternalHref(srcOrHref) || srcOrHref.startsWith('/')) return null;
-    const { path } = splitWikiHash(srcOrHref);
-    if (!path) return null;
-    const resolvedAssetPath = resolveWikiPathFromFile(selectedDoc.filePath, path).toLowerCase();
-    return wikiAssetByPath.get(resolvedAssetPath) ?? null;
+    const target = resolveWikiLinkTarget(selectedDoc.filePath, srcOrHref);
+    if (!target) return null;
+    return wikiAssetByPath.get(target.path.toLowerCase()) ?? null;
   };
 
   const wikiMarkdownComponents: Components = {

--- a/pages/WikiBrowser.tsx
+++ b/pages/WikiBrowser.tsx
@@ -12,7 +12,10 @@ import {
   stripFrontmatter,
 } from '../utils/markdownHelpers.mjs';
 import {
+  isExternalHref,
   isWikiIndexSlug,
+  resolveWikiPathFromFile,
+  splitWikiHash,
   toWikiLlmsPath,
   toWikiRoute,
 } from '../utils/wikiPathHelpers.mjs';
@@ -24,44 +27,8 @@ interface WikiDoc {
   content: string;
 }
 
-const normalizePath = (path: string): string => {
-  const clean = path.replace(/\\/g, '/');
-  const parts: string[] = [];
-  for (const part of clean.split('/')) {
-    if (!part || part === '.') continue;
-    if (part === '..') {
-      if (parts.length > 0) parts.pop();
-      continue;
-    }
-    parts.push(part);
-  }
-  return parts.join('/');
-};
-
-const dirname = (path: string): string => {
-  const idx = path.lastIndexOf('/');
-  return idx === -1 ? '' : path.slice(0, idx);
-};
-
-const resolveFromFile = (currentFilePath: string, targetPath: string): string => {
-  if (!targetPath) return currentFilePath;
-  if (targetPath.startsWith('/')) return normalizePath(targetPath.slice(1));
-  const baseDir = dirname(currentFilePath);
-  const joined = baseDir ? `${baseDir}/${targetPath}` : targetPath;
-  return normalizePath(joined);
-};
-
-const splitHash = (href: string): { path: string; hash: string } => {
-  const idx = href.indexOf('#');
-  if (idx === -1) return { path: href, hash: '' };
-  return { path: href.slice(0, idx), hash: href.slice(idx) };
-};
-
 const toWikiRelativePath = (globPath: string): string =>
   globPath.replace(/^\.\.\/wiki\//, '').replace(/\\/g, '/');
-
-const isExternalHref = (href: string): boolean =>
-  /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href) || href.startsWith('//');
 
 const ALLOWED_LINK_SCHEMES = new Set(['http:', 'https:', 'mailto:', 'tel:']);
 const ALLOWED_IMAGE_SCHEMES = new Set(['http:', 'https:']);
@@ -266,10 +233,10 @@ export const WikiBrowser: React.FC = () => {
     if (!href || isExternalHref(href) || href.startsWith('mailto:') || href.startsWith('tel:')) {
       return null;
     }
-    const { path, hash } = splitHash(href);
+    const { path, hash } = splitWikiHash(href);
     if (!path || !path.toLowerCase().endsWith('.md')) return null;
 
-    const resolvedFilePath = resolveFromFile(selectedDoc.filePath, path).toLowerCase();
+    const resolvedFilePath = resolveWikiPathFromFile(selectedDoc.filePath, path).toLowerCase();
     const targetDoc = wikiDocByFilePath.get(resolvedFilePath);
     if (!targetDoc) return null;
     return `${toWikiRoute(targetDoc.slug)}${hash}`;
@@ -277,9 +244,9 @@ export const WikiBrowser: React.FC = () => {
 
   const resolveAssetUrl = (srcOrHref: string): string | null => {
     if (!srcOrHref || isExternalHref(srcOrHref) || srcOrHref.startsWith('/')) return null;
-    const { path } = splitHash(srcOrHref);
+    const { path } = splitWikiHash(srcOrHref);
     if (!path) return null;
-    const resolvedAssetPath = resolveFromFile(selectedDoc.filePath, path).toLowerCase();
+    const resolvedAssetPath = resolveWikiPathFromFile(selectedDoc.filePath, path).toLowerCase();
     return wikiAssetByPath.get(resolvedAssetPath) ?? null;
   };
 

--- a/scripts/build-github-wiki-export.mjs
+++ b/scripts/build-github-wiki-export.mjs
@@ -2,14 +2,12 @@ import { copyFile, mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promi
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
-  isExternalHref,
   normalizeWikiPath,
-  resolveWikiPathFromFile,
-  splitWikiHash,
+  resolveWikiLinkTarget,
 } from '../utils/wikiPathHelpers.mjs';
 
 const MARKDOWN_EXTENSION = /\.md$/i;
-const MARKDOWN_LINK_PATTERN = /(\]\()([^)\s]+\.md(?:#[^)]+)?)(\))/g;
+const MARKDOWN_LINK_PATTERN = /(\]\()([^)\s]+)(\))/g;
 
 const listFiles = async (rootDir) => {
   const files = [];
@@ -72,26 +70,16 @@ const buildMarkdownPathMap = (markdownFiles) => {
   return sourceToOutput;
 };
 
-const resolveMarkdownTarget = (sourcePath, href) => {
-  if (!href || isExternalHref(href) || href.startsWith('#') || href.startsWith('/')) {
-    return null;
-  }
-
-  const { path: targetPath, hash } = splitWikiHash(href);
-  if (!MARKDOWN_EXTENSION.test(targetPath)) return null;
-
-  return {
-    sourcePath: resolveWikiPathFromFile(sourcePath, targetPath),
-    hash,
-  };
-};
-
-const rewriteMarkdownLinks = ({ content, sourcePath, sourceToOutput }) =>
+const rewriteMarkdownLinks = ({ content, sourcePath, sourceToOutput, assetPaths }) =>
   content.replace(MARKDOWN_LINK_PATTERN, (match, prefix, href, suffix) => {
-    const target = resolveMarkdownTarget(sourcePath, href);
+    const target = resolveWikiLinkTarget(sourcePath, href);
     if (!target) return match;
 
-    const outputPath = sourceToOutput.get(target.sourcePath.toLowerCase());
+    const targetKey = target.path.toLowerCase();
+    const outputPath = MARKDOWN_EXTENSION.test(target.path)
+      ? sourceToOutput.get(targetKey)
+      : assetPaths.has(targetKey) ? target.path : null;
+
     if (!outputPath) return match;
 
     return `${prefix}${outputPath}${target.hash}${suffix}`;
@@ -112,6 +100,7 @@ export const buildGithubWikiExport = async ({ sourceDir, outputDir }) => {
   const markdownFiles = files.filter((file) => MARKDOWN_EXTENSION.test(file));
   const assetFiles = files.filter((file) => !MARKDOWN_EXTENSION.test(file));
   const sourceToOutput = buildMarkdownPathMap(markdownFiles);
+  const assetPaths = new Set(assetFiles.map((file) => file.toLowerCase()));
 
   await rm(outputDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
@@ -126,7 +115,7 @@ export const buildGithubWikiExport = async ({ sourceDir, outputDir }) => {
     await mkdir(path.dirname(outputFullPath), { recursive: true });
     await writeFile(
       outputFullPath,
-      rewriteMarkdownLinks({ content, sourcePath, sourceToOutput }),
+      rewriteMarkdownLinks({ content, sourcePath, sourceToOutput, assetPaths }),
       'utf8',
     );
     exportedFiles.push({ sourcePath, outputPath });

--- a/scripts/build-github-wiki-export.mjs
+++ b/scripts/build-github-wiki-export.mjs
@@ -1,23 +1,15 @@
 import { copyFile, mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  isExternalHref,
+  normalizeWikiPath,
+  resolveWikiPathFromFile,
+  splitWikiHash,
+} from '../utils/wikiPathHelpers.mjs';
 
 const MARKDOWN_EXTENSION = /\.md$/i;
 const MARKDOWN_LINK_PATTERN = /(\]\()([^)\s]+\.md(?:#[^)]+)?)(\))/g;
-const EXTERNAL_HREF_PATTERN = /^[a-zA-Z][a-zA-Z0-9+.-]*:|^\/\//;
-
-const toPosixPath = (value) => String(value ?? '').replace(/\\/g, '/');
-
-const normalizeRelativePath = (value) => path.posix.normalize(toPosixPath(value)).replace(/^\.\//, '');
-
-const splitHash = (value) => {
-  const hashIndex = value.indexOf('#');
-  if (hashIndex === -1) return { pathname: value, hash: '' };
-  return {
-    pathname: value.slice(0, hashIndex),
-    hash: value.slice(hashIndex),
-  };
-};
 
 const listFiles = async (rootDir) => {
   const files = [];
@@ -27,7 +19,7 @@ const listFiles = async (rootDir) => {
     const entries = await readdir(absoluteDir, { withFileTypes: true });
     for (const entry of entries) {
       const relativePath = relativeDir
-        ? path.posix.join(toPosixPath(relativeDir), entry.name)
+        ? normalizeWikiPath(`${relativeDir}/${entry.name}`)
         : entry.name;
 
       if (entry.isDirectory()) {
@@ -81,20 +73,15 @@ const buildMarkdownPathMap = (markdownFiles) => {
 };
 
 const resolveMarkdownTarget = (sourcePath, href) => {
-  if (!href || EXTERNAL_HREF_PATTERN.test(href) || href.startsWith('#') || href.startsWith('/')) {
+  if (!href || isExternalHref(href) || href.startsWith('#') || href.startsWith('/')) {
     return null;
   }
 
-  const { pathname, hash } = splitHash(href);
-  if (!MARKDOWN_EXTENSION.test(pathname)) return null;
-
-  const sourceDir = path.posix.dirname(sourcePath);
-  const resolvedPath = normalizeRelativePath(
-    sourceDir === '.' ? pathname : path.posix.join(sourceDir, pathname),
-  );
+  const { path: targetPath, hash } = splitWikiHash(href);
+  if (!MARKDOWN_EXTENSION.test(targetPath)) return null;
 
   return {
-    sourcePath: resolvedPath,
+    sourcePath: resolveWikiPathFromFile(sourcePath, targetPath),
     hash,
   };
 };

--- a/scripts/build-github-wiki-export.mjs
+++ b/scripts/build-github-wiki-export.mjs
@@ -8,6 +8,7 @@ import {
 
 const MARKDOWN_EXTENSION = /\.md$/i;
 const MARKDOWN_LINK_PATTERN = /(\]\()([^)\s]+)(\))/g;
+const LEGACY_ALIAS_MARKER = '<!-- LEGACY-WIKI-ALIAS -->';
 
 const listFiles = async (rootDir) => {
   const files = [];
@@ -70,27 +71,57 @@ const buildMarkdownPathMap = (markdownFiles) => {
   return sourceToOutput;
 };
 
+const toGithubWikiPageHref = (outputPath) =>
+  outputPath.replace(MARKDOWN_EXTENSION, '');
+
+const toRelativeWikiHref = (fromPath, outputPath) => {
+  const fromDir = path.posix.dirname(normalizeWikiPath(fromPath));
+  const target = toGithubWikiPageHref(outputPath);
+  const relative = fromDir === '.'
+    ? target
+    : path.posix.relative(fromDir, target);
+  return relative || toGithubWikiPageHref('Home.md');
+};
+
 const rewriteMarkdownLinks = ({ content, sourcePath, sourceToOutput, assetPaths }) =>
   content.replace(MARKDOWN_LINK_PATTERN, (match, prefix, href, suffix) => {
     const target = resolveWikiLinkTarget(sourcePath, href);
     if (!target) return match;
 
     const targetKey = target.path.toLowerCase();
-    const outputPath = MARKDOWN_EXTENSION.test(target.path)
-      ? sourceToOutput.get(targetKey)
-      : assetPaths.has(targetKey) ? target.path : null;
+    if (MARKDOWN_EXTENSION.test(target.path)) {
+      const outputPath = sourceToOutput.get(targetKey);
+      return outputPath
+        ? `${prefix}${toGithubWikiPageHref(outputPath)}${target.hash}${suffix}`
+        : match;
+    }
 
+    const outputPath = assetPaths.has(targetKey) ? target.path : null;
     if (!outputPath) return match;
 
     return `${prefix}${outputPath}${target.hash}${suffix}`;
   });
+
+const buildLegacyAliasContent = ({ sourcePath, outputPath }) => {
+  const targetHref = toRelativeWikiHref(sourcePath, outputPath);
+  const targetLabel = toGithubWikiPageHref(outputPath);
+
+  return [
+    LEGACY_ALIAS_MARKER,
+    '',
+    '# Page moved',
+    '',
+    `This GitHub Wiki page moved to [${targetLabel}](${targetHref}).`,
+    '',
+  ].join('\n');
+};
 
 /**
  * Build the flattened markdown tree that GitHub Wiki can display without
  * duplicate basename entries.
  *
  * @param {{ sourceDir: string, outputDir: string }} options
- * @returns {Promise<{ files: Array<{ sourcePath: string, outputPath: string }>, assets: string[] }>}
+ * @returns {Promise<{ files: Array<{ sourcePath: string, outputPath: string }>, aliases: Array<{ sourcePath: string, outputPath: string }>, assets: string[] }>}
  */
 export const buildGithubWikiExport = async ({ sourceDir, outputDir }) => {
   if (!sourceDir) throw new Error('sourceDir is required');
@@ -106,6 +137,7 @@ export const buildGithubWikiExport = async ({ sourceDir, outputDir }) => {
   await mkdir(outputDir, { recursive: true });
 
   const exportedFiles = [];
+  const exportedAliases = [];
   for (const sourcePath of markdownFiles) {
     const outputPath = sourceToOutput.get(sourcePath.toLowerCase());
     const sourceFullPath = path.join(sourceDir, sourcePath);
@@ -119,6 +151,17 @@ export const buildGithubWikiExport = async ({ sourceDir, outputDir }) => {
       'utf8',
     );
     exportedFiles.push({ sourcePath, outputPath });
+
+    if (sourcePath.includes('/')) {
+      const aliasFullPath = path.join(outputDir, sourcePath);
+      await mkdir(path.dirname(aliasFullPath), { recursive: true });
+      await writeFile(
+        aliasFullPath,
+        buildLegacyAliasContent({ sourcePath, outputPath }),
+        'utf8',
+      );
+      exportedAliases.push({ sourcePath, outputPath: sourcePath });
+    }
   }
 
   for (const sourcePath of assetFiles) {
@@ -130,6 +173,7 @@ export const buildGithubWikiExport = async ({ sourceDir, outputDir }) => {
 
   return {
     files: exportedFiles,
+    aliases: exportedAliases,
     assets: assetFiles,
   };
 };
@@ -169,5 +213,7 @@ const isDirectRun = () => {
 
 if (isDirectRun()) {
   const result = await buildGithubWikiExport(parseArgs(process.argv.slice(2)));
-  console.log(`Exported ${result.files.length} wiki pages and ${result.assets.length} assets.`);
+  console.log(
+    `Exported ${result.files.length} wiki pages, ${result.aliases.length} legacy aliases, and ${result.assets.length} assets.`,
+  );
 }

--- a/scripts/build-github-wiki-export.mjs
+++ b/scripts/build-github-wiki-export.mjs
@@ -1,0 +1,197 @@
+import { copyFile, mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MARKDOWN_EXTENSION = /\.md$/i;
+const MARKDOWN_LINK_PATTERN = /(\]\()([^)\s]+\.md(?:#[^)]+)?)(\))/g;
+const EXTERNAL_HREF_PATTERN = /^[a-zA-Z][a-zA-Z0-9+.-]*:|^\/\//;
+
+const toPosixPath = (value) => String(value ?? '').replace(/\\/g, '/');
+
+const normalizeRelativePath = (value) => path.posix.normalize(toPosixPath(value)).replace(/^\.\//, '');
+
+const splitHash = (value) => {
+  const hashIndex = value.indexOf('#');
+  if (hashIndex === -1) return { pathname: value, hash: '' };
+  return {
+    pathname: value.slice(0, hashIndex),
+    hash: value.slice(hashIndex),
+  };
+};
+
+const listFiles = async (rootDir) => {
+  const files = [];
+
+  const walk = async (relativeDir = '') => {
+    const absoluteDir = path.join(rootDir, relativeDir);
+    const entries = await readdir(absoluteDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const relativePath = relativeDir
+        ? path.posix.join(toPosixPath(relativeDir), entry.name)
+        : entry.name;
+
+      if (entry.isDirectory()) {
+        await walk(relativePath);
+      } else if (entry.isFile()) {
+        files.push(relativePath);
+      }
+    }
+  };
+
+  await walk();
+  return files.sort();
+};
+
+const toFlattenedMarkdownPath = (sourcePath) => {
+  const withoutExtension = sourcePath.replace(MARKDOWN_EXTENSION, '');
+  const parts = withoutExtension.split('/').filter(Boolean);
+  const lastPart = parts.at(-1) ?? '';
+
+  if (parts.length === 1 && lastPart.toLowerCase() === 'index') {
+    return 'Home.md';
+  }
+
+  if (lastPart.toLowerCase() === 'index') {
+    return `${[...parts.slice(0, -1), 'Home'].join('-')}.md`;
+  }
+
+  return `${parts.join('-')}.md`;
+};
+
+const buildMarkdownPathMap = (markdownFiles) => {
+  const sourceToOutput = new Map();
+  const outputToSource = new Map();
+
+  for (const sourcePath of markdownFiles) {
+    const outputPath = toFlattenedMarkdownPath(sourcePath);
+    const outputKey = outputPath.toLowerCase();
+    const existingSource = outputToSource.get(outputKey);
+
+    if (existingSource) {
+      throw new Error(
+        `Flattened wiki export collision: ${existingSource} and ${sourcePath} both map to ${outputPath}`,
+      );
+    }
+
+    sourceToOutput.set(sourcePath.toLowerCase(), outputPath);
+    outputToSource.set(outputKey, sourcePath);
+  }
+
+  return sourceToOutput;
+};
+
+const resolveMarkdownTarget = (sourcePath, href) => {
+  if (!href || EXTERNAL_HREF_PATTERN.test(href) || href.startsWith('#') || href.startsWith('/')) {
+    return null;
+  }
+
+  const { pathname, hash } = splitHash(href);
+  if (!MARKDOWN_EXTENSION.test(pathname)) return null;
+
+  const sourceDir = path.posix.dirname(sourcePath);
+  const resolvedPath = normalizeRelativePath(
+    sourceDir === '.' ? pathname : path.posix.join(sourceDir, pathname),
+  );
+
+  return {
+    sourcePath: resolvedPath,
+    hash,
+  };
+};
+
+const rewriteMarkdownLinks = ({ content, sourcePath, sourceToOutput }) =>
+  content.replace(MARKDOWN_LINK_PATTERN, (match, prefix, href, suffix) => {
+    const target = resolveMarkdownTarget(sourcePath, href);
+    if (!target) return match;
+
+    const outputPath = sourceToOutput.get(target.sourcePath.toLowerCase());
+    if (!outputPath) return match;
+
+    return `${prefix}${outputPath}${target.hash}${suffix}`;
+  });
+
+/**
+ * Build the flattened markdown tree that GitHub Wiki can display without
+ * duplicate basename entries.
+ *
+ * @param {{ sourceDir: string, outputDir: string }} options
+ * @returns {Promise<{ files: Array<{ sourcePath: string, outputPath: string }>, assets: string[] }>}
+ */
+export const buildGithubWikiExport = async ({ sourceDir, outputDir }) => {
+  if (!sourceDir) throw new Error('sourceDir is required');
+  if (!outputDir) throw new Error('outputDir is required');
+
+  const files = await listFiles(sourceDir);
+  const markdownFiles = files.filter((file) => MARKDOWN_EXTENSION.test(file));
+  const assetFiles = files.filter((file) => !MARKDOWN_EXTENSION.test(file));
+  const sourceToOutput = buildMarkdownPathMap(markdownFiles);
+
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  const exportedFiles = [];
+  for (const sourcePath of markdownFiles) {
+    const outputPath = sourceToOutput.get(sourcePath.toLowerCase());
+    const sourceFullPath = path.join(sourceDir, sourcePath);
+    const outputFullPath = path.join(outputDir, outputPath);
+    const content = await readFile(sourceFullPath, 'utf8');
+
+    await mkdir(path.dirname(outputFullPath), { recursive: true });
+    await writeFile(
+      outputFullPath,
+      rewriteMarkdownLinks({ content, sourcePath, sourceToOutput }),
+      'utf8',
+    );
+    exportedFiles.push({ sourcePath, outputPath });
+  }
+
+  for (const sourcePath of assetFiles) {
+    const sourceFullPath = path.join(sourceDir, sourcePath);
+    const outputFullPath = path.join(outputDir, sourcePath);
+    await mkdir(path.dirname(outputFullPath), { recursive: true });
+    await copyFile(sourceFullPath, outputFullPath);
+  }
+
+  return {
+    files: exportedFiles,
+    assets: assetFiles,
+  };
+};
+
+const parseArgs = (argv) => {
+  const options = {
+    sourceDir: 'wiki',
+    outputDir: '',
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+
+    if (arg === '--source') {
+      options.sourceDir = next;
+      i += 1;
+    } else if (arg === '--output') {
+      options.outputDir = next;
+      i += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.outputDir) {
+    throw new Error('Usage: node scripts/build-github-wiki-export.mjs [--source wiki] --output <dir>');
+  }
+
+  return options;
+};
+
+const isDirectRun = () => {
+  if (!process.argv[1]) return false;
+  return fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+};
+
+if (isDirectRun()) {
+  const result = await buildGithubWikiExport(parseArgs(process.argv.slice(2)));
+  console.log(`Exported ${result.files.length} wiki pages and ${result.assets.length} assets.`);
+}

--- a/scripts/test-wiki-sync-export.mjs
+++ b/scripts/test-wiki-sync-export.mjs
@@ -48,13 +48,23 @@ test('buildGithubWikiExport flattens nested wiki pages and rewrites markdown lin
     '',
   ].join('\n'));
   await writeFixture(sourceDir, 'es/overview.md', '# Resumen\n');
+  await writeFixture(sourceDir, 'es/media.md', [
+    '# Media',
+    '',
+    '![Logo](../assets/logo.png)',
+    '[Logo download](../assets/logo.png)',
+    '',
+  ].join('\n'));
   await writeFixture(sourceDir, 'modules/automation-release.md', '# Automation\n');
+  await writeFixture(sourceDir, 'assets/logo.png', 'fake-png');
 
   const result = await buildGithubWikiExport({ sourceDir, outputDir });
 
   assert.deepEqual(await listFiles(outputDir), [
     'Home.md',
+    'assets/logo.png',
     'es-Home.md',
+    'es-media.md',
     'es-overview.md',
     'modules-automation-release.md',
     'overview.md',
@@ -64,6 +74,7 @@ test('buildGithubWikiExport flattens nested wiki pages and rewrites markdown lin
     [
       ['INDEX.md', 'Home.md'],
       ['es/INDEX.md', 'es-Home.md'],
+      ['es/media.md', 'es-media.md'],
       ['es/overview.md', 'es-overview.md'],
       ['modules/automation-release.md', 'modules-automation-release.md'],
       ['overview.md', 'overview.md'],
@@ -79,6 +90,11 @@ test('buildGithubWikiExport flattens nested wiki pages and rewrites markdown lin
   const spanishHome = await readFile(path.join(outputDir, 'es-Home.md'), 'utf8');
   assert.match(spanishHome, /\[Resumen\]\(es-overview\.md\)/);
   assert.match(spanishHome, /\[English overview\]\(overview\.md\)/);
+
+  const media = await readFile(path.join(outputDir, 'es-media.md'), 'utf8');
+  assert.match(media, /!\[Logo\]\(assets\/logo\.png\)/);
+  assert.match(media, /\[Logo download\]\(assets\/logo\.png\)/);
+  assert.doesNotMatch(media, /\.\.\/assets\/logo\.png/);
 });
 
 test('buildGithubWikiExport rejects flattened filename collisions', async () => {

--- a/scripts/test-wiki-sync-export.mjs
+++ b/scripts/test-wiki-sync-export.mjs
@@ -66,7 +66,11 @@ test('buildGithubWikiExport flattens nested wiki pages and rewrites markdown lin
     'es-Home.md',
     'es-media.md',
     'es-overview.md',
+    'es/INDEX.md',
+    'es/media.md',
+    'es/overview.md',
     'modules-automation-release.md',
+    'modules/automation-release.md',
     'overview.md',
   ]);
   assert.deepEqual(
@@ -80,21 +84,34 @@ test('buildGithubWikiExport flattens nested wiki pages and rewrites markdown lin
       ['overview.md', 'overview.md'],
     ],
   );
+  assert.deepEqual(
+    result.aliases.map((file) => [file.sourcePath, file.outputPath]),
+    [
+      ['es/INDEX.md', 'es/INDEX.md'],
+      ['es/media.md', 'es/media.md'],
+      ['es/overview.md', 'es/overview.md'],
+      ['modules/automation-release.md', 'modules/automation-release.md'],
+    ],
+  );
 
   const home = await readFile(path.join(outputDir, 'Home.md'), 'utf8');
-  assert.match(home, /\[Overview\]\(overview\.md\)/);
-  assert.match(home, /\[Spanish\]\(es-Home\.md\)/);
-  assert.match(home, /\[Automation\]\(modules-automation-release\.md#dry-run\)/);
+  assert.match(home, /\[Overview\]\(overview\)/);
+  assert.match(home, /\[Spanish\]\(es-Home\)/);
+  assert.match(home, /\[Automation\]\(modules-automation-release#dry-run\)/);
   assert.doesNotMatch(home, /es\/INDEX\.md|modules\/automation-release\.md/);
 
   const spanishHome = await readFile(path.join(outputDir, 'es-Home.md'), 'utf8');
-  assert.match(spanishHome, /\[Resumen\]\(es-overview\.md\)/);
-  assert.match(spanishHome, /\[English overview\]\(overview\.md\)/);
+  assert.match(spanishHome, /\[Resumen\]\(es-overview\)/);
+  assert.match(spanishHome, /\[English overview\]\(overview\)/);
 
   const media = await readFile(path.join(outputDir, 'es-media.md'), 'utf8');
   assert.match(media, /!\[Logo\]\(assets\/logo\.png\)/);
   assert.match(media, /\[Logo download\]\(assets\/logo\.png\)/);
   assert.doesNotMatch(media, /\.\.\/assets\/logo\.png/);
+
+  const moduleAlias = await readFile(path.join(outputDir, 'modules/automation-release.md'), 'utf8');
+  assert.match(moduleAlias, /LEGACY-WIKI-ALIAS/);
+  assert.match(moduleAlias, /\[modules-automation-release\]\(\.\.\/modules-automation-release\)/);
 });
 
 test('buildGithubWikiExport rejects flattened filename collisions', async () => {
@@ -145,6 +162,11 @@ test('wiki workflows verify pull requests without publishing and publish flatten
     syncWorkflow,
     /node scripts\/build-github-wiki-export\.mjs --source wiki --output "\$WIKI_EXPORT"/,
     'wiki sync workflow must publish the flattened export directory',
+  );
+  assert.match(
+    verifyWorkflow,
+    /LEGACY-WIKI-ALIAS/,
+    'wiki export verification must allow only generated legacy alias markdown below nested paths',
   );
   assert.doesNotMatch(
     syncWorkflow,

--- a/scripts/test-wiki-sync-export.mjs
+++ b/scripts/test-wiki-sync-export.mjs
@@ -95,34 +95,43 @@ test('buildGithubWikiExport rejects flattened filename collisions', async () => 
   );
 });
 
-test('wiki-sync workflow verifies the flattened export in pull requests before syncing', async () => {
-  const workflow = await readFile(
+test('wiki workflows verify pull requests without publishing and publish flattened sync output', async () => {
+  const verifyWorkflow = await readFile(
+    new URL('../.github/workflows/wiki-export-verify.yml', import.meta.url),
+    'utf8',
+  );
+  const syncWorkflow = await readFile(
     new URL('../.github/workflows/wiki-sync.yml', import.meta.url),
     'utf8',
   );
 
   assert.match(
-    workflow,
+    verifyWorkflow,
     /pull_request:[\s\S]*scripts\/test-wiki-sync-export\.mjs/,
-    'wiki sync workflow must run on pull requests that change the export test',
+    'wiki export verification workflow must run on pull requests that change the export test',
   );
   assert.match(
-    workflow,
+    verifyWorkflow,
     /name: Test wiki export transform[\s\S]*node scripts\/test-wiki-sync-export\.mjs/,
-    'wiki sync workflow must run the deterministic export test before merge',
+    'wiki export verification workflow must run the deterministic export test before merge',
+  );
+  assert.doesNotMatch(
+    syncWorkflow,
+    /pull_request:/,
+    'wiki sync workflow must not run on pull_request events',
   );
   assert.match(
-    workflow,
-    /sync-wiki:[\s\S]*if: github\.event_name != 'pull_request'/,
-    'wiki sync workflow must not push to the GitHub Wiki from pull_request events',
+    syncWorkflow,
+    /name: Test wiki export transform[\s\S]*node scripts\/test-wiki-sync-export\.mjs/,
+    'wiki sync workflow must run the deterministic export test before publishing',
   );
   assert.match(
-    workflow,
+    syncWorkflow,
     /node scripts\/build-github-wiki-export\.mjs --source wiki --output "\$WIKI_EXPORT"/,
     'wiki sync workflow must publish the flattened export directory',
   );
   assert.doesNotMatch(
-    workflow,
+    syncWorkflow,
     /rsync -a --delete --exclude '\.git\/' wiki\/ "\$WIKI_TMP\/"/,
     'wiki sync workflow must not rsync the nested source wiki directly',
   );

--- a/scripts/test-wiki-sync-export.mjs
+++ b/scripts/test-wiki-sync-export.mjs
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, readdir, writeFile, mkdir } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { buildGithubWikiExport } from './build-github-wiki-export.mjs';
+
+const writeFixture = async (root, relativePath, content) => {
+  const fullPath = path.join(root, relativePath);
+  await mkdir(path.dirname(fullPath), { recursive: true });
+  await writeFile(fullPath, content, 'utf8');
+};
+
+const listFiles = async (root) => {
+  const entries = await readdir(root, { recursive: true, withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => path.join(entry.parentPath, entry.name))
+    .map((fullPath) => path.relative(root, fullPath).replace(/\\/g, '/'))
+    .sort();
+};
+
+test('buildGithubWikiExport flattens nested wiki pages and rewrites markdown links', async () => {
+  const tmpRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-export-'));
+  const sourceDir = path.join(tmpRoot, 'wiki');
+  const outputDir = path.join(tmpRoot, 'export');
+
+  await writeFixture(sourceDir, 'INDEX.md', [
+    '# Wiki Index',
+    '',
+    '- [Overview](overview.md)',
+    '- [Spanish](es/INDEX.md)',
+    '- [Automation](modules/automation-release.md#dry-run)',
+    '',
+  ].join('\n'));
+  await writeFixture(sourceDir, 'overview.md', [
+    '# Overview',
+    '',
+    'See [Automation](modules/automation-release.md).',
+    '',
+  ].join('\n'));
+  await writeFixture(sourceDir, 'es/INDEX.md', [
+    '# Indice',
+    '',
+    '- [Resumen](overview.md)',
+    '- [English overview](../overview.md)',
+    '',
+  ].join('\n'));
+  await writeFixture(sourceDir, 'es/overview.md', '# Resumen\n');
+  await writeFixture(sourceDir, 'modules/automation-release.md', '# Automation\n');
+
+  const result = await buildGithubWikiExport({ sourceDir, outputDir });
+
+  assert.deepEqual(await listFiles(outputDir), [
+    'Home.md',
+    'es-Home.md',
+    'es-overview.md',
+    'modules-automation-release.md',
+    'overview.md',
+  ]);
+  assert.deepEqual(
+    result.files.map((file) => [file.sourcePath, file.outputPath]),
+    [
+      ['INDEX.md', 'Home.md'],
+      ['es/INDEX.md', 'es-Home.md'],
+      ['es/overview.md', 'es-overview.md'],
+      ['modules/automation-release.md', 'modules-automation-release.md'],
+      ['overview.md', 'overview.md'],
+    ],
+  );
+
+  const home = await readFile(path.join(outputDir, 'Home.md'), 'utf8');
+  assert.match(home, /\[Overview\]\(overview\.md\)/);
+  assert.match(home, /\[Spanish\]\(es-Home\.md\)/);
+  assert.match(home, /\[Automation\]\(modules-automation-release\.md#dry-run\)/);
+  assert.doesNotMatch(home, /es\/INDEX\.md|modules\/automation-release\.md/);
+
+  const spanishHome = await readFile(path.join(outputDir, 'es-Home.md'), 'utf8');
+  assert.match(spanishHome, /\[Resumen\]\(es-overview\.md\)/);
+  assert.match(spanishHome, /\[English overview\]\(overview\.md\)/);
+});
+
+test('buildGithubWikiExport rejects flattened filename collisions', async () => {
+  const tmpRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-export-collision-'));
+  const sourceDir = path.join(tmpRoot, 'wiki');
+  const outputDir = path.join(tmpRoot, 'export');
+
+  await writeFixture(sourceDir, 'foo/bar.md', '# Nested\n');
+  await writeFixture(sourceDir, 'foo-bar.md', '# Flat\n');
+
+  await assert.rejects(
+    buildGithubWikiExport({ sourceDir, outputDir }),
+    /Flattened wiki export collision/,
+  );
+});
+
+test('wiki-sync workflow verifies the flattened export in pull requests before syncing', async () => {
+  const workflow = await readFile(
+    new URL('../.github/workflows/wiki-sync.yml', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(
+    workflow,
+    /pull_request:[\s\S]*scripts\/test-wiki-sync-export\.mjs/,
+    'wiki sync workflow must run on pull requests that change the export test',
+  );
+  assert.match(
+    workflow,
+    /name: Test wiki export transform[\s\S]*node scripts\/test-wiki-sync-export\.mjs/,
+    'wiki sync workflow must run the deterministic export test before merge',
+  );
+  assert.match(
+    workflow,
+    /sync-wiki:[\s\S]*if: github\.event_name != 'pull_request'/,
+    'wiki sync workflow must not push to the GitHub Wiki from pull_request events',
+  );
+  assert.match(
+    workflow,
+    /node scripts\/build-github-wiki-export\.mjs --source wiki --output "\$WIKI_EXPORT"/,
+    'wiki sync workflow must publish the flattened export directory',
+  );
+  assert.doesNotMatch(
+    workflow,
+    /rsync -a --delete --exclude '\.git\/' wiki\/ "\$WIKI_TMP\/"/,
+    'wiki sync workflow must not rsync the nested source wiki directly',
+  );
+});

--- a/utils/wikiPathHelpers.mjs
+++ b/utils/wikiPathHelpers.mjs
@@ -1,12 +1,73 @@
 /**
+ * Normalize a wiki-relative path without allowing it to escape above the wiki root.
+ * @param {string} value
+ * @returns {string}
+ */
+export const normalizeWikiPath = (value) => {
+  const clean = String(value ?? '').replace(/\\/g, '/');
+  const parts = [];
+  for (const part of clean.split('/')) {
+    if (!part || part === '.') continue;
+    if (part === '..') {
+      if (parts.length > 0) parts.pop();
+      continue;
+    }
+    parts.push(part);
+  }
+  return parts.join('/');
+};
+
+/**
+ * Return the directory portion of a wiki-relative path.
+ * @param {string} value
+ * @returns {string}
+ */
+const wikiDirname = (value) => {
+  const normalized = normalizeWikiPath(value);
+  const idx = normalized.lastIndexOf('/');
+  return idx === -1 ? '' : normalized.slice(0, idx);
+};
+
+/**
+ * Resolve a wiki-relative link from the file that contains it.
+ * @param {string} currentFilePath
+ * @param {string} targetPath
+ * @returns {string}
+ */
+export const resolveWikiPathFromFile = (currentFilePath, targetPath) => {
+  if (!targetPath) return normalizeWikiPath(currentFilePath);
+  if (targetPath.startsWith('/')) return normalizeWikiPath(targetPath.slice(1));
+  const baseDir = wikiDirname(currentFilePath);
+  return normalizeWikiPath(baseDir ? `${baseDir}/${targetPath}` : targetPath);
+};
+
+/**
+ * Split a URL/hash fragment from a wiki link target.
+ * @param {string} value
+ * @returns {{ path: string, hash: string }}
+ */
+export const splitWikiHash = (value) => {
+  const text = String(value ?? '');
+  const idx = text.indexOf('#');
+  if (idx === -1) return { path: text, hash: '' };
+  return { path: text.slice(0, idx), hash: text.slice(idx) };
+};
+
+/**
+ * Return whether an href points outside the wiki/link resolver.
+ * @param {string} href
+ * @returns {boolean}
+ */
+export const isExternalHref = (href) =>
+  /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(String(href ?? '')) || String(href ?? '').startsWith('//');
+
+/**
  * Normalize a wiki slug for route/path construction.
  * @param {string} slug
  * @returns {string}
  */
 const normalizeWikiSlug = (slug) =>
-  String(slug ?? '')
-    .replace(/\\/g, '/')
-    .replace(/^\/+|\/+$/g, '');
+  normalizeWikiPath(slug).replace(/^\/+|\/+$/g, '');
 
 /**
  * Return whether a slug represents the wiki index page.

--- a/utils/wikiPathHelpers.mjs
+++ b/utils/wikiPathHelpers.mjs
@@ -62,6 +62,28 @@ export const isExternalHref = (href) =>
   /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(String(href ?? '')) || String(href ?? '').startsWith('//');
 
 /**
+ * Resolve an internal wiki link target from the file that contains it.
+ * External URLs, root-absolute URLs, and same-page hash links return null.
+ * @param {string} currentFilePath
+ * @param {string} href
+ * @returns {{ path: string, hash: string } | null}
+ */
+export const resolveWikiLinkTarget = (currentFilePath, href) => {
+  const text = String(href ?? '');
+  if (!text || isExternalHref(text) || text.startsWith('#') || text.startsWith('/')) {
+    return null;
+  }
+
+  const { path, hash } = splitWikiHash(text);
+  if (!path) return null;
+
+  return {
+    path: resolveWikiPathFromFile(currentFilePath, path),
+    hash,
+  };
+};
+
+/**
  * Normalize a wiki slug for route/path construction.
  * @param {string} slug
  * @returns {string}


### PR DESCRIPTION
# User description
## Summary
- Adds a deterministic GitHub Wiki export script that keeps `wiki/` structured in-repo but publishes a flat wiki tree.
- Maps `INDEX.md` to `Home.md`, localized indexes to names like `es-Home.md`, and nested pages to names like `modules-automation-release.md`.
- Rewrites intra-wiki markdown links to the flattened filenames before sync.
- Adds PR verification to `.github/workflows/wiki-sync.yml` so export tests run before merge, while the actual wiki push is skipped on `pull_request` events.

## Security / operational benefit
- Removes duplicate page basenames from the GitHub Wiki page list without changing the app-rendered wiki routes.
- Keeps the production wiki sync gated by the same export test used in PRs.

## Testing
- `node scripts/test-wiki-sync-export.mjs`
- `node scripts/build-github-wiki-export.mjs --source wiki --output "$EXPORT_DIR"` with checks for `Home.md`, flattened localized/module pages, no nested markdown files, and no duplicate markdown basenames
- `npx eslint scripts/build-github-wiki-export.mjs scripts/test-wiki-sync-export.mjs --max-warnings 0`
- `npx tsc --noEmit`
- `npm run build`

Note: full `npx eslint . --ext .ts,.tsx,.js,.jsx,.mjs --max-warnings 0` is currently blocked locally by generated JS under `.worktrees/pr-255/dist`, unrelated to this change. The changed scripts pass targeted ESLint.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add a deterministic export pipeline backed by <code>build-github-wiki-export.mjs</code> and <code>wikiPathHelpers</code> to flatten wiki markdown, rewrite intra-wiki links, and surface legacy alias placeholders for nested pages before publishing. Update CI to run the export test via <code>test-wiki-sync-export.mjs</code> on pull requests while keeping the sync workflow’s actual push gated to main-only runs.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/285?tool=ast&topic=Flattened+export.>Flattened export.</a>
        </td><td>Flatten wiki export by mapping nested markdown paths to unique <code>Home.md</code>-style filenames, rewriting links via <code>resolveWikiLinkTarget</code>, and emitting legacy alias pages plus supporting <code>WikiBrowser</code> helpers so flattened names still resolve correctly.<details><summary>Modified files (4)</summary><ul><li>pages/WikiBrowser.tsx</li>
<li>scripts/build-github-wiki-export.mjs</li>
<li>scripts/test-wiki-sync-export.mjs</li>
<li>utils/wikiPathHelpers.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(wiki): preserve le...</td><td>June 29, 2026</td></tr>
<tr><td>david@abutbul.com</td><td>feat(i18n): add multil...</td><td>April 29, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/285?tool=ast&topic=Wiki+CI+gating>Wiki CI gating</a>
        </td><td>Enforce wiki export verification in CI by adding a <code>wiki-export-verify</code> workflow that runs the deterministic export test on PRs and updating the sync workflow to run the same test before pushing the flattened export.<details><summary>Modified files (2)</summary><ul><li>.github/workflows/wiki-export-verify.yml</li>
<li>.github/workflows/wiki-sync.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(wiki): preserve le...</td><td>June 29, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>Codex/wiki sync revert...</td><td>February 25, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/285?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>