### PR TITLE
fix(wiki): remove duplicate GitHub Wiki pages

### DIFF
--- a/.github/workflows/wiki-export-verify.yml
+++ b/.github/workflows/wiki-export-verify.yml
@@ -43,9 +43,8 @@ jobs:
           node scripts/build-github-wiki-export.mjs --source wiki --output "$EXPORT_DIR"
 
           test -f "${EXPORT_DIR}/Home.md"
-          while IFS= read -r nested_file; do
-            if ! grep -q '<!-- LEGACY-WIKI-ALIAS -->' "$nested_file"; then
-              echo "::error::Nested markdown file is not a generated legacy alias: ${nested_file}"
-              exit 1
-            fi
-          done < <(find "$EXPORT_DIR" -mindepth 2 -type f -name '*.md')
+          if find "$EXPORT_DIR" -mindepth 2 -type f -name '*.md' | grep -q .; then
+            echo "::error::Flattened GitHub Wiki export contains nested markdown files"
+            find "$EXPORT_DIR" -mindepth 2 -type f -name '*.md'
+            exit 1
+          fi

--- a/scripts/build-github-wiki-export.mjs
+++ b/scripts/build-github-wiki-export.mjs
@@ -8,7 +8,6 @@ import {
 
 const MARKDOWN_EXTENSION = /\.md$/i;
 const MARKDOWN_LINK_PATTERN = /(\]\()([^)\s]+)(\))/g;
