### PR TITLE
fix(advisories): make polling reporting deterministic

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,7 @@ permissions: read-all
 jobs:
   analyze:
     name: Analyze (CodeQL)
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'automated/nvd-cve-update')
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -266,6 +266,7 @@ jobs:
           FILTERED=$(jq 'length' tmp/filtered_cves.json)
           echo "Filtered CVEs (matching criteria): $FILTERED"
           echo "filtered_count=$FILTERED" >> $GITHUB_OUTPUT
+          echo "nvd_filtered_count=$FILTERED" >> $GITHUB_OUTPUT
 
       - name: Get existing advisories
         id: existing
@@ -291,6 +292,7 @@ jobs:
             echo '[]' > tmp/updated_advisories.json
             echo "Advisories to update: 0"
             echo "update_count=0" >> $GITHUB_OUTPUT
+            echo "nvd_updated_count=0" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -521,6 +523,7 @@ jobs:
           UPDATE_COUNT=$(jq 'length' tmp/updated_advisories.json)
           echo "Advisories to update: $UPDATE_COUNT"
           echo "update_count=$UPDATE_COUNT" >> $GITHUB_OUTPUT
+          echo "nvd_updated_count=$UPDATE_COUNT" >> $GITHUB_OUTPUT
 
           if [ "$UPDATE_COUNT" -gt 0 ]; then
             echo "=== Updated advisories ==="
@@ -530,12 +533,14 @@ jobs:
       - name: Transform CVEs to advisories
         id: transform
         run: |
-          # Read existing IDs into a jq-friendly file for jq (avoids huge CLI args on full scans).
+          # Read existing IDs into jq-friendly files (avoids huge CLI args on full scans).
+          jq -R -s 'split("\n") | map(select(length > 0))' < tmp/existing_ids.txt > tmp/existing_ids_from_feed.json
+
           if [ "${{ inputs.force_full_scan }}" = "true" ]; then
             echo "Full scan mode enabled: rebuilding CVE advisories from scratch."
             echo '[]' > tmp/existing_ids.json
           else
-            jq -R -s 'split("\n") | map(select(length > 0))' < tmp/existing_ids.txt > tmp/existing_ids.json
+            cp tmp/existing_ids_from_feed.json tmp/existing_ids.json
           fi
           
           # Transform NVD CVEs to our advisory format
@@ -715,8 +720,23 @@ jobs:
           ' tmp/filtered_cves.json > tmp/new_advisories.json
           
           NEW_COUNT=$(jq 'length' tmp/new_advisories.json)
