### PR TITLE
fix(wiki): add hierarchical GitHub Wiki sidebar

### DIFF
--- a/.github/workflows/wiki-export-verify.yml
+++ b/.github/workflows/wiki-export-verify.yml
@@ -43,6 +43,7 @@ jobs:
           node scripts/build-github-wiki-export.mjs --source wiki --output "$EXPORT_DIR"
 
           test -f "${EXPORT_DIR}/Home.md"
+          test -f "${EXPORT_DIR}/_Sidebar.md"
           if find "$EXPORT_DIR" -mindepth 2 -type f -name '*.md' | grep -q .; then
             echo "::error::Flattened GitHub Wiki export contains nested markdown files"
             find "$EXPORT_DIR" -mindepth 2 -type f -name '*.md'

--- a/scripts/build-github-wiki-export.mjs
+++ b/scripts/build-github-wiki-export.mjs
@@ -8,6 +8,34 @@ import {
 
 const MARKDOWN_EXTENSION = /\.md$/i;
 const MARKDOWN_LINK_PATTERN = /(\]\()([^)\s]+)(\))/g;
+const SIDEBAR_OUTPUT_PATH = '_Sidebar.md';
+const ROOT_SIDEBAR_SECTIONS = [
+  'Start Here',
+  'Guides',
+  'Operations',
+  'Modules',
+  'Glossary',
+  'Generation Metadata',
+];
+const LANGUAGE_PAGE_ORDER = [
+  'INDEX.md',
+  'overview.md',
+  'architecture.md',
+  'localization.md',
+  'dependencies.md',
+  'data-flow.md',
+  'configuration.md',
+  'testing.md',
+  'workflow.md',
+  'security.md',
+  'security-signing-runbook.md',
+  'migration-signed-feed.md',
+  'platform-verification.md',
+  'remediation-plan.md',
+  'exploitability-scoring.md',
+  'glossary.md',
+  'GENERATION.md',
+];
 
 const listFiles = async (rootDir) => {
   const files = [];
@@ -73,6 +101,139 @@ const buildMarkdownPathMap = (markdownFiles) => {
 const toGithubWikiPageHref = (outputPath) =>
   outputPath.replace(MARKDOWN_EXTENSION, '');
 
+const formatLanguagePageLabel = (relativePath) => {
+  if (relativePath.toLowerCase() === 'index.md') return 'Home';
+  return relativePath
+    .replace(MARKDOWN_EXTENSION, '')
+    .replace(/\//g, ' / ')
+    .replace(/-/g, ' ');
+};
+
+const compareLanguagePages = (left, right) => {
+  const leftIndex = LANGUAGE_PAGE_ORDER.findIndex(
+    (page) => page.toLowerCase() === left.toLowerCase(),
+  );
+  const rightIndex = LANGUAGE_PAGE_ORDER.findIndex(
+    (page) => page.toLowerCase() === right.toLowerCase(),
+  );
+
+  if (leftIndex !== -1 || rightIndex !== -1) {
+    if (leftIndex === -1) return 1;
+    if (rightIndex === -1) return -1;
+    return leftIndex - rightIndex;
+  }
+
+  return left.localeCompare(right);
+};
+
+const extractLinkedSections = ({ content, currentFilePath, sourceToOutput }) => {
+  const sections = new Map();
+  let currentSection = '';
+
+  for (const line of content.split(/\r?\n/)) {
+    const headingMatch = /^##\s+(.+?)\s*$/.exec(line);
+    if (headingMatch) {
+      currentSection = headingMatch[1];
+      if (!sections.has(currentSection)) sections.set(currentSection, []);
+      continue;
+    }
+
+    const linkMatch = /^\s*-\s+\[([^\]]+)\]\(([^)\s]+)\)/.exec(line);
+    if (!currentSection || !linkMatch) continue;
+
+    const [, label, href] = linkMatch;
+    const target = resolveWikiLinkTarget(currentFilePath, href);
+    if (!target || !MARKDOWN_EXTENSION.test(target.path)) continue;
+
+    const outputPath = sourceToOutput.get(target.path.toLowerCase());
+    if (!outputPath) continue;
+
+    sections.get(currentSection).push({
+      label,
+      sourcePath: target.path,
+      href: toGithubWikiPageHref(outputPath),
+    });
+  }
+
+  return sections;
+};
+
+const buildLanguageGroups = ({ markdownFiles, rootSections, sourceToOutput }) => {
+  const translations = rootSections.get('Translations') ?? [];
+  const orderedLanguageCodes = translations
+    .map(({ sourcePath }) => /^([^/]+)\/INDEX\.md$/i.exec(sourcePath)?.[1])
+    .filter(Boolean);
+  const languageCodes = orderedLanguageCodes.length > 0
+    ? orderedLanguageCodes
+    : markdownFiles
+      .map((sourcePath) => /^([^/]+)\/INDEX\.md$/i.exec(sourcePath)?.[1])
+      .filter(Boolean)
+      .sort();
+
+  return languageCodes.map((languageCode) => {
+    const languagePrefix = `${languageCode}/`;
+    const pages = markdownFiles
+      .filter((sourcePath) => sourcePath.startsWith(languagePrefix))
+      .map((sourcePath) => ({
+        sourcePath,
+        relativePath: sourcePath.slice(languagePrefix.length),
+      }))
+      .sort((left, right) => compareLanguagePages(left.relativePath, right.relativePath))
+      .map(({ sourcePath, relativePath }) => ({
+        label: formatLanguagePageLabel(relativePath),
+        href: toGithubWikiPageHref(sourceToOutput.get(sourcePath.toLowerCase())),
+      }));
+
+    return {
+      code: languageCode,
+      pages,
+    };
+  });
+};
+
+const appendSidebarEntries = (lines, entries) => {
+  for (const entry of entries) {
+    lines.push(`- [${entry.label}](${entry.href})`);
+  }
+};
+
+const buildSidebarContent = ({ rootIndexContent, markdownFiles, sourceToOutput }) => {
+  const rootSections = extractLinkedSections({
+    content: rootIndexContent,
+    currentFilePath: 'INDEX.md',
+    sourceToOutput,
+  });
+  const languageGroups = buildLanguageGroups({ markdownFiles, rootSections, sourceToOutput });
+  const lines = [
+    '# ClawSec Wiki',
+    '',
+    '- [Home](Home)',
+    '',
+  ];
+
+  for (const sectionTitle of ROOT_SIDEBAR_SECTIONS) {
+    const entries = rootSections.get(sectionTitle) ?? [];
+    if (entries.length === 0) continue;
+    lines.push(`## ${sectionTitle}`);
+    appendSidebarEntries(lines, entries);
+    lines.push('');
+  }
+
+  if (languageGroups.length > 0) {
+    lines.push('## Translations');
+    for (const group of languageGroups) {
+      const homeHref = group.pages.find((page) => page.label === 'Home')?.href;
+      lines.push(homeHref ? `- **[${group.code}](${homeHref})**` : `- **${group.code}**`);
+      for (const page of group.pages.filter((entry) => entry.label !== 'Home')) {
+        lines.push(`  - [${page.label}](${page.href})`);
+      }
+    }
+    lines.push('');
+  }
+
+  return `${lines.join('\n').trimEnd()}\n`;
+};
+
 const rewriteMarkdownLinks = ({ content, sourcePath, sourceToOutput, assetPaths }) =>
   content.replace(MARKDOWN_LINK_PATTERN, (match, prefix, href, suffix) => {
     const target = resolveWikiLinkTarget(sourcePath, href);
@@ -97,7 +258,7 @@ const rewriteMarkdownLinks = ({ content, sourcePath, sourceToOutput, assetPaths 
  * duplicate basename entries.
  *
  * @param {{ sourceDir: string, outputDir: string }} options
- * @returns {Promise<{ files: Array<{ sourcePath: string, outputPath: string }>, assets: string[] }>}
+ * @returns {Promise<{ files: Array<{ sourcePath: string, outputPath: string }>, sidebar: string, assets: string[] }>}
  */
 export const buildGithubWikiExport = async ({ sourceDir, outputDir }) => {
   if (!sourceDir) throw new Error('sourceDir is required');
@@ -128,6 +289,14 @@ export const buildGithubWikiExport = async ({ sourceDir, outputDir }) => {
     exportedFiles.push({ sourcePath, outputPath });
   }
 
+  const rootIndexPath = path.join(sourceDir, 'INDEX.md');
+  const rootIndexContent = await readFile(rootIndexPath, 'utf8');
+  await writeFile(
+    path.join(outputDir, SIDEBAR_OUTPUT_PATH),
+    buildSidebarContent({ rootIndexContent, markdownFiles, sourceToOutput }),
+    'utf8',
+  );
+
   for (const sourcePath of assetFiles) {
     const sourceFullPath = path.join(sourceDir, sourcePath);
     const outputFullPath = path.join(outputDir, sourcePath);
@@ -137,6 +306,7 @@ export const buildGithubWikiExport = async ({ sourceDir, outputDir }) => {
 
   return {
     files: exportedFiles,
+    sidebar: SIDEBAR_OUTPUT_PATH,
     assets: assetFiles,
   };
 };
@@ -176,5 +346,7 @@ const isDirectRun = () => {
 
 if (isDirectRun()) {
   const result = await buildGithubWikiExport(parseArgs(process.argv.slice(2)));
-  console.log(`Exported ${result.files.length} wiki pages and ${result.assets.length} assets.`);
+  console.log(
+    `Exported ${result.files.length} wiki pages, ${result.sidebar}, and ${result.assets.length} assets.`,
+  );
 }

--- a/scripts/test-wiki-sync-export.mjs
+++ b/scripts/test-wiki-sync-export.mjs
@@ -44,8 +44,13 @@ test('buildGithubWikiExport flattens nested wiki pages and rewrites markdown lin
   await writeFixture(sourceDir, 'INDEX.md', [
     '# Wiki Index',
     '',
+    '## Start Here',
     '- [Overview](overview.md)',
+    '',
+    '## Translations',
     '- [Spanish](es/INDEX.md)',
+    '',
+    '## Modules',
     '- [Automation](modules/automation-release.md#dry-run)',
     '',
   ].join('\n'));
@@ -77,6 +82,7 @@ test('buildGithubWikiExport flattens nested wiki pages and rewrites markdown lin
 
   assert.deepEqual(await listFiles(outputDir), [
     'Home.md',
+    '_Sidebar.md',
     'assets/logo.png',
     'es-Home.md',
     'es-media.md',
@@ -95,6 +101,7 @@ test('buildGithubWikiExport flattens nested wiki pages and rewrites markdown lin
       ['overview.md', 'overview.md'],
     ],
   );
+  assert.equal(result.sidebar, '_Sidebar.md');
 
   const home = await readFile(path.join(outputDir, 'Home.md'), 'utf8');
   assert.match(home, /\[Overview\]\(overview\)/);
@@ -110,6 +117,17 @@ test('buildGithubWikiExport flattens nested wiki pages and rewrites markdown lin
   assert.match(media, /!\[Logo\]\(assets\/logo\.png\)/);
   assert.match(media, /\[Logo download\]\(assets\/logo\.png\)/);
   assert.doesNotMatch(media, /\.\.\/assets\/logo\.png/);
+
+  const sidebar = await readFile(path.join(outputDir, '_Sidebar.md'), 'utf8');
+  assert.match(sidebar, /^# ClawSec Wiki$/m);
+  assert.match(sidebar, /^- \[Home\]\(Home\)$/m);
+  assert.match(sidebar, /^## Start Here$/m);
+  assert.match(sidebar, /^- \[Overview\]\(overview\)$/m);
+  assert.match(sidebar, /^- \[Automation\]\(modules-automation-release\)$/m);
+  assert.match(sidebar, /^## Translations$/m);
+  assert.match(sidebar, /^- \*\*\[es\]\(es-Home\)\*\*$/m);
+  assert.match(sidebar, /^\s{2}- \[overview\]\(es-overview\)$/m);
+  assert.match(sidebar, /^\s{2}- \[media\]\(es-media\)$/m);
 });
 
 test('buildGithubWikiExport rejects flattened filename collisions', async () => {
@@ -144,6 +162,18 @@ test('buildGithubWikiExport exports the repository wiki without duplicate GitHub
     listDuplicatePageBasenames(files),
     [],
     'GitHub Wiki export must not include duplicate markdown basenames',
+  );
+
+  const sidebar = await readFile(path.join(outputDir, '_Sidebar.md'), 'utf8');
+  assert.match(
+    sidebar,
+    /^- \*\*\[de\]\(de-Home\)\*\*[\s\S]*^\s{2}- \[architecture\]\(de-architecture\)$/m,
+    'GitHub Wiki sidebar must group translated pages below their language code',
+  );
+  assert.match(
+    sidebar,
+    /^- \*\*\[ja\]\(ja-Home\)\*\*[\s\S]*^\s{2}- \[configuration\]\(ja-configuration\)$/m,
+    'GitHub Wiki sidebar must keep every language as a parent section',
   );
 });
 
@@ -186,6 +216,11 @@ test('wiki workflows verify pull requests without publishing and publish flatten
     verifyWorkflow,
     /Flattened GitHub Wiki export contains nested markdown files/,
     'wiki export verification must reject nested markdown files because GitHub lists them as duplicate page names',
+  );
+  assert.match(
+    verifyWorkflow,
+    /test -f "\$\{EXPORT_DIR\}\/_Sidebar\.md"/,
+    'wiki export verification must require the custom GitHub Wiki sidebar',
   );
   assert.doesNotMatch(
     syncWorkflow,


### PR DESCRIPTION
# User description
## Summary
- generates a custom GitHub Wiki `_Sidebar.md` during wiki export
- keeps exported wiki pages flattened to avoid duplicate page names
- groups translated pages under language-code parents such as `de -> architecture` in the sidebar
- requires `_Sidebar.md` in the PR wiki export verification workflow

## Why
GitHub Wiki page files need to remain flattened because nested markdown files produce duplicate page-list entries. GitHub supports custom sidebar files, so this PR uses `_Sidebar.md` to present the hierarchy users expect without reintroducing nested wiki markdown files.

## Verification
- `node scripts/test-wiki-sync-export.mjs`
- real export check: `_Sidebar.md` exists, nested markdown count is `0`, duplicate basenames are absent, and sidebar contains `de -> architecture` plus `ja -> configuration`
- `npx eslint scripts/build-github-wiki-export.mjs scripts/test-wiki-sync-export.mjs --max-warnings 0`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

## Post-merge effect
After merge, the wiki sync job will publish `_Sidebar.md`. GitHub should use that custom sidebar for navigation, so translated pages appear grouped under their language code while the actual page files stay duplicate-free.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Generate custom <code>_Sidebar.md</code> during <code>buildGithubWikiExport</code> so the flattened wiki export includes hierarchical navigation built from index sections and ordered language pages. Ensure <code>test-wiki-sync-export.mjs</code> forces <code>_Sidebar.md</code> checks and the workflow requires that file to pass verification.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/289?tool=ast&topic=Sidebar+Generation>Sidebar Generation</a>
        </td><td>Generate hierarchical <code>_Sidebar.md</code> content via <code>buildGithubWikiExport</code> by extracting index sections, ordering translation pages, and returning the sidebar path for the flattened export so translated pages stay grouped without nested files.<details><summary>Modified files (2)</summary><ul><li>scripts/build-github-wiki-export.mjs</li>
<li>scripts/test-wiki-sync-export.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(wiki): generate hi...</td><td>June 30, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(wiki): remove dupl...</td><td>June 29, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/289?tool=ast&topic=Export+Verification>Export Verification</a>
        </td><td>Enforce flattened export rules and require <code>_Sidebar.md</code> in both the verification workflow and <code>test-wiki-sync-export.mjs</code> so PRs cannot publish without the custom sidebar.<details><summary>Modified files (2)</summary><ul><li>.github/workflows/wiki-export-verify.yml</li>
<li>scripts/test-wiki-sync-export.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(wiki): generate hi...</td><td>June 30, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(wiki): remove dupl...</td><td>June 29, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/289?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>