-const LEGACY_ALIAS_MARKER = '<!-- LEGACY-WIKI-ALIAS -->';
 
 const listFiles = async (rootDir) => {
   const files = [];
@@ -74,15 +73,6 @@ const buildMarkdownPathMap = (markdownFiles) => {
 const toGithubWikiPageHref = (outputPath) =>
   outputPath.replace(MARKDOWN_EXTENSION, '');
 
-const toRelativeWikiHref = (fromPath, outputPath) => {
-  const fromDir = path.posix.dirname(normalizeWikiPath(fromPath));
-  const target = toGithubWikiPageHref(outputPath);
-  const relative = fromDir === '.'
-    ? target
-    : path.posix.relative(fromDir, target);
-  return relative || toGithubWikiPageHref('Home.md');
-};
-
 const rewriteMarkdownLinks = ({ content, sourcePath, sourceToOutput, assetPaths }) =>
   content.replace(MARKDOWN_LINK_PATTERN, (match, prefix, href, suffix) => {
     const target = resolveWikiLinkTarget(sourcePath, href);
@@ -102,26 +92,12 @@ const rewriteMarkdownLinks = ({ content, sourcePath, sourceToOutput, assetPaths 
     return `${prefix}${outputPath}${target.hash}${suffix}`;
   });
 
-const buildLegacyAliasContent = ({ sourcePath, outputPath }) => {
-  const targetHref = toRelativeWikiHref(sourcePath, outputPath);
-  const targetLabel = toGithubWikiPageHref(outputPath);
-
-  return [
-    LEGACY_ALIAS_MARKER,
-    '',
-    '# Page moved',
-    '',
-    `This GitHub Wiki page moved to [${targetLabel}](${targetHref}).`,
-    '',
-  ].join('\n');
-};
-
 /**
  * Build the flattened markdown tree that GitHub Wiki can display without
  * duplicate basename entries.
  *
  * @param {{ sourceDir: string, outputDir: string }} options
- * @returns {Promise<{ files: Array<{ sourcePath: string, outputPath: string }>, aliases: Array<{ sourcePath: string, outputPath: string }>, assets: string[] }>}
+ * @returns {Promise<{ files: Array<{ sourcePath: string, outputPath: string }>, assets: string[] }>}
  */
 export const buildGithubWikiExport = async ({ sourceDir, outputDir }) => {
   if (!sourceDir) throw new Error('sourceDir is required');
@@ -137,7 +113,6 @@ export const buildGithubWikiExport = async ({ sourceDir, outputDir }) => {
   await mkdir(outputDir, { recursive: true });
 
   const exportedFiles = [];
-  const exportedAliases = [];
   for (const sourcePath of markdownFiles) {
     const outputPath = sourceToOutput.get(sourcePath.toLowerCase());
     const sourceFullPath = path.join(sourceDir, sourcePath);
@@ -151,17 +126,6 @@ export const buildGithubWikiExport = async ({ sourceDir, outputDir }) => {
       'utf8',
     );
     exportedFiles.push({ sourcePath, outputPath });
-
-    if (sourcePath.includes('/')) {
-      const aliasFullPath = path.join(outputDir, sourcePath);
-      await mkdir(path.dirname(aliasFullPath), { recursive: true });
-      await writeFile(
-        aliasFullPath,
-        buildLegacyAliasContent({ sourcePath, outputPath }),
-        'utf8',
-      );
-      exportedAliases.push({ sourcePath, outputPath: sourcePath });
-    }
   }
 
   for (const sourcePath of assetFiles) {
@@ -173,7 +137,6 @@ export const buildGithubWikiExport = async ({ sourceDir, outputDir }) => {
 
   return {
     files: exportedFiles,
-    aliases: exportedAliases,
     assets: assetFiles,
   };
 };
@@ -213,7 +176,5 @@ const isDirectRun = () => {
 
 if (isDirectRun()) {
   const result = await buildGithubWikiExport(parseArgs(process.argv.slice(2)));
-  console.log(
-    `Exported ${result.files.length} wiki pages, ${result.aliases.length} legacy aliases, and ${result.assets.length} assets.`,
-  );
+  console.log(`Exported ${result.files.length} wiki pages and ${result.assets.length} assets.`);
 }

--- a/scripts/test-wiki-sync-export.mjs
+++ b/scripts/test-wiki-sync-export.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { mkdtemp, readFile, readdir, writeFile, mkdir } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -18,6 +19,20 @@ const listFiles = async (root) => {
     .filter((entry) => entry.isFile())
     .map((entry) => path.join(entry.parentPath, entry.name))
     .map((fullPath) => path.relative(root, fullPath).replace(/\\/g, '/'))
+    .sort();
+};
+
+const listDuplicatePageBasenames = (files) => {
+  const counts = new Map();
+  for (const file of files) {
+    if (!file.endsWith('.md')) continue;
+    const basename = path.basename(file, '.md').toLowerCase();
+    counts.set(basename, (counts.get(basename) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([basename, count]) => `${basename}:${count}`)
     .sort();
 };
 
@@ -66,11 +81,7 @@ test('buildGithubWikiExport flattens nested wiki pages and rewrites markdown lin
     'es-Home.md',
     'es-media.md',
     'es-overview.md',
-    'es/INDEX.md',
-    'es/media.md',
-    'es/overview.md',
     'modules-automation-release.md',
-    'modules/automation-release.md',
     'overview.md',
   ]);
   assert.deepEqual(
@@ -82,15 +93,6 @@ test('buildGithubWikiExport flattens nested wiki pages and rewrites markdown lin
       ['es/overview.md', 'es-overview.md'],
       ['modules/automation-release.md', 'modules-automation-release.md'],
       ['overview.md', 'overview.md'],
-    ],
-  );
-  assert.deepEqual(
-    result.aliases.map((file) => [file.sourcePath, file.outputPath]),
-    [
-      ['es/INDEX.md', 'es/INDEX.md'],
-      ['es/media.md', 'es/media.md'],
-      ['es/overview.md', 'es/overview.md'],
-      ['modules/automation-release.md', 'modules/automation-release.md'],
     ],
   );
 
@@ -108,10 +110,6 @@ test('buildGithubWikiExport flattens nested wiki pages and rewrites markdown lin
   assert.match(media, /!\[Logo\]\(assets\/logo\.png\)/);
   assert.match(media, /\[Logo download\]\(assets\/logo\.png\)/);
   assert.doesNotMatch(media, /\.\.\/assets\/logo\.png/);
-
-  const moduleAlias = await readFile(path.join(outputDir, 'modules/automation-release.md'), 'utf8');
-  assert.match(moduleAlias, /LEGACY-WIKI-ALIAS/);
-  assert.match(moduleAlias, /\[modules-automation-release\]\(\.\.\/modules-automation-release\)/);
 });
 
 test('buildGithubWikiExport rejects flattened filename collisions', async () => {
@@ -125,6 +123,27 @@ test('buildGithubWikiExport rejects flattened filename collisions', async () => 
   await assert.rejects(
     buildGithubWikiExport({ sourceDir, outputDir }),
     /Flattened wiki export collision/,
+  );
+});
+
+test('buildGithubWikiExport exports the repository wiki without duplicate GitHub page names', async () => {
+  const tmpRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-export-real-'));
+  const outputDir = path.join(tmpRoot, 'export');
+  const sourceDir = fileURLToPath(new URL('../wiki', import.meta.url));
+
+  await buildGithubWikiExport({ sourceDir, outputDir });
+  const files = await listFiles(outputDir);
+  const nestedMarkdownFiles = files.filter((file) => file.includes('/') && file.endsWith('.md'));
+
+  assert.deepEqual(
+    nestedMarkdownFiles,
+    [],
+    'GitHub Wiki export must not include nested markdown files because they produce duplicate page-list entries',
+  );
+  assert.deepEqual(
+    listDuplicatePageBasenames(files),
+    [],
+    'GitHub Wiki export must not include duplicate markdown basenames',
   );
 });
 
@@ -165,8 +184,8 @@ test('wiki workflows verify pull requests without publishing and publish flatten
   );
   assert.match(
     verifyWorkflow,
-    /LEGACY-WIKI-ALIAS/,
-    'wiki export verification must allow only generated legacy alias markdown below nested paths',
+    /Flattened GitHub Wiki export contains nested markdown files/,
+    'wiki export verification must reject nested markdown files because GitHub lists them as duplicate page names',
   );
   assert.doesNotMatch(
     syncWorkflow,


### PR DESCRIPTION
# User description
## Summary
- removes legacy nested alias markdown from the GitHub Wiki export
- restores the PR workflow guard that rejects nested markdown in the flattened export
- adds a real-repo export regression test that fails on duplicate GitHub Wiki page names

## Root cause
GitHub Wiki lists every `.md` file by basename. The prior compatibility alias layer emitted nested files like `es/architecture.md` and `de/architecture.md` next to flattened files like `es-architecture.md`, so the live Wiki page list still showed repeated `architecture`, `configuration`, and similar entries.

## Verification
- `node scripts/test-wiki-sync-export.mjs`
- real export check: nested markdown count is `0`; duplicate markdown basenames are absent
- `npx eslint scripts/build-github-wiki-export.mjs scripts/test-wiki-sync-export.mjs --max-warnings 0`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

## Post-merge effect
After this lands on `main`, the wiki sync job should rsync the flattened export with `--delete`, removing the nested alias markdown files from `clawsec.wiki.git` and clearing the duplicate page-list entries.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Remove legacy nested alias creation from <code>buildGithubWikiExport</code> so the canonical wiki export stays flattened, and log only the canonical page and asset counts. Re-enable the workflow guard and extend <code>test-wiki-sync-export.mjs</code> regression coverage to reject nested markdown and duplicate basenames before the export sync runs.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/286?tool=ast&topic=Flatten+GitHub+Wiki>Flatten GitHub Wiki</a>
        </td><td>Remove legacy alias creation from <code>buildGithubWikiExport</code>, ensuring the export no longer writes nested markdown files while reporting only canonical wiki pages and assets.<details><summary>Modified files (1)</summary><ul><li>scripts/build-github-wiki-export.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(wiki): remove dupl...</td><td>June 29, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>ci(wiki): flatten GitH...</td><td>June 29, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/286?tool=ast&topic=Wiki+export+tests>Wiki export tests</a>
        </td><td>Rework <code>test-wiki-sync-export.mjs</code> and the verification workflow so they detect and reject nested markdown files and duplicate basenames in the exported wiki.<details><summary>Modified files (2)</summary><ul><li>.github/workflows/wiki-export-verify.yml</li>
<li>scripts/test-wiki-sync-export.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(wiki): remove dupl...</td><td>June 29, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>ci(wiki): flatten GitH...</td><td>June 29, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/286?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>