-          echo "New advisories to add: $NEW_COUNT"
+          jq --slurpfile existing tmp/existing_ids_from_feed.json '
+            [.[] | select(.id as $id | (($existing[0] // []) | index($id) | not))]
+          ' tmp/new_advisories.json > tmp/net_new_advisories.json
+
+          NET_NEW_COUNT=$(jq 'length' tmp/net_new_advisories.json)
+          if [ "${{ inputs.force_full_scan }}" = "true" ]; then
+            REBUILT_COUNT="$NEW_COUNT"
+          else
+            REBUILT_COUNT=0
+          fi
+
+          echo "Transformed NVD advisories: $NEW_COUNT"
+          echo "NVD advisories rebuilt: $REBUILT_COUNT"
+          echo "Net-new NVD advisories to add: $NET_NEW_COUNT"
           echo "new_count=$NEW_COUNT" >> $GITHUB_OUTPUT
+          echo "nvd_rebuilt_count=$REBUILT_COUNT" >> $GITHUB_OUTPUT
+          echo "nvd_new_to_feed_count=$NET_NEW_COUNT" >> $GITHUB_OUTPUT
 
           if [ "${{ inputs.force_full_scan }}" = "true" ]; then
             FILTERED_COUNT="${{ steps.process.outputs.filtered_count }}"
@@ -726,9 +746,9 @@ jobs:
             fi
           fi
           
-          if [ "$NEW_COUNT" -gt 0 ]; then
-            echo "=== New advisories ==="
-            jq '.[].id' tmp/new_advisories.json
+          if [ "$NET_NEW_COUNT" -gt 0 ]; then
+            echo "=== Net-new NVD advisories ==="
+            jq '.[].id' tmp/net_new_advisories.json
           fi
 
       - name: Set up Python for exploitability analysis
@@ -858,8 +878,20 @@ jobs:
           NVD_CHANGED=false
           GHSA_CHANGED=false
           AGENT_CHANGED=false
+          GHSA_ACTIVE_COUNT="$(
+            jq '[.advisories[]? | select((.id // "") | startswith("GHSA-")) | select(.status == "active")] | length' "$FEED_PATH"
+          )"
+          GHSA_ADDED_COUNT="$(
+            jq --slurpfile existing tmp/existing_ids_from_feed.json '
+              [.advisories[]? |
+                select((.id // "") | startswith("GHSA-")) |
+                select(.status == "active") |
+                select(.id as $id | (($existing[0] // []) | index($id) | not))
+              ] | length
+            ' "$FEED_PATH"
+          )"
 
-          if [ "${{ steps.transform.outputs.new_count }}" != "0" ] || [ "${{ steps.updates.outputs.update_count }}" != "0" ]; then
+          if [ "${{ steps.transform.outputs.nvd_rebuilt_count }}" != "0" ] || [ "${{ steps.transform.outputs.nvd_new_to_feed_count }}" != "0" ] || [ "${{ steps.updates.outputs.nvd_updated_count }}" != "0" ]; then
             NVD_CHANGED=true
           fi
 
@@ -874,6 +906,8 @@ jobs:
           echo "nvd_changed=$NVD_CHANGED" >> "$GITHUB_OUTPUT"
           echo "ghsa_changed=$GHSA_CHANGED" >> "$GITHUB_OUTPUT"
           echo "agent_changed=$AGENT_CHANGED" >> "$GITHUB_OUTPUT"
+          echo "ghsa_active_count=$GHSA_ACTIVE_COUNT" >> "$GITHUB_OUTPUT"
+          echo "ghsa_added_to_consolidated_count=$GHSA_ADDED_COUNT" >> "$GITHUB_OUTPUT"
 
           if [ "$GHSA_CHANGED" = "true" ] || [ "$AGENT_CHANGED" = "true" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -941,7 +975,7 @@ jobs:
 
           BRANCH_PREFIX="automated/nvd-cve-update"
           PR_COMMENT="Superseded by newer automated NVD advisory update."
-          TITLE="chore: update NVD/GHSA advisories - ${{ steps.transform.outputs.new_count }} NVD new, ${{ steps.updates.outputs.update_count }} NVD updated"
+          TITLE="chore: update NVD/GHSA advisories - ${{ steps.transform.outputs.nvd_new_to_feed_count }} NVD new, ${{ steps.updates.outputs.nvd_updated_count }} NVD updated, ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }} GHSA active added"
           COMMIT_SUBJECT="$TITLE"
           COMMIT_BODY=$'Automated update from NVD CVE and GHSA advisory feeds.\nKeywords: ${{ env.KEYWORDS }}\nPoll window: ${{ steps.dates.outputs.start_date }} to ${{ steps.dates.outputs.end_date }}'
 
@@ -962,8 +996,11 @@ jobs:
           Automated update from NVD CVE and GHSA advisory feeds.
 
           - **Mode:** ${MODE}
-          - **New NVD advisories:** ${{ steps.transform.outputs.new_count }}
-          - **Updated NVD advisories:** ${{ steps.updates.outputs.update_count }}
+          - **Filtered NVD CVEs:** ${{ steps.process.outputs.nvd_filtered_count }}
+          - **Rebuilt NVD advisories:** ${{ steps.transform.outputs.nvd_rebuilt_count }}
+          - **Net-new NVD advisories:** ${{ steps.transform.outputs.nvd_new_to_feed_count }}
+          - **Updated NVD advisories:** ${{ steps.updates.outputs.nvd_updated_count }}
+          - **GHSA active advisories added to consolidated feed:** ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }}
           - **GHSA source feed changed:** ${{ steps.feed_changes.outputs.ghsa_changed }}
           - **Consolidated agent feed changed:** ${{ steps.feed_changes.outputs.agent_changed }}
           - **GHSA provisional advisories:** ${GHSA_TOTAL} total (${GHSA_ACTIVE} active, ${GHSA_MATURED} matured, ${GHSA_STALE} stale)
@@ -1109,31 +1146,33 @@ jobs:
           echo "| Mode | $MODE |" >> $GITHUB_STEP_SUMMARY
           echo "| Poll Window | ${{ steps.dates.outputs.start_date }} → ${{ steps.dates.outputs.end_date }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Keywords | $KEYWORDS |" >> $GITHUB_STEP_SUMMARY
-          echo "| CVEs Found (filtered) | ${{ steps.process.outputs.filtered_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| New Advisories | ${{ steps.transform.outputs.new_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Updated Advisories | ${{ steps.updates.outputs.update_count }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| NVD CVEs Found (filtered) | ${{ steps.process.outputs.nvd_filtered_count }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| NVD Advisories Rebuilt | ${{ steps.transform.outputs.nvd_rebuilt_count }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Net-new NVD Advisories | ${{ steps.transform.outputs.nvd_new_to_feed_count }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Updated NVD Advisories | ${{ steps.updates.outputs.nvd_updated_count }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| GHSA Active Added | ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }} |" >> $GITHUB_STEP_SUMMARY
           echo "| GHSA source feed changed | ${{ steps.feed_changes.outputs.ghsa_changed }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Consolidated agent feed changed | ${{ steps.feed_changes.outputs.agent_changed }} |" >> $GITHUB_STEP_SUMMARY
           echo "| GHSA provisional advisories | $(jq '.advisories | length' "$GHSA_FEED_PATH") |" >> $GITHUB_STEP_SUMMARY
 
-          if [ "${{ steps.transform.outputs.new_count }}" != "0" ]; then
+          if [ "${{ steps.transform.outputs.nvd_new_to_feed_count }}" != "0" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### New Advisories" >> $GITHUB_STEP_SUMMARY
+            echo "### Net-new NVD Advisories" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            jq -r '.[] | "- **\(.id)** (\(.severity)): \(.title)"' tmp/new_advisories.json >> $GITHUB_STEP_SUMMARY
+            jq -r '.[] | "- **\(.id)** (\(.severity)): \(.title)"' tmp/net_new_advisories.json >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ "${{ steps.updates.outputs.update_count }}" != "0" ]; then
+          if [ "${{ steps.updates.outputs.nvd_updated_count }}" != "0" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### Updated Advisories" >> $GITHUB_STEP_SUMMARY
+            echo "### Updated NVD Advisories" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             jq -r '.[] | "- **\(.id)**: \(.changes | join(", "))"' tmp/updated_advisories.json >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ "${{ steps.transform.outputs.new_count }}" != "0" ] || [ "${{ steps.updates.outputs.update_count }}" != "0" ]; then
+          if [ "${{ steps.feed_changes.outputs.changed }}" = "true" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "🔀 Upserted PR: ${{ steps.upsert-pr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
           else
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "✅ No new or updated CVEs found." >> $GITHUB_STEP_SUMMARY
+            echo "✅ No new or updated NVD CVEs or GHSA changes found." >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -520,6 +520,12 @@ jobs:
             ]
           ' > tmp/updated_advisories.json
 
+          node scripts/ci/repair_stale_exploitability.mjs \
+            --feed "$FEED_PATH" \
+            --updates tmp/updated_advisories.json \
+            --output tmp/updated_advisories.json \
+            --nvd-json tmp/filtered_cves.json
+
           UPDATE_COUNT=$(jq 'length' tmp/updated_advisories.json)
           echo "Advisories to update: $UPDATE_COUNT"
           echo "update_count=$UPDATE_COUNT" >> $GITHUB_OUTPUT
@@ -790,8 +796,39 @@ jobs:
           jq -r '.[] | "\(.id): \(.exploitability_score // "unknown")"' tmp/new_advisories.json | \
             awk -F': ' '{scores[$2]++} END {for (s in scores) print "  " s ": " scores[s]}'
 
+      - name: Finalize NVD update counts
+        id: nvd_counts
+        run: |
+          set -euo pipefail
+
+          if [ "${{ inputs.force_full_scan }}" = "true" ]; then
+            jq -n --slurpfile existing tmp/existing_advisories.json --slurpfile rebuilt tmp/new_advisories.json '
+              ($existing[0]
+                | map(select((.id // "") | startswith("CVE-")))
+                | map({key: .id, value: .})
+                | from_entries
+              ) as $existing_by_id |
+              [
+                $rebuilt[0][] |
+                . as $rebuilt_entry |
+                ($existing_by_id[$rebuilt_entry.id] // null) as $existing_entry |
+                select($existing_entry != null and $existing_entry != $rebuilt_entry) |
+                {
+                  id: $rebuilt_entry.id,
+                  changes: ["rebuilt advisory differs from existing feed"],
+                  updated_fields: $rebuilt_entry
+                }
+              ]
+            ' > tmp/updated_advisories.json
+          fi
+
+          UPDATE_COUNT=$(jq 'length' tmp/updated_advisories.json)
+          echo "Final NVD advisories to update: $UPDATE_COUNT"
+          echo "update_count=$UPDATE_COUNT" >> "$GITHUB_OUTPUT"
+          echo "nvd_updated_count=$UPDATE_COUNT" >> "$GITHUB_OUTPUT"
+
       - name: Update feed.json
-        if: steps.transform.outputs.new_count != '0' || steps.updates.outputs.update_count != '0'
+        if: steps.transform.outputs.new_count != '0' || steps.nvd_counts.outputs.update_count != '0'
         run: |
           NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           FORCE_FULL_SCAN="${{ inputs.force_full_scan }}"
@@ -891,7 +928,7 @@ jobs:
             ' "$FEED_PATH"
           )"
 
-          if [ "${{ steps.transform.outputs.nvd_rebuilt_count }}" != "0" ] || [ "${{ steps.transform.outputs.nvd_new_to_feed_count }}" != "0" ] || [ "${{ steps.updates.outputs.nvd_updated_count }}" != "0" ]; then
+          if [ "${{ steps.transform.outputs.nvd_rebuilt_count }}" != "0" ] || [ "${{ steps.transform.outputs.nvd_new_to_feed_count }}" != "0" ] || [ "${{ steps.nvd_counts.outputs.nvd_updated_count }}" != "0" ]; then
             NVD_CHANGED=true
           fi
 
@@ -975,7 +1012,7 @@ jobs:
 
           BRANCH_PREFIX="automated/nvd-cve-update"
           PR_COMMENT="Superseded by newer automated NVD advisory update."
-          TITLE="chore: update NVD/GHSA advisories - ${{ steps.transform.outputs.nvd_new_to_feed_count }} NVD new, ${{ steps.updates.outputs.nvd_updated_count }} NVD updated, ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }} GHSA active added"
+          TITLE="chore: update NVD/GHSA advisories - ${{ steps.transform.outputs.nvd_new_to_feed_count }} NVD new, ${{ steps.nvd_counts.outputs.nvd_updated_count }} NVD updated, ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }} GHSA active added"
           COMMIT_SUBJECT="$TITLE"
           COMMIT_BODY=$'Automated update from NVD CVE and GHSA advisory feeds.\nKeywords: ${{ env.KEYWORDS }}\nPoll window: ${{ steps.dates.outputs.start_date }} to ${{ steps.dates.outputs.end_date }}'
 
@@ -999,7 +1036,7 @@ jobs:
           - **Filtered NVD CVEs:** ${{ steps.process.outputs.nvd_filtered_count }}
           - **Rebuilt NVD advisories:** ${{ steps.transform.outputs.nvd_rebuilt_count }}
           - **Net-new NVD advisories:** ${{ steps.transform.outputs.nvd_new_to_feed_count }}
-          - **Updated NVD advisories:** ${{ steps.updates.outputs.nvd_updated_count }}
+          - **Updated NVD advisories:** ${{ steps.nvd_counts.outputs.nvd_updated_count }}
           - **GHSA active advisories added to consolidated feed:** ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }}
           - **GHSA source feed changed:** ${{ steps.feed_changes.outputs.ghsa_changed }}
           - **Consolidated agent feed changed:** ${{ steps.feed_changes.outputs.agent_changed }}
@@ -1149,7 +1186,7 @@ jobs:
           echo "| NVD CVEs Found (filtered) | ${{ steps.process.outputs.nvd_filtered_count }} |" >> $GITHUB_STEP_SUMMARY
           echo "| NVD Advisories Rebuilt | ${{ steps.transform.outputs.nvd_rebuilt_count }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Net-new NVD Advisories | ${{ steps.transform.outputs.nvd_new_to_feed_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Updated NVD Advisories | ${{ steps.updates.outputs.nvd_updated_count }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Updated NVD Advisories | ${{ steps.nvd_counts.outputs.nvd_updated_count }} |" >> $GITHUB_STEP_SUMMARY
           echo "| GHSA Active Added | ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }} |" >> $GITHUB_STEP_SUMMARY
           echo "| GHSA source feed changed | ${{ steps.feed_changes.outputs.ghsa_changed }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Consolidated agent feed changed | ${{ steps.feed_changes.outputs.agent_changed }} |" >> $GITHUB_STEP_SUMMARY
@@ -1162,7 +1199,7 @@ jobs:
             jq -r '.[] | "- **\(.id)** (\(.severity)): \(.title)"' tmp/net_new_advisories.json >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ "${{ steps.updates.outputs.nvd_updated_count }}" != "0" ]; then
+          if [ "${{ steps.nvd_counts.outputs.nvd_updated_count }}" != "0" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Updated NVD Advisories" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/scripts/ci/repair_stale_exploitability.mjs
+++ b/scripts/ci/repair_stale_exploitability.mjs
@@ -61,6 +61,18 @@ async function readJson(path) {
   return JSON.parse(await readFile(path, 'utf8'));
 }
 
+async function readJsonIfExists(path, fallback) {
+  try {
+    return await readJson(path);
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      console.log(`Existing feed not found at ${path}; skipping stale exploitability repair`);
+      return fallback;
+    }
+    throw error;
+  }
+}
+
 function nvdEntriesFromPayload(payload) {
   if (!payload) {
     return [];
@@ -190,7 +202,7 @@ function mergeUpdate(existingUpdate, fields) {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const feed = await readJson(args.feed);
+  const feed = await readJsonIfExists(args.feed, { advisories: [] });
   const updates = await readJson(args.updates);
   const nvdPayload = args.nvdJson ? await readJson(args.nvdJson) : null;
   const nvdById = new Map(nvdEntriesFromPayload(nvdPayload).map(entry => [nvdEntryId(entry), entry]));

--- a/scripts/ci/repair_stale_exploitability.mjs
+++ b/scripts/ci/repair_stale_exploitability.mjs
@@ -125,7 +125,7 @@ async function fetchNvdEntry(id) {
 
   for (let attempt = 1; attempt <= 3; attempt += 1) {
     try {
-      const response = await fetch(url);
+      const response = await globalThis.fetch(url);
       if (response.ok) {
         const payload = await response.json();
         const entry = nvdEntriesFromPayload(payload).find(item => nvdEntryId(item) === id);

--- a/scripts/ci/repair_stale_exploitability.mjs
+++ b/scripts/ci/repair_stale_exploitability.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { readFile, writeFile } from 'node:fs/promises';
+import process from 'node:process';
+
+const DEFAULT_MAX_CANDIDATES = 50;
+const NVD_API_BASE = 'https://services.nvd.nist.gov/rest/json/cves/2.0';
+
+function usage() {
+  console.error(`Usage:
+  node scripts/ci/repair_stale_exploitability.mjs \\
+    --feed <advisories/feed.json> \\
+    --updates <tmp/updated_advisories.json> \\
+    --output <tmp/updated_advisories.json> \\
+    [--nvd-json <tmp/filtered_cves.json>] \\
+    [--max-candidates <count>] \\
+    [--no-network]
+`);
+}
+
+function parseArgs(argv) {
+  const args = {
+    maxCandidates: DEFAULT_MAX_CANDIDATES,
+    noNetwork: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--feed') {
+      args.feed = argv[++i];
+    } else if (arg === '--updates') {
+      args.updates = argv[++i];
+    } else if (arg === '--output') {
+      args.output = argv[++i];
+    } else if (arg === '--nvd-json') {
+      args.nvdJson = argv[++i];
+    } else if (arg === '--max-candidates') {
+      args.maxCandidates = Number.parseInt(argv[++i], 10);
+    } else if (arg === '--no-network') {
+      args.noNetwork = true;
+    } else if (arg === '--help' || arg === '-h') {
+      usage();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!args.feed || !args.updates || !args.output) {
+    usage();
+    throw new Error('--feed, --updates, and --output are required');
+  }
+  if (!Number.isInteger(args.maxCandidates) || args.maxCandidates < 0) {
+    throw new Error('--max-candidates must be a non-negative integer');
+  }
+
+  return args;
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+
+function nvdEntriesFromPayload(payload) {
+  if (!payload) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (Array.isArray(payload.vulnerabilities)) {
+    return payload.vulnerabilities;
+  }
+  return [];
+}
+
+function nvdEntryId(entry) {
+  return entry?.cve?.id;
+}
+
+function cvssVectorFromNvd(entry) {
+  const metrics = entry?.cve?.metrics ?? {};
+  return (
+    metrics.cvssMetricV31?.[0]?.cvssData?.vectorString ??
+    metrics.cvssMetricV30?.[0]?.cvssData?.vectorString ??
+    metrics.cvssMetricV2?.[0]?.cvssData?.vectorString ??
+    metrics.cvssMetricV2?.[0]?.vectorString ??
+    ''
+  );
+}
+
+function extractRationaleScore(rationale) {
+  if (typeof rationale !== 'string') {
+    return null;
+  }
+  const match = rationale.match(/\((\d+(?:\.\d+)?)\)/);
+  return match ? Number.parseFloat(match[1]) : null;
+}
+
+function hasStaleExploitability(advisory) {
+  if (!String(advisory?.id ?? '').startsWith('CVE-')) {
+    return false;
+  }
+
+  const score = Number(advisory.cvss_score);
+  if (!Number.isFinite(score) || score <= 0) {
+    return false;
+  }
+
+  if (!advisory.exploitability_score || !advisory.exploitability_rationale || !advisory.attack_vector_analysis) {
+    return true;
+  }
+
+  const rationaleScore = extractRationaleScore(advisory.exploitability_rationale);
+  return Number.isFinite(rationaleScore) && Math.abs(rationaleScore - score) > 0.05;
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function fetchNvdEntry(id) {
+  const url = `${NVD_API_BASE}?cveId=${encodeURIComponent(id)}`;
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        const payload = await response.json();
+        const entry = nvdEntriesFromPayload(payload).find(item => nvdEntryId(item) === id);
+        if (!entry) {
+          throw new Error(`NVD response did not contain ${id}`);
+        }
+        return entry;
+      }
+
+      lastError = new Error(`HTTP ${response.status}`);
+      const waitMs = response.status === 403 || response.status === 429 ? 30000 : 5000;
+      await sleep(waitMs);
+    } catch (error) {
+      lastError = error;
+      await sleep(5000);
+    }
+  }
+
+  throw new Error(`Failed to fetch NVD entry for ${id}: ${lastError?.message ?? 'unknown error'}`);
+}
+
+function runAnalyzer(input) {
+  const command = process.env.PYTHON ? process.env.PYTHON : 'python3';
+  const result = spawnSync(command, ['utils/analyze_exploitability.py', '--json', '--check-exploits'], {
+    input: JSON.stringify(input),
+    encoding: 'utf8',
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`Exploitability analyzer failed: ${result.stderr || result.stdout}`);
+  }
+
+  return JSON.parse(result.stdout);
+}
+
+function changedFields(advisory, analysis) {
+  const fields = {};
+  for (const key of ['exploitability_score', 'exploitability_rationale', 'attack_vector_analysis', 'exploit_detection']) {
+    if (JSON.stringify(advisory[key]) !== JSON.stringify(analysis[key])) {
+      fields[key] = analysis[key];
+    }
+  }
+  return fields;
+}
+
+function mergeUpdate(existingUpdate, fields) {
+  const update = existingUpdate ?? {
+    id: '',
+    changes: [],
+    updated_fields: {},
+  };
+
+  return {
+    ...update,
+    changes: [...new Set([...(update.changes ?? []), 'exploitability refreshed'])],
+    updated_fields: {
+      ...(update.updated_fields ?? {}),
+      ...fields,
+    },
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const feed = await readJson(args.feed);
+  const updates = await readJson(args.updates);
+  const nvdPayload = args.nvdJson ? await readJson(args.nvdJson) : null;
+  const nvdById = new Map(nvdEntriesFromPayload(nvdPayload).map(entry => [nvdEntryId(entry), entry]));
+
+  const candidates = (feed.advisories ?? []).filter(hasStaleExploitability);
+  console.log(`Stale exploitability repair candidates: ${candidates.length}`);
+
+  if (candidates.length > args.maxCandidates) {
+    throw new Error(
+      `Refusing to repair ${candidates.length} stale exploitability records in one delta run; max is ${args.maxCandidates}. Run a full refresh.`,
+    );
+  }
+
+  const updatesById = new Map(updates.map(update => [update.id, update]));
+  let fetchedCount = 0;
+  let repairedCount = 0;
+
+  for (const [index, advisory] of candidates.entries()) {
+    let nvdEntry = nvdById.get(advisory.id);
+    if (!nvdEntry) {
+      if (args.noNetwork) {
+        throw new Error(`Missing NVD entry for ${advisory.id} and --no-network was set`);
+      }
+      if (fetchedCount > 0) {
+        await sleep(6000);
+      }
+      nvdEntry = await fetchNvdEntry(advisory.id);
+      fetchedCount += 1;
+      nvdById.set(advisory.id, nvdEntry);
+    }
+
+    const analysis = runAnalyzer({
+      cve_id: advisory.id,
+      cvss_score: Number(advisory.cvss_score ?? 0),
+      cvss_vector: cvssVectorFromNvd(nvdEntry),
+      type: advisory.type ?? '',
+      description: advisory.description ?? '',
+      references: advisory.references ?? [],
+    });
+
+    const fields = changedFields(advisory, analysis);
+    if (Object.keys(fields).length === 0) {
+      continue;
+    }
+
+    const merged = mergeUpdate(updatesById.get(advisory.id), fields);
+    merged.id = advisory.id;
+    updatesById.set(advisory.id, merged);
+    repairedCount += 1;
+    console.log(`Queued exploitability repair for ${advisory.id} (${index + 1}/${candidates.length})`);
+  }
+
+  const output = [...updatesById.values()].sort((a, b) => a.id.localeCompare(b.id));
+  await writeFile(args.output, `${JSON.stringify(output, null, 2)}\n`);
+  console.log(`Exploitability repairs queued: ${repairedCount}`);
+}
+
+main().catch(error => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/ghsa-without-cve-feed.mjs
+++ b/scripts/ghsa-without-cve-feed.mjs
@@ -200,6 +200,10 @@ function equivalentAdvisories(left, right) {
   return JSON.stringify(left ?? []) === JSON.stringify(right ?? []);
 }
 
+function updatedTimestampForAdvisoryChange(advisories, existingAdvisories, existingUpdated, now) {
+  return equivalentAdvisories(advisories, existingAdvisories) ? existingUpdated || now : now;
+}
+
 function isCveId(value) {
   return typeof value === 'string' && /^CVE-\d{4}-\d{4,}$/i.test(value);
 }
@@ -261,12 +265,10 @@ export function buildConsolidatedAdvisoryFeed({ canonicalFeed = {}, ghsaFeed = {
     }
     return String(a.id || '').localeCompare(String(b.id || ''));
   });
-  const advisoriesChanged = !equivalentAdvisories(advisories, canonicalFeedEntries);
-
   return {
     ...canonicalFeed,
     version: canonicalFeed.version || '1.0.0',
-    updated: advisoriesChanged ? now : canonicalFeed.updated || now,
+    updated: updatedTimestampForAdvisoryChange(advisories, canonicalFeedEntries, canonicalFeed.updated, now),
     description: canonicalFeed.description || 'Community-driven security advisory feed for ClawSec',
     advisories,
   };
@@ -322,9 +324,7 @@ export function buildGhsaWithoutCveFeed({
     return a.id.localeCompare(b.id);
   });
 
-  const updated = equivalentAdvisories(advisories, existingEntries)
-    ? existingFeed.updated || now
-    : now;
+  const updated = updatedTimestampForAdvisoryChange(advisories, existingEntries, existingFeed.updated, now);
 
   return {
     version: FEED_VERSION,

--- a/scripts/ghsa-without-cve-feed.mjs
+++ b/scripts/ghsa-without-cve-feed.mjs
@@ -261,11 +261,12 @@ export function buildConsolidatedAdvisoryFeed({ canonicalFeed = {}, ghsaFeed = {
     }
     return String(a.id || '').localeCompare(String(b.id || ''));
   });
+  const advisoriesChanged = !equivalentAdvisories(advisories, canonicalFeedEntries);
 
   return {
     ...canonicalFeed,
     version: canonicalFeed.version || '1.0.0',
-    updated: canonicalFeed.updated || now,
+    updated: advisoriesChanged ? now : canonicalFeed.updated || now,
     description: canonicalFeed.description || 'Community-driven security advisory feed for ClawSec',
     advisories,
   };

--- a/scripts/test-ghsa-without-cve-feed.mjs
+++ b/scripts/test-ghsa-without-cve-feed.mjs
@@ -211,7 +211,7 @@ test('buildGhsaWithoutCveFeed matures tracked GHSAs when the CVE feed references
   assert.equal(feed.advisories[0].cve_id, 'CVE-2026-3333');
 });
 
-test('buildConsolidatedAdvisoryFeed appends active GHSA advisories without moving the NVD poll cursor', () => {
+test('buildConsolidatedAdvisoryFeed advances updated when GHSA consolidation changes advisories', () => {
   const canonicalFeed = {
     version: '1.0.0',
     updated: '2026-05-23T00:00:00Z',
@@ -250,8 +250,34 @@ test('buildConsolidatedAdvisoryFeed appends active GHSA advisories without movin
     consolidated.advisories.map((entry) => entry.id),
     ['CVE-2026-1111', 'GHSA-active-1111-2222'],
   );
-  assert.equal(consolidated.updated, canonicalFeed.updated);
+  assert.equal(consolidated.updated, fixedNow);
   assert.equal(consolidated.advisories[1].source_feed, 'ghsa-without-cve');
+});
+
+test('buildConsolidatedAdvisoryFeed preserves updated when GHSA consolidation is unchanged', () => {
+  const canonicalFeed = {
+    version: '1.0.0',
+    updated: '2026-05-23T00:00:00Z',
+    description: 'Community-driven security advisory feed for ClawSec',
+    advisories: [
+      {
+        id: 'GHSA-same-1111-2222',
+        ghsa_id: 'GHSA-same-1111-2222',
+        status: 'active',
+        source_feed: 'ghsa-without-cve',
+        title: 'Existing GHSA payload',
+        published: '2026-05-01T00:00:00Z',
+      },
+    ],
+  };
+
+  const consolidated = buildConsolidatedAdvisoryFeed({
+    canonicalFeed,
+    ghsaFeed: { advisories: [] },
+    now: fixedNow,
+  });
+
+  assert.equal(consolidated.updated, canonicalFeed.updated);
 });
 
 test('buildConsolidatedAdvisoryFeed keeps existing GHSA advisories when replacement feed is empty', () => {

--- a/scripts/test-nvd-exploitability-repair.mjs
+++ b/scripts/test-nvd-exploitability-repair.mjs
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const workdir = await mkdtemp(join(tmpdir(), 'clawsec-exploitability-repair-'));
+
+try {
+  const feedPath = join(workdir, 'feed.json');
+  const updatesPath = join(workdir, 'updates.json');
+  const nvdPath = join(workdir, 'nvd.json');
+  const outputPath = join(workdir, 'output.json');
+
+  await writeFile(
+    feedPath,
+    JSON.stringify(
+      {
+        version: '1.0.0',
+        updated: '2026-06-30T00:00:00Z',
+        advisories: [
+          {
+            id: 'CVE-2026-44112',
+            severity: 'critical',
+            type: 'unspecified_weakness',
+            title: 'OpenClaw network issue',
+            description: 'OpenClaw exposes a network reachable issue.',
+            affected: ['openclaw@*'],
+            platforms: ['openclaw'],
+            references: ['https://example.test/advisory'],
+            published: '2026-06-01T00:00:00.000Z',
+            cvss_score: 9.6,
+            exploitability_score: 'medium',
+            exploitability_rationale: 'Medium CVSS score (5.3); network accessible',
+            attack_vector_analysis: {
+              is_network_accessible: true,
+              requires_authentication: true,
+              requires_user_interaction: false,
+              complexity: 'high',
+            },
+          },
+          {
+            id: 'CVE-2026-44113',
+            severity: 'high',
+            type: 'path_traversal',
+            title: 'Already consistent advisory',
+            description: 'A local-only issue.',
+            affected: ['openclaw@*'],
+            platforms: ['openclaw'],
+            references: [],
+            published: '2026-06-02T00:00:00.000Z',
+            cvss_score: 7.7,
+            exploitability_score: 'high',
+            exploitability_rationale: 'High CVSS score (7.7); network accessible',
+            attack_vector_analysis: {
+              is_network_accessible: true,
+              requires_authentication: true,
+              requires_user_interaction: false,
+              complexity: 'low',
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  await writeFile(
+    updatesPath,
+    JSON.stringify(
+      [
+        {
+          id: 'CVE-2026-44112',
+          changes: ['severity: high to critical'],
+          updated_fields: {
+            severity: 'critical',
+          },
+        },
+      ],
+      null,
+      2,
+    ),
+  );
+
+  await writeFile(
+    nvdPath,
+    JSON.stringify(
+      {
+        vulnerabilities: [
+          {
+            cve: {
+              id: 'CVE-2026-44112',
+              metrics: {
+                cvssMetricV31: [
+                  {
+                    cvssData: {
+                      baseScore: 9.6,
+                      vectorString: 'CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  await execFileAsync('node', [
+    'scripts/ci/repair_stale_exploitability.mjs',
+    '--feed',
+    feedPath,
+    '--updates',
+    updatesPath,
+    '--output',
+    outputPath,
+    '--nvd-json',
+    nvdPath,
+    '--no-network',
+  ]);
+
+  const output = JSON.parse(await readFile(outputPath, 'utf8'));
+  assert.equal(output.length, 1, 'only the stale advisory should be queued');
+  assert.equal(output[0].id, 'CVE-2026-44112');
+  assert.deepEqual(output[0].changes, ['severity: high to critical', 'exploitability refreshed']);
+  assert.equal(output[0].updated_fields.severity, 'critical', 'existing update fields must be preserved');
+  assert.equal(output[0].updated_fields.exploitability_score, 'high');
+  assert.equal(output[0].updated_fields.exploitability_rationale, 'Critical CVSS score (9.6); network accessible');
+  assert.deepEqual(output[0].updated_fields.attack_vector_analysis, {
+    is_network_accessible: true,
+    requires_authentication: true,
+    requires_user_interaction: false,
+    complexity: 'low',
+  });
+} finally {
+  await rm(workdir, { recursive: true, force: true });
+}

--- a/scripts/test-nvd-exploitability-repair.mjs
+++ b/scripts/test-nvd-exploitability-repair.mjs
@@ -14,6 +14,7 @@ try {
   const updatesPath = join(workdir, 'updates.json');
   const nvdPath = join(workdir, 'nvd.json');
   const outputPath = join(workdir, 'output.json');
+  const missingFeedOutputPath = join(workdir, 'missing-feed-output.json');
 
   await writeFile(
     feedPath,
@@ -139,6 +140,34 @@ try {
     requires_user_interaction: false,
     complexity: 'low',
   });
+
+  await execFileAsync('node', [
+    'scripts/ci/repair_stale_exploitability.mjs',
+    '--feed',
+    join(workdir, 'missing-feed.json'),
+    '--updates',
+    updatesPath,
+    '--output',
+    missingFeedOutputPath,
+    '--nvd-json',
+    nvdPath,
+    '--no-network',
+  ]);
+
+  const missingFeedOutput = JSON.parse(await readFile(missingFeedOutputPath, 'utf8'));
+  assert.deepEqual(
+    missingFeedOutput,
+    [
+      {
+        id: 'CVE-2026-44112',
+        changes: ['severity: high to critical'],
+        updated_fields: {
+          severity: 'critical',
+        },
+      },
+    ],
+    'missing existing feed should preserve the update list unchanged',
+  );
 } finally {
   await rm(workdir, { recursive: true, force: true });
 }

--- a/scripts/test-nvd-ghsa-consolidation-workflow.mjs
+++ b/scripts/test-nvd-ghsa-consolidation-workflow.mjs
@@ -61,6 +61,16 @@ assert.match(
 );
 assert.match(
   workflow,
+  /node scripts\/ci\/repair_stale_exploitability\.mjs[\s\S]*--feed "\$FEED_PATH"[\s\S]*--updates tmp\/updated_advisories\.json[\s\S]*--output tmp\/updated_advisories\.json[\s\S]*--nvd-json tmp\/filtered_cves\.json/,
+  'NVD delta updates must repair stale exploitability enrichment before publishing the feed',
+);
+assert.match(
+  workflow,
+  /id: nvd_counts[\s\S]*Final NVD advisories to update:[\s\S]*nvd_updated_count=\$UPDATE_COUNT/,
+  'NVD workflow must finalize updated counts after enrichment and full-scan rebuild comparison',
+);
+assert.match(
+  workflow,
   /REBUILT_COUNT=/,
   'NVD full-scan mode must report rebuilt CVEs separately from net-new CVEs',
 );
@@ -86,7 +96,7 @@ assert.match(
 );
 assert.match(
   workflow,
-  /TITLE="chore: update NVD\/GHSA advisories - \$\{\{ steps\.transform\.outputs\.nvd_new_to_feed_count \}\} NVD new, \$\{\{ steps\.updates\.outputs\.nvd_updated_count \}\} NVD updated, \$\{\{ steps\.feed_changes\.outputs\.ghsa_added_to_consolidated_count \}\} GHSA active added"/,
+  /TITLE="chore: update NVD\/GHSA advisories - \$\{\{ steps\.transform\.outputs\.nvd_new_to_feed_count \}\} NVD new, \$\{\{ steps\.nvd_counts\.outputs\.nvd_updated_count \}\} NVD updated, \$\{\{ steps\.feed_changes\.outputs\.ghsa_added_to_consolidated_count \}\} GHSA active added"/,
   'Generated PR titles must include net-new NVD, updated NVD, and GHSA-only addition counts',
 );
 assert.match(

--- a/scripts/test-nvd-ghsa-consolidation-workflow.mjs
+++ b/scripts/test-nvd-ghsa-consolidation-workflow.mjs
@@ -3,6 +3,8 @@ import { readFile } from 'node:fs/promises';
 
 const workflowPath = new URL('../.github/workflows/poll-nvd-cves.yml', import.meta.url);
 const workflow = await readFile(workflowPath, 'utf8');
+const codeqlWorkflowPath = new URL('../.github/workflows/codeql.yml', import.meta.url);
+const codeqlWorkflow = await readFile(codeqlWorkflowPath, 'utf8');
 const ciWorkflowPath = new URL('../.github/workflows/ci.yml', import.meta.url);
 const ciWorkflow = await readFile(ciWorkflowPath, 'utf8');
 
@@ -47,6 +49,51 @@ assert.match(
   /git add "\$FEED_PATH" "\$FEED_SIG_PATH" "\$GHSA_FEED_PATH" "\$GHSA_FEED_SIG_PATH" "\$SKILL_FEED_PATH" "\$SKILL_FEED_SIG_PATH"/,
   'NVD workflow PR must include both NVD and GHSA feed artifacts',
 );
+assert.match(
+  workflow,
+  /echo "nvd_filtered_count=\$FILTERED" >> \$GITHUB_OUTPUT/,
+  'NVD workflow must expose the filtered NVD CVE count with an explicit output name',
+);
+assert.match(
+  workflow,
+  /echo "nvd_updated_count=\$UPDATE_COUNT" >> \$GITHUB_OUTPUT/,
+  'NVD workflow must expose updated NVD advisories with an explicit output name',
+);
+assert.match(
+  workflow,
+  /REBUILT_COUNT=/,
+  'NVD full-scan mode must report rebuilt CVEs separately from net-new CVEs',
+);
+assert.match(
+  workflow,
+  /echo "nvd_rebuilt_count=\$REBUILT_COUNT" >> \$GITHUB_OUTPUT/,
+  'NVD workflow must expose rebuilt CVE count separately from new-to-feed count',
+);
+assert.match(
+  workflow,
+  /echo "nvd_new_to_feed_count=\$NET_NEW_COUNT" >> \$GITHUB_OUTPUT/,
+  'NVD workflow must expose net-new CVE advisories separately from rebuilt count',
+);
+assert.match(
+  workflow,
+  /echo "ghsa_active_count=\$GHSA_ACTIVE_COUNT" >> "\$GITHUB_OUTPUT"/,
+  'NVD workflow must expose active GHSA count from the consolidated feed path',
+);
+assert.match(
+  workflow,
+  /echo "ghsa_added_to_consolidated_count=\$GHSA_ADDED_COUNT" >> "\$GITHUB_OUTPUT"/,
+  'NVD workflow must expose GHSA-only additions to the consolidated feed',
+);
+assert.match(
+  workflow,
+  /TITLE="chore: update NVD\/GHSA advisories - \$\{\{ steps\.transform\.outputs\.nvd_new_to_feed_count \}\} NVD new, \$\{\{ steps\.updates\.outputs\.nvd_updated_count \}\} NVD updated, \$\{\{ steps\.feed_changes\.outputs\.ghsa_added_to_consolidated_count \}\} GHSA active added"/,
+  'Generated PR titles must include net-new NVD, updated NVD, and GHSA-only addition counts',
+);
+assert.match(
+  workflow,
+  /\*\*GHSA active advisories added to consolidated feed:\*\* \$\{\{ steps\.feed_changes\.outputs\.ghsa_added_to_consolidated_count \}\}/,
+  'Generated PR bodies must include GHSA-only additions',
+);
 assert.doesNotMatch(
   workflow,
   /gh run list[\s\S]*--jq --arg/,
@@ -61,6 +108,11 @@ assert.match(
   ciWorkflow,
   /name: NVD \+ GHSA Pipeline Dry Run[\s\S]*node scripts\/test-nvd-ghsa-pipeline-dry-run\.mjs/,
   'CI must run the deterministic NVD + GHSA pipeline dry run before merge',
+);
+assert.match(
+  codeqlWorkflow,
+  /if: github\.event_name != 'pull_request' \|\| !startsWith\(github\.head_ref, 'automated\/nvd-cve-update'\)/,
+  'PR-triggered CodeQL must skip generated NVD advisory PRs because poll-nvd-cves dispatches CodeQL explicitly',
 );
 
 const updateFeedIndex = requiredIndex('name: Update feed.json', 'NVD workflow must update the CVE feed first');


### PR DESCRIPTION
# User description
## Summary

Fixes the advisory polling reporting path so full rebuilds, incremental NVD updates, GHSA-only additions, and CodeQL gating are reported separately.

## Changes

- Split NVD workflow counters into filtered, rebuilt, net-new, and updated advisory counts.
- Include GHSA-only additions in generated advisory PR titles and bodies.
- Advance the consolidated feed `updated` timestamp when GHSA consolidation changes the advisory set.
- Skip PR-triggered CodeQL for generated `automated/nvd-cve-update` PRs because the poll workflow dispatches CodeQL explicitly.
- Added regression coverage for GHSA timestamp behavior, workflow counters, generated PR text, and CodeQL skip behavior.

## Validation

- `node scripts/test-ghsa-without-cve-feed.mjs`
- `node scripts/test-ghsa-poll-workflow.mjs`
- `node scripts/test-nvd-ghsa-pipeline-dry-run.mjs`
- `node scripts/test-nvd-ghsa-consolidation-workflow.mjs`
- `npm run build`
- `git diff --check`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Highlight deterministic reporting of filtered CVEs, rebuilt versus net-new advisories, updated advisories, and GHSA-only additions inside the NVD polling workflow and associated helper script. Adjust GHSA consolidation timestamp handling and CodeQL gating so generated <code>automated/nvd-cve-update</code> PRs reflect GHSA changes while skipping redundant PR-triggered scans.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/291?tool=ast&topic=GHSA+Consolidation>GHSA Consolidation</a>
        </td><td>Adjust GHSA consolidation timestamp tracking and PR generation so GHSA-only updates advance the consolidated feed, and ensure generated <code>automated/nvd-cve-update</code> PRs skip PR-triggered CodeQL runs.<details><summary>Modified files (3)</summary><ul><li>.github/workflows/codeql.yml</li>
<li>scripts/ghsa-without-cve-feed.mjs</li>
<li>scripts/test-ghsa-without-cve-feed.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>refactor(advisories): ...</td><td>June 30, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>feat(advisories): add ...</td><td>May 24, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/291?tool=ast&topic=NVD+Poll+Reporting>NVD Poll Reporting</a>
        </td><td>Ensure the NVD polling flow emits explicit counts for filtered CVEs, rebuilt versus net-new advisory batches, updated advisories, and GHSA additions while repairing stale exploitability data before publishing.<details><summary>Modified files (4)</summary><ul><li>.github/workflows/poll-nvd-cves.yml</li>
<li>scripts/ci/repair_stale_exploitability.mjs</li>
<li>scripts/test-nvd-exploitability-repair.mjs</li>
<li>scripts/test-nvd-ghsa-consolidation-workflow.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(advisories): handl...</td><td>June 30, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(workflow): filter ...</td><td>June 10, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/291?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>