### PR TITLE
fix(advisories): publish checksum aliases beside feed

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -347,36 +347,10 @@ jobs:
               echo "Warning: Suite release assets not mirrored (missing: $MIRROR_TAG_DIR)"
             fi
 
-            # Mirror advisories feed + signatures at the path referenced by suite docs/heartbeat
-            if [ -f "public/advisories/feed.json" ]; then
-              mkdir -p "$MIRROR_LATEST_DIR/advisories"
-              cp "public/advisories/feed.json" "$MIRROR_LATEST_DIR/advisories/feed.json"
-              cp "public/advisories/feed.json" "$MIRROR_LATEST_DIR/feed.json"
-            fi
-            if [ -f "public/advisories/feed.json.sig" ]; then
-              mkdir -p "$MIRROR_LATEST_DIR/advisories"
-              cp "public/advisories/feed.json.sig" "$MIRROR_LATEST_DIR/advisories/feed.json.sig"
-              cp "public/advisories/feed.json.sig" "$MIRROR_LATEST_DIR/feed.json.sig"
-            fi
-            if [ -f "public/advisories/ghsa-without-cve.json" ]; then
-              mkdir -p "$MIRROR_LATEST_DIR/advisories"
-              cp "public/advisories/ghsa-without-cve.json" "$MIRROR_LATEST_DIR/advisories/ghsa-without-cve.json"
-              cp "public/advisories/ghsa-without-cve.json" "$MIRROR_LATEST_DIR/ghsa-without-cve.json"
-            fi
-            if [ -f "public/advisories/ghsa-without-cve.json.sig" ]; then
-              mkdir -p "$MIRROR_LATEST_DIR/advisories"
-              cp "public/advisories/ghsa-without-cve.json.sig" "$MIRROR_LATEST_DIR/advisories/ghsa-without-cve.json.sig"
-              cp "public/advisories/ghsa-without-cve.json.sig" "$MIRROR_LATEST_DIR/ghsa-without-cve.json.sig"
-            fi
-            if [ -f "public/checksums.json" ]; then
-              cp "public/checksums.json" "$MIRROR_LATEST_DIR/checksums.json"
-            fi
-            if [ -f "public/checksums.sig" ]; then
-              cp "public/checksums.sig" "$MIRROR_LATEST_DIR/checksums.sig"
-            fi
-            if [ -f "public/signing-public.pem" ]; then
-              cp "public/signing-public.pem" "$MIRROR_LATEST_DIR/signing-public.pem"
-            fi
+            # Mirror the advisory contract at the paths referenced by suite docs/heartbeat.
+            node scripts/ci/advisory_pages_artifacts.mjs publish-release-mirror \
+              --public-dir public \
+              --mirror-dir "$MIRROR_LATEST_DIR"
           else
             echo "No clawsec-suite release found, using fallback"
           fi
@@ -400,6 +374,9 @@ jobs:
           ls -la dist/
           ls -la dist/skills/ 2>/dev/null || echo "No skills in dist"
           ls -la dist/advisories/ 2>/dev/null || echo "No advisories in dist"
+
+      - name: Smoke-test built advisory endpoints
+        run: node scripts/ci/advisory_pages_artifacts.mjs smoke-http --dist-dir dist
 
       - name: Add .nojekyll file
         run: touch dist/.nojekyll

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+
       - name: Verify signing key consistency (repo + docs)
         run: ./scripts/ci/verify_signing_key_consistency.sh
 
@@ -277,48 +283,7 @@ jobs:
           signature_file: public/advisories/ghsa-without-cve.json.sig
 
       - name: Generate advisory checksums manifest
-        run: |
-          set -euo pipefail
-
-          FILES_JSON="{}"
-          ADVISORY_ARTIFACTS=(public/advisories/*.json public/advisories/*.json.sig)
-          for file in "${ADVISORY_ARTIFACTS[@]}"; do
-            [ -e "$file" ] || continue
-            REL_PATH="${file#public/}"
-            FILE_SHA=$(sha256sum "$file" | awk '{print $1}')
-            FILE_SIZE=$(stat -c%s "$file" 2>/dev/null || stat -f%z "$file")
-            FILES_JSON=$(jq \
-              --arg path "$REL_PATH" \
-              --arg sha "$FILE_SHA" \
-              --argjson size "$FILE_SIZE" \
-              '. + {($path): {sha256: $sha, size: $size, path: $path, url: ("https://clawsec.prompt.security/" + $path)}}' \
-              <<< "$FILES_JSON")
-          done
-
-          # Generate checksums manifest conforming to parseChecksumsManifest expectations:
-          # - schema_version: "1" (manifest format version)
-          # - algorithm: "sha256" (hash algorithm)
-          # - version: "1.1.0" (feed content version, for informational purposes)
-          # - generated_at, repository: metadata
-          # - files: map of path -> {sha256, size, path, url}
-          jq -n \
-            --arg schema_version "1" \
-            --arg algorithm "sha256" \
-            --arg version "1.1.0" \
-            --arg generated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            --arg repo "${{ github.repository }}" \
-            --argjson files "$FILES_JSON" \
-            '{
-              schema_version: $schema_version,
-              algorithm: $algorithm,
-              version: $version,
-              generated_at: $generated,
-              repository: $repo,
-              files: $files
-            }' > public/checksums.json
-
-          echo "Generated public/checksums.json"
-          jq . public/checksums.json
+        run: node scripts/ci/advisory_pages_artifacts.mjs generate --public-dir public --repository "${{ github.repository }}"
 
       - name: Sign checksums and verify
         uses: ./.github/actions/sign-and-verify
@@ -328,11 +293,8 @@ jobs:
           input_file: public/checksums.json
           signature_file: public/checksums.sig
 
-      - name: Publish advisory checksum aliases
-        run: |
-          set -euo pipefail
-          cp public/checksums.json public/advisories/checksums.json
-          cp public/checksums.sig public/advisories/checksums.json.sig
+      - name: Publish advisory compatibility aliases
+        run: node scripts/ci/advisory_pages_artifacts.mjs publish-aliases --public-dir public
 
       - name: Verify generated public signing key matches canonical key
         run: |
@@ -346,26 +308,11 @@ jobs:
             exit 1
           fi
 
-      - name: Copy public key to advisory directory
-        run: |
-          # Clients expect the public key at advisories/feed-signing-public.pem
-          mkdir -p public/advisories
-          cp public/signing-public.pem public/advisories/feed-signing-public.pem
-          echo "Public key available at:"
-          echo "  - public/signing-public.pem (root)"
-          echo "  - public/advisories/feed-signing-public.pem (advisory-specific)"
-
       - name: Show signed advisory artifacts
         run: |
           echo "Signed advisory artifacts:"
           ls -la public/advisories/*.json*
           ls -la public/checksums.json public/checksums.sig public/signing-public.pem
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '20'
-          cache: 'npm'
 
       - name: Get latest clawsec-suite release URL
         env:
@@ -443,17 +390,11 @@ jobs:
           NODE_ENV: production
           VITE_CLAWSEC_SUITE_URL: ${{ env.VITE_CLAWSEC_SUITE_URL }}
 
-      - name: Copy skills data to dist
+      - name: Verify built public artifacts
         run: |
           set -euo pipefail
-          cp -r public/skills dist/skills 2>/dev/null || echo "No skills directory"
-          cp public/checksums.json dist/checksums.json 2>/dev/null || echo "No checksums manifest"
-          cp public/checksums.sig dist/checksums.sig 2>/dev/null || echo "No checksums signature"
-          cp public/signing-public.pem dist/signing-public.pem 2>/dev/null || echo "No signing public key"
-          cp -r public/advisories dist/advisories 2>/dev/null || echo "No advisories directory"
-
-          cmp dist/checksums.json dist/advisories/checksums.json
-          cmp dist/checksums.sig dist/advisories/checksums.json.sig
+          test -f dist/skills/index.json
+          node scripts/ci/advisory_pages_artifacts.mjs verify-built --public-dir public --dist-dir dist
 
           echo "=== Dist contents ==="
           ls -la dist/

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -328,6 +328,12 @@ jobs:
           input_file: public/checksums.json
           signature_file: public/checksums.sig
 
+      - name: Publish advisory checksum aliases
+        run: |
+          set -euo pipefail
+          cp public/checksums.json public/advisories/checksums.json
+          cp public/checksums.sig public/advisories/checksums.json.sig
+
       - name: Verify generated public signing key matches canonical key
         run: |
           set -euo pipefail
@@ -439,11 +445,15 @@ jobs:
 
       - name: Copy skills data to dist
         run: |
+          set -euo pipefail
           cp -r public/skills dist/skills 2>/dev/null || echo "No skills directory"
           cp public/checksums.json dist/checksums.json 2>/dev/null || echo "No checksums manifest"
           cp public/checksums.sig dist/checksums.sig 2>/dev/null || echo "No checksums signature"
           cp public/signing-public.pem dist/signing-public.pem 2>/dev/null || echo "No signing public key"
           cp -r public/advisories dist/advisories 2>/dev/null || echo "No advisories directory"
+
+          cmp dist/checksums.json dist/advisories/checksums.json
+          cmp dist/checksums.sig dist/advisories/checksums.json.sig
 
           echo "=== Dist contents ==="
           ls -la dist/

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -412,3 +412,23 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+
+  verify-production:
+    name: Verify Production Advisory Endpoints
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+
+      - name: Verify deployed advisory endpoints
+        run: |
+          node scripts/ci/advisory_pages_artifacts.mjs verify-url \
+            --base-url https://clawsec.prompt.security \
+            --attempts 12 \
+            --retry-delay-ms 10000

--- a/.github/workflows/pages-verify.yml
+++ b/.github/workflows/pages-verify.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+
       - name: Verify signing key consistency (repo + docs)
         run: ./scripts/ci/verify_signing_key_consistency.sh
 
@@ -30,39 +36,6 @@ jobs:
           if [ -f advisories/ghsa-without-cve.json ]; then
             cp advisories/ghsa-without-cve.json public/advisories/ghsa-without-cve.json
           fi
-
-      - name: Generate advisory checksums manifest
-        run: |
-          set -euo pipefail
-
-          FILES_JSON="{}"
-          for file in public/advisories/*.json; do
-            REL_PATH="${file#public/}"
-            FILE_SHA=$(sha256sum "$file" | awk '{print $1}')
-            FILE_SIZE=$(stat -c%s "$file" 2>/dev/null || stat -f%z "$file")
-            FILES_JSON=$(jq \
-              --arg path "$REL_PATH" \
-              --arg sha "$FILE_SHA" \
-              --argjson size "$FILE_SIZE" \
-              '. + {($path): {sha256: $sha, size: $size, path: $path, url: ("https://clawsec.prompt.security/" + $path)}}' \
-              <<< "$FILES_JSON")
-          done
-
-          jq -n \
-            --arg schema_version "1" \
-            --arg algorithm "sha256" \
-            --arg version "1.1.0" \
-            --arg generated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            --arg repo "${{ github.repository }}" \
-            --argjson files "$FILES_JSON" \
-            '{
-              schema_version: $schema_version,
-              algorithm: $algorithm,
-              version: $version,
-              generated_at: $generated,
-              repository: $repo,
-              files: $files
-            }' > public/checksums.json
 
       - name: Generate ephemeral signing key for PR verification
         id: test_key
@@ -93,6 +66,9 @@ jobs:
           input_file: public/advisories/ghsa-without-cve.json
           signature_file: public/advisories/ghsa-without-cve.json.sig
 
+      - name: Generate advisory checksums manifest
+        run: node scripts/ci/advisory_pages_artifacts.mjs generate --public-dir public --repository "${{ github.repository }}"
+
       - name: Sign checksums and verify
         uses: ./.github/actions/sign-and-verify
         with:
@@ -100,17 +76,8 @@ jobs:
           input_file: public/checksums.json
           signature_file: public/checksums.sig
 
-      - name: Publish advisory checksum aliases
-        run: |
-          set -euo pipefail
-          cp public/checksums.json public/advisories/checksums.json
-          cp public/checksums.sig public/advisories/checksums.json.sig
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '20'
-          cache: 'npm'
+      - name: Publish advisory compatibility aliases
+        run: node scripts/ci/advisory_pages_artifacts.mjs publish-aliases --public-dir public
 
       - name: Install dependencies
         run: npm ci
@@ -124,13 +91,4 @@ jobs:
         run: |
           set -euo pipefail
           test -f dist/index.html
-          test -f public/advisories/feed.json.sig
-          if [ -f public/advisories/ghsa-without-cve.json ]; then
-            test -f public/advisories/ghsa-without-cve.json.sig
-          fi
-          test -f public/checksums.sig
-          test -f public/signing-public.pem
-          test -f dist/advisories/checksums.json
-          test -f dist/advisories/checksums.json.sig
-          cmp public/checksums.json dist/advisories/checksums.json
-          cmp public/checksums.sig dist/advisories/checksums.json.sig
+          node scripts/ci/advisory_pages_artifacts.mjs verify-built --public-dir public --dist-dir dist

--- a/.github/workflows/pages-verify.yml
+++ b/.github/workflows/pages-verify.yml
@@ -100,6 +100,12 @@ jobs:
           input_file: public/checksums.json
           signature_file: public/checksums.sig
 
+      - name: Publish advisory checksum aliases
+        run: |
+          set -euo pipefail
+          cp public/checksums.json public/advisories/checksums.json
+          cp public/checksums.sig public/advisories/checksums.json.sig
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -124,3 +130,7 @@ jobs:
           fi
           test -f public/checksums.sig
           test -f public/signing-public.pem
+          test -f dist/advisories/checksums.json
+          test -f dist/advisories/checksums.json.sig
+          cmp public/checksums.json dist/advisories/checksums.json
+          cmp public/checksums.sig dist/advisories/checksums.json.sig

--- a/.github/workflows/pages-verify.yml
+++ b/.github/workflows/pages-verify.yml
@@ -79,6 +79,12 @@ jobs:
       - name: Publish advisory compatibility aliases
         run: node scripts/ci/advisory_pages_artifacts.mjs publish-aliases --public-dir public
 
+      - name: Simulate release compatibility mirror
+        run: |
+          node scripts/ci/advisory_pages_artifacts.mjs publish-release-mirror \
+            --public-dir public \
+            --mirror-dir public/releases/latest/download
+
       - name: Install dependencies
         run: npm ci
 
@@ -92,3 +98,6 @@ jobs:
           set -euo pipefail
           test -f dist/index.html
           node scripts/ci/advisory_pages_artifacts.mjs verify-built --public-dir public --dist-dir dist
+
+      - name: Smoke-test built advisory endpoints
+        run: node scripts/ci/advisory_pages_artifacts.mjs smoke-http --dist-dir dist

--- a/scripts/ci/advisory_pages_artifacts.mjs
+++ b/scripts/ci/advisory_pages_artifacts.mjs
@@ -69,7 +69,11 @@ async function advisoryMappings(publicDir) {
   const ghsaPath = path.join(publicDir, "advisories/ghsa-without-cve.json");
   if (!(await fileExists(ghsaPath))) return [...RELEASE_MIRROR_MAPPINGS];
   await requireFile(path.join(publicDir, "advisories/ghsa-without-cve.json.sig"));
-  return [...RELEASE_MIRROR_MAPPINGS, ...OPTIONAL_GHSA_MAPPINGS];
+  return releaseMappings(true);
+}
+
+function releaseMappings(includeGhsa) {
+  return includeGhsa ? [...RELEASE_MIRROR_MAPPINGS, ...OPTIONAL_GHSA_MAPPINGS] : [...RELEASE_MIRROR_MAPPINGS];
 }
 
 async function copyMappings({ sourceRoot, destinationRoot, mappings }) {
@@ -228,7 +232,7 @@ async function stopServer(server) {
 }
 
 async function fetchArtifact(baseUrl, artifactPath) {
-  const response = await globalThis.fetch(`${baseUrl}/${artifactPath}`);
+  const response = await globalThis.fetch(`${baseUrl.replace(/\/+$/, "")}/${artifactPath}`);
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} for /${artifactPath}`);
   }
@@ -238,78 +242,105 @@ async function fetchArtifact(baseUrl, artifactPath) {
   };
 }
 
+async function verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMirror }) {
+  const fetched = new Map();
+  for (const artifactPath of ADVISORY_PUBLIC_CONTRACT) {
+    fetched.set(artifactPath, await fetchArtifact(baseUrl, artifactPath));
+  }
+  if (includeGhsa) {
+    for (const artifactPath of ["advisories/ghsa-without-cve.json", "advisories/ghsa-without-cve.json.sig"]) {
+      fetched.set(artifactPath, await fetchArtifact(baseUrl, artifactPath));
+    }
+  }
+
+  if (!fetched.get(CHECKSUM_ALIAS).contentType.startsWith("application/json")) {
+    throw new Error(`unexpected content type for /${CHECKSUM_ALIAS}`);
+  }
+
+  const checksums = fetched.get("checksums.json").body;
+  const checksumsSignature = fetched.get("checksums.sig").body;
+  const publicKey = fetched.get("signing-public.pem").body;
+  verifySignature(checksums, checksumsSignature, publicKey, "checksum manifest");
+  verifySignature(
+    fetched.get("advisories/feed.json").body,
+    fetched.get("advisories/feed.json.sig").body,
+    publicKey,
+    "advisory feed",
+  );
+
+  const manifest = JSON.parse(checksums.toString("utf8"));
+  verifyManifestEntry(manifest, "advisories/feed.json", fetched.get("advisories/feed.json").body);
+  verifyManifestEntry(manifest, "advisories/feed.json.sig", fetched.get("advisories/feed.json.sig").body);
+  if (includeGhsa) {
+    verifySignature(
+      fetched.get("advisories/ghsa-without-cve.json").body,
+      fetched.get("advisories/ghsa-without-cve.json.sig").body,
+      publicKey,
+      "provisional GHSA feed",
+    );
+    verifyManifestEntry(
+      manifest,
+      "advisories/ghsa-without-cve.json",
+      fetched.get("advisories/ghsa-without-cve.json").body,
+    );
+    verifyManifestEntry(
+      manifest,
+      "advisories/ghsa-without-cve.json.sig",
+      fetched.get("advisories/ghsa-without-cve.json.sig").body,
+    );
+  }
+
+  if (!checksums.equals(fetched.get(CHECKSUM_ALIAS).body)) throw new Error("HTTP checksum alias differs from root");
+  if (!checksumsSignature.equals(fetched.get(CHECKSUM_SIGNATURE_ALIAS).body)) {
+    throw new Error("HTTP checksum signature alias differs from root");
+  }
+  if (!publicKey.equals(fetched.get(PUBLIC_KEY_ALIAS).body)) throw new Error("HTTP signing-key alias differs from root");
+
+  if (includeReleaseMirror) {
+    for (const [source, destination] of releaseMappings(includeGhsa)) {
+      const [sourceArtifact, mirroredArtifact] = await Promise.all([
+        fetchArtifact(baseUrl, source),
+        fetchArtifact(baseUrl, `releases/latest/download/${destination}`),
+      ]);
+      if (!sourceArtifact.body.equals(mirroredArtifact.body)) {
+        throw new Error(`HTTP release mirror differs: ${destination}`);
+      }
+    }
+  }
+}
+
 export async function smokeTestBuiltAdvisoryEndpoints({ distDir = "dist" } = {}) {
   const { server, baseUrl } = await startStaticServer(distDir);
   try {
-    const fetched = new Map();
-    for (const artifactPath of ADVISORY_PUBLIC_CONTRACT) {
-      fetched.set(artifactPath, await fetchArtifact(baseUrl, artifactPath));
-    }
-    const hasGhsaFeed = await fileExists(path.join(distDir, "advisories/ghsa-without-cve.json"));
-    if (hasGhsaFeed) {
-      for (const artifactPath of ["advisories/ghsa-without-cve.json", "advisories/ghsa-without-cve.json.sig"]) {
-        fetched.set(artifactPath, await fetchArtifact(baseUrl, artifactPath));
-      }
-    }
-
-    if (!fetched.get(CHECKSUM_ALIAS).contentType.startsWith("application/json")) {
-      throw new Error(`unexpected content type for /${CHECKSUM_ALIAS}`);
-    }
-
-    const checksums = fetched.get("checksums.json").body;
-    const checksumsSignature = fetched.get("checksums.sig").body;
-    const publicKey = fetched.get("signing-public.pem").body;
-    verifySignature(checksums, checksumsSignature, publicKey, "checksum manifest");
-    verifySignature(
-      fetched.get("advisories/feed.json").body,
-      fetched.get("advisories/feed.json.sig").body,
-      publicKey,
-      "advisory feed",
-    );
-
-    const manifest = JSON.parse(checksums.toString("utf8"));
-    verifyManifestEntry(manifest, "advisories/feed.json", fetched.get("advisories/feed.json").body);
-    verifyManifestEntry(manifest, "advisories/feed.json.sig", fetched.get("advisories/feed.json.sig").body);
-    if (hasGhsaFeed) {
-      verifySignature(
-        fetched.get("advisories/ghsa-without-cve.json").body,
-        fetched.get("advisories/ghsa-without-cve.json.sig").body,
-        publicKey,
-        "provisional GHSA feed",
-      );
-      verifyManifestEntry(
-        manifest,
-        "advisories/ghsa-without-cve.json",
-        fetched.get("advisories/ghsa-without-cve.json").body,
-      );
-      verifyManifestEntry(
-        manifest,
-        "advisories/ghsa-without-cve.json.sig",
-        fetched.get("advisories/ghsa-without-cve.json.sig").body,
-      );
-    }
-
-    if (!checksums.equals(fetched.get(CHECKSUM_ALIAS).body)) throw new Error("HTTP checksum alias differs from root");
-    if (!checksumsSignature.equals(fetched.get(CHECKSUM_SIGNATURE_ALIAS).body)) {
-      throw new Error("HTTP checksum signature alias differs from root");
-    }
-    if (!publicKey.equals(fetched.get(PUBLIC_KEY_ALIAS).body)) throw new Error("HTTP signing-key alias differs from root");
-
-    const mirrorDir = path.join(distDir, "releases/latest/download");
-    if (await directoryExists(mirrorDir)) {
-      for (const [source, destination] of await advisoryMappings(distDir)) {
-        const [sourceArtifact, mirroredArtifact] = await Promise.all([
-          fetchArtifact(baseUrl, source),
-          fetchArtifact(baseUrl, `releases/latest/download/${destination}`),
-        ]);
-        if (!sourceArtifact.body.equals(mirroredArtifact.body)) {
-          throw new Error(`HTTP release mirror differs: ${destination}`);
-        }
-      }
-    }
+    await verifyAdvisoryEndpoints({
+      baseUrl,
+      includeGhsa: await fileExists(path.join(distDir, "advisories/ghsa-without-cve.json")),
+      includeReleaseMirror: await directoryExists(path.join(distDir, "releases/latest/download")),
+    });
   } finally {
     await stopServer(server);
   }
+}
+
+export async function verifyLiveAdvisoryEndpoints({
+  baseUrl = "https://clawsec.prompt.security",
+  attempts = 12,
+  retryDelayMs = 10_000,
+} = {}) {
+  let lastError;
+  for (let attempt = 1; attempt <= Number(attempts); attempt += 1) {
+    try {
+      await verifyAdvisoryEndpoints({ baseUrl, includeGhsa: true, includeReleaseMirror: true });
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < Number(attempts)) {
+        process.stderr.write(`Production verification attempt ${attempt} failed: ${error.message}; retrying\n`);
+        await new Promise((resolve) => globalThis.setTimeout(resolve, Number(retryDelayMs)));
+      }
+    }
+  }
+  throw lastError;
 }
 
 function parseOptions(args) {
@@ -324,6 +355,9 @@ function parseOptions(args) {
     else if (option === "--dist-dir") options.distDir = value;
     else if (option === "--mirror-dir") options.mirrorDir = value;
     else if (option === "--repository") options.repository = value;
+    else if (option === "--base-url") options.baseUrl = value;
+    else if (option === "--attempts") options.attempts = Number(value);
+    else if (option === "--retry-delay-ms") options.retryDelayMs = Number(value);
     else throw new Error(`unknown option: ${option}`);
     index += 1;
   }
@@ -348,9 +382,12 @@ async function main() {
   } else if (command === "smoke-http") {
     await smokeTestBuiltAdvisoryEndpoints(options);
     process.stdout.write("Smoke-tested built advisory endpoints over HTTP\n");
+  } else if (command === "verify-url") {
+    await verifyLiveAdvisoryEndpoints(options);
+    process.stdout.write(`Verified deployed advisory endpoints at ${options.baseUrl}\n`);
   } else {
     throw new Error(
-      "usage: advisory_pages_artifacts.mjs <generate|publish-aliases|publish-release-mirror|verify-built|smoke-http> [options]",
+      "usage: advisory_pages_artifacts.mjs <generate|publish-aliases|publish-release-mirror|verify-built|smoke-http|verify-url> [options]",
     );
   }
 }

--- a/scripts/ci/advisory_pages_artifacts.mjs
+++ b/scripts/ci/advisory_pages_artifacts.mjs
@@ -312,25 +312,39 @@ async function verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMir
 export async function smokeTestBuiltAdvisoryEndpoints({ distDir = "dist" } = {}) {
   const { server, baseUrl } = await startStaticServer(distDir);
   try {
-    await verifyAdvisoryEndpoints({
+    await verifyLiveAdvisoryEndpoints({
       baseUrl,
+      attempts: 1,
+      retryDelayMs: 0,
       includeGhsa: await fileExists(path.join(distDir, "advisories/ghsa-without-cve.json")),
-      includeReleaseMirror: await directoryExists(path.join(distDir, "releases/latest/download")),
     });
   } finally {
     await stopServer(server);
   }
 }
 
+async function probeReleaseMirror(baseUrl) {
+  const probePath = "releases/latest/download/checksums.json";
+  const response = await globalThis.fetch(`${baseUrl.replace(/\/+$/, "")}/${probePath}`);
+  if (response.ok) return true;
+  if (response.status === 404) {
+    process.stderr.write(`Release compatibility mirror is absent at /${probePath}; skipping mirror verification\n`);
+    return false;
+  }
+  throw new Error(`HTTP ${response.status} while probing /${probePath}`);
+}
+
 export async function verifyLiveAdvisoryEndpoints({
   baseUrl = "https://clawsec.prompt.security",
   attempts = 12,
   retryDelayMs = 10_000,
+  includeGhsa = true,
 } = {}) {
   let lastError;
   for (let attempt = 1; attempt <= Number(attempts); attempt += 1) {
     try {
-      await verifyAdvisoryEndpoints({ baseUrl, includeGhsa: true, includeReleaseMirror: true });
+      const includeReleaseMirror = await probeReleaseMirror(baseUrl);
+      await verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMirror });
       return;
     } catch (error) {
       lastError = error;

--- a/scripts/ci/advisory_pages_artifacts.mjs
+++ b/scripts/ci/advisory_pages_artifacts.mjs
@@ -2,6 +2,7 @@
 
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import http from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -9,13 +10,50 @@ const CHECKSUM_ALIAS = "advisories/checksums.json";
 const CHECKSUM_SIGNATURE_ALIAS = "advisories/checksums.json.sig";
 const PUBLIC_KEY_ALIAS = "advisories/feed-signing-public.pem";
 
+export const ADVISORY_PUBLIC_CONTRACT = Object.freeze([
+  "checksums.json",
+  "checksums.sig",
+  "signing-public.pem",
+  "advisories/feed.json",
+  "advisories/feed.json.sig",
+  CHECKSUM_ALIAS,
+  CHECKSUM_SIGNATURE_ALIAS,
+  PUBLIC_KEY_ALIAS,
+]);
+
+export const RELEASE_MIRROR_MAPPINGS = Object.freeze([
+  ["advisories/feed.json", "feed.json"],
+  ["advisories/feed.json", "advisories/feed.json"],
+  ["advisories/feed.json.sig", "feed.json.sig"],
+  ["advisories/feed.json.sig", "advisories/feed.json.sig"],
+  ["checksums.json", "checksums.json"],
+  ["checksums.sig", "checksums.sig"],
+  ["signing-public.pem", "signing-public.pem"],
+]);
+
+const OPTIONAL_GHSA_MAPPINGS = Object.freeze([
+  ["advisories/ghsa-without-cve.json", "ghsa-without-cve.json"],
+  ["advisories/ghsa-without-cve.json", "advisories/ghsa-without-cve.json"],
+  ["advisories/ghsa-without-cve.json.sig", "ghsa-without-cve.json.sig"],
+  ["advisories/ghsa-without-cve.json.sig", "advisories/ghsa-without-cve.json.sig"],
+]);
+
 function sha256(content) {
   return crypto.createHash("sha256").update(content).digest("hex");
 }
 
-async function requireFile(filePath) {
+async function fileExists(filePath) {
   const stat = await fs.stat(filePath).catch(() => null);
-  if (!stat?.isFile()) {
+  return stat?.isFile() === true;
+}
+
+async function directoryExists(directoryPath) {
+  const stat = await fs.stat(directoryPath).catch(() => null);
+  return stat?.isDirectory() === true;
+}
+
+async function requireFile(filePath) {
+  if (!(await fileExists(filePath))) {
     throw new Error(`required file is missing: ${filePath}`);
   }
 }
@@ -24,6 +62,24 @@ async function assertSameFile(firstPath, secondPath) {
   const [first, second] = await Promise.all([fs.readFile(firstPath), fs.readFile(secondPath)]);
   if (!first.equals(second)) {
     throw new Error(`files differ: ${firstPath} != ${secondPath}`);
+  }
+}
+
+async function advisoryMappings(publicDir) {
+  const ghsaPath = path.join(publicDir, "advisories/ghsa-without-cve.json");
+  if (!(await fileExists(ghsaPath))) return [...RELEASE_MIRROR_MAPPINGS];
+  await requireFile(path.join(publicDir, "advisories/ghsa-without-cve.json.sig"));
+  return [...RELEASE_MIRROR_MAPPINGS, ...OPTIONAL_GHSA_MAPPINGS];
+}
+
+async function copyMappings({ sourceRoot, destinationRoot, mappings }) {
+  await Promise.all(mappings.map(([source]) => requireFile(path.join(sourceRoot, source))));
+  for (const [source, destination] of mappings) {
+    const sourcePath = path.join(sourceRoot, source);
+    const destinationPath = path.join(destinationRoot, destination);
+    await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+    await fs.copyFile(sourcePath, destinationPath);
+    await assertSameFile(sourcePath, destinationPath);
   }
 }
 
@@ -72,36 +128,28 @@ export async function generateAdvisoryChecksums({
 }
 
 export async function publishAdvisoryAliases({ publicDir = "public" } = {}) {
-  const aliases = [
-    ["checksums.json", CHECKSUM_ALIAS],
-    ["checksums.sig", CHECKSUM_SIGNATURE_ALIAS],
-    ["signing-public.pem", PUBLIC_KEY_ALIAS],
-  ];
+  await copyMappings({
+    sourceRoot: publicDir,
+    destinationRoot: publicDir,
+    mappings: [
+      ["checksums.json", CHECKSUM_ALIAS],
+      ["checksums.sig", CHECKSUM_SIGNATURE_ALIAS],
+      ["signing-public.pem", PUBLIC_KEY_ALIAS],
+    ],
+  });
+}
 
-  await Promise.all(aliases.map(([source]) => requireFile(path.join(publicDir, source))));
-  await fs.mkdir(path.join(publicDir, "advisories"), { recursive: true });
-
-  for (const [source, destination] of aliases) {
-    const sourcePath = path.join(publicDir, source);
-    const destinationPath = path.join(publicDir, destination);
-    await fs.copyFile(sourcePath, destinationPath);
-    await assertSameFile(sourcePath, destinationPath);
-  }
+export async function publishReleaseCompatibilityMirror({
+  publicDir = "public",
+  mirrorDir = path.join(publicDir, "releases/latest/download"),
+} = {}) {
+  const mappings = await advisoryMappings(publicDir);
+  await copyMappings({ sourceRoot: publicDir, destinationRoot: mirrorDir, mappings });
 }
 
 export async function verifyBuiltAdvisoryArtifacts({ publicDir = "public", distDir = "dist" } = {}) {
-  const requiredArtifacts = [
-    "checksums.json",
-    "checksums.sig",
-    "signing-public.pem",
-    "advisories/feed.json",
-    "advisories/feed.json.sig",
-    CHECKSUM_ALIAS,
-    CHECKSUM_SIGNATURE_ALIAS,
-    PUBLIC_KEY_ALIAS,
-  ];
-
-  if (await fs.stat(path.join(publicDir, "advisories/ghsa-without-cve.json")).catch(() => null)) {
+  const requiredArtifacts = [...ADVISORY_PUBLIC_CONTRACT];
+  if (await fileExists(path.join(publicDir, "advisories/ghsa-without-cve.json"))) {
     requiredArtifacts.push("advisories/ghsa-without-cve.json", "advisories/ghsa-without-cve.json.sig");
   }
 
@@ -116,6 +164,152 @@ export async function verifyBuiltAdvisoryArtifacts({ publicDir = "public", distD
   await assertSameFile(path.join(distDir, "checksums.json"), path.join(distDir, CHECKSUM_ALIAS));
   await assertSameFile(path.join(distDir, "checksums.sig"), path.join(distDir, CHECKSUM_SIGNATURE_ALIAS));
   await assertSameFile(path.join(distDir, "signing-public.pem"), path.join(distDir, PUBLIC_KEY_ALIAS));
+
+  const publicMirrorDir = path.join(publicDir, "releases/latest/download");
+  if (await directoryExists(publicMirrorDir)) {
+    const mappings = await advisoryMappings(publicDir);
+    for (const [source, destination] of mappings) {
+      const sourcePath = path.join(publicDir, source);
+      const publicMirrorPath = path.join(publicMirrorDir, destination);
+      const distMirrorPath = path.join(distDir, "releases/latest/download", destination);
+      await requireFile(publicMirrorPath);
+      await requireFile(distMirrorPath);
+      await assertSameFile(sourcePath, publicMirrorPath);
+      await assertSameFile(publicMirrorPath, distMirrorPath);
+    }
+  }
+}
+
+function verifySignature(payload, signatureRaw, publicKey, label) {
+  const signature = Buffer.from(signatureRaw.toString("utf8").trim(), "base64");
+  if (!crypto.verify(null, payload, publicKey, signature)) {
+    throw new Error(`${label} signature verification failed`);
+  }
+}
+
+function verifyManifestEntry(manifest, entryName, content) {
+  const entry = manifest.files?.[entryName];
+  const expected = typeof entry === "string" ? entry : entry?.sha256;
+  if (expected !== sha256(content)) {
+    throw new Error(`checksum mismatch for ${entryName}`);
+  }
+}
+
+async function startStaticServer(distDir) {
+  const root = path.resolve(distDir);
+  const server = http.createServer((request, response) => {
+    void (async () => {
+      const pathname = decodeURIComponent(new URL(request.url || "/", "http://127.0.0.1").pathname);
+      const relativePath = pathname.replace(/^\/+/, "");
+      const filePath = path.resolve(root, relativePath);
+      if (filePath !== root && !filePath.startsWith(`${root}${path.sep}`)) {
+        response.writeHead(400).end("invalid path");
+        return;
+      }
+      const content = await fs.readFile(filePath);
+      const contentType = filePath.endsWith(".json")
+        ? "application/json"
+        : filePath.endsWith(".sig")
+          ? "application/pgp-signature"
+          : "text/plain";
+      response.writeHead(200, { "content-type": contentType }).end(content);
+    })().catch((error) => {
+      response.writeHead(error?.code === "ENOENT" ? 404 : 500).end(error?.message || String(error));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("failed to start local artifact server");
+  return { server, baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+async function stopServer(server) {
+  await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+async function fetchArtifact(baseUrl, artifactPath) {
+  const response = await globalThis.fetch(`${baseUrl}/${artifactPath}`);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} for /${artifactPath}`);
+  }
+  return {
+    body: Buffer.from(await response.arrayBuffer()),
+    contentType: response.headers.get("content-type") || "",
+  };
+}
+
+export async function smokeTestBuiltAdvisoryEndpoints({ distDir = "dist" } = {}) {
+  const { server, baseUrl } = await startStaticServer(distDir);
+  try {
+    const fetched = new Map();
+    for (const artifactPath of ADVISORY_PUBLIC_CONTRACT) {
+      fetched.set(artifactPath, await fetchArtifact(baseUrl, artifactPath));
+    }
+    const hasGhsaFeed = await fileExists(path.join(distDir, "advisories/ghsa-without-cve.json"));
+    if (hasGhsaFeed) {
+      for (const artifactPath of ["advisories/ghsa-without-cve.json", "advisories/ghsa-without-cve.json.sig"]) {
+        fetched.set(artifactPath, await fetchArtifact(baseUrl, artifactPath));
+      }
+    }
+
+    if (!fetched.get(CHECKSUM_ALIAS).contentType.startsWith("application/json")) {
+      throw new Error(`unexpected content type for /${CHECKSUM_ALIAS}`);
+    }
+
+    const checksums = fetched.get("checksums.json").body;
+    const checksumsSignature = fetched.get("checksums.sig").body;
+    const publicKey = fetched.get("signing-public.pem").body;
+    verifySignature(checksums, checksumsSignature, publicKey, "checksum manifest");
+    verifySignature(
+      fetched.get("advisories/feed.json").body,
+      fetched.get("advisories/feed.json.sig").body,
+      publicKey,
+      "advisory feed",
+    );
+
+    const manifest = JSON.parse(checksums.toString("utf8"));
+    verifyManifestEntry(manifest, "advisories/feed.json", fetched.get("advisories/feed.json").body);
+    verifyManifestEntry(manifest, "advisories/feed.json.sig", fetched.get("advisories/feed.json.sig").body);
+    if (hasGhsaFeed) {
+      verifySignature(
+        fetched.get("advisories/ghsa-without-cve.json").body,
+        fetched.get("advisories/ghsa-without-cve.json.sig").body,
+        publicKey,
+        "provisional GHSA feed",
+      );
+      verifyManifestEntry(
+        manifest,
+        "advisories/ghsa-without-cve.json",
+        fetched.get("advisories/ghsa-without-cve.json").body,
+      );
+      verifyManifestEntry(
+        manifest,
+        "advisories/ghsa-without-cve.json.sig",
+        fetched.get("advisories/ghsa-without-cve.json.sig").body,
+      );
+    }
+
+    if (!checksums.equals(fetched.get(CHECKSUM_ALIAS).body)) throw new Error("HTTP checksum alias differs from root");
+    if (!checksumsSignature.equals(fetched.get(CHECKSUM_SIGNATURE_ALIAS).body)) {
+      throw new Error("HTTP checksum signature alias differs from root");
+    }
+    if (!publicKey.equals(fetched.get(PUBLIC_KEY_ALIAS).body)) throw new Error("HTTP signing-key alias differs from root");
+
+    const mirrorDir = path.join(distDir, "releases/latest/download");
+    if (await directoryExists(mirrorDir)) {
+      for (const [source, destination] of await advisoryMappings(distDir)) {
+        const [sourceArtifact, mirroredArtifact] = await Promise.all([
+          fetchArtifact(baseUrl, source),
+          fetchArtifact(baseUrl, `releases/latest/download/${destination}`),
+        ]);
+        if (!sourceArtifact.body.equals(mirroredArtifact.body)) {
+          throw new Error(`HTTP release mirror differs: ${destination}`);
+        }
+      }
+    }
+  } finally {
+    await stopServer(server);
+  }
 }
 
 function parseOptions(args) {
@@ -128,6 +322,7 @@ function parseOptions(args) {
     }
     if (option === "--public-dir") options.publicDir = value;
     else if (option === "--dist-dir") options.distDir = value;
+    else if (option === "--mirror-dir") options.mirrorDir = value;
     else if (option === "--repository") options.repository = value;
     else throw new Error(`unknown option: ${option}`);
     index += 1;
@@ -144,11 +339,19 @@ async function main() {
   } else if (command === "publish-aliases") {
     await publishAdvisoryAliases(options);
     process.stdout.write("Published advisory checksum and signing-key aliases\n");
+  } else if (command === "publish-release-mirror") {
+    await publishReleaseCompatibilityMirror(options);
+    process.stdout.write("Published release compatibility mirror\n");
   } else if (command === "verify-built") {
     await verifyBuiltAdvisoryArtifacts(options);
     process.stdout.write("Verified built advisory artifacts\n");
+  } else if (command === "smoke-http") {
+    await smokeTestBuiltAdvisoryEndpoints(options);
+    process.stdout.write("Smoke-tested built advisory endpoints over HTTP\n");
   } else {
-    throw new Error("usage: advisory_pages_artifacts.mjs <generate|publish-aliases|verify-built> [options]");
+    throw new Error(
+      "usage: advisory_pages_artifacts.mjs <generate|publish-aliases|publish-release-mirror|verify-built|smoke-http> [options]",
+    );
   }
 }
 

--- a/scripts/ci/advisory_pages_artifacts.mjs
+++ b/scripts/ci/advisory_pages_artifacts.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CHECKSUM_ALIAS = "advisories/checksums.json";
+const CHECKSUM_SIGNATURE_ALIAS = "advisories/checksums.json.sig";
+const PUBLIC_KEY_ALIAS = "advisories/feed-signing-public.pem";
+
+function sha256(content) {
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+async function requireFile(filePath) {
+  const stat = await fs.stat(filePath).catch(() => null);
+  if (!stat?.isFile()) {
+    throw new Error(`required file is missing: ${filePath}`);
+  }
+}
+
+async function assertSameFile(firstPath, secondPath) {
+  const [first, second] = await Promise.all([fs.readFile(firstPath), fs.readFile(secondPath)]);
+  if (!first.equals(second)) {
+    throw new Error(`files differ: ${firstPath} != ${secondPath}`);
+  }
+}
+
+export async function generateAdvisoryChecksums({
+  publicDir = "public",
+  repository = process.env.GITHUB_REPOSITORY || "prompt-security/clawsec",
+  generatedAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+} = {}) {
+  const advisoryDir = path.join(publicDir, "advisories");
+  const entries = await fs.readdir(advisoryDir, { withFileTypes: true });
+  const artifactNames = entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((name) => name.endsWith(".json") || name.endsWith(".json.sig"))
+    .filter((name) => name !== "checksums.json" && name !== "checksums.json.sig")
+    .sort((left, right) => left.localeCompare(right));
+
+  if (artifactNames.length === 0) {
+    throw new Error(`no advisory JSON artifacts found in ${advisoryDir}`);
+  }
+
+  const files = {};
+  for (const name of artifactNames) {
+    const absolutePath = path.join(advisoryDir, name);
+    const content = await fs.readFile(absolutePath);
+    const relativePath = path.posix.join("advisories", name);
+    files[relativePath] = {
+      sha256: sha256(content),
+      size: content.byteLength,
+      path: relativePath,
+      url: `https://clawsec.prompt.security/${relativePath}`,
+    };
+  }
+
+  const manifest = {
+    schema_version: "1",
+    algorithm: "sha256",
+    version: "1.1.0",
+    generated_at: generatedAt,
+    repository,
+    files,
+  };
+  const outputPath = path.join(publicDir, "checksums.json");
+  await fs.writeFile(outputPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  return { manifest, outputPath };
+}
+
+export async function publishAdvisoryAliases({ publicDir = "public" } = {}) {
+  const aliases = [
+    ["checksums.json", CHECKSUM_ALIAS],
+    ["checksums.sig", CHECKSUM_SIGNATURE_ALIAS],
+    ["signing-public.pem", PUBLIC_KEY_ALIAS],
+  ];
+
+  await Promise.all(aliases.map(([source]) => requireFile(path.join(publicDir, source))));
+  await fs.mkdir(path.join(publicDir, "advisories"), { recursive: true });
+
+  for (const [source, destination] of aliases) {
+    const sourcePath = path.join(publicDir, source);
+    const destinationPath = path.join(publicDir, destination);
+    await fs.copyFile(sourcePath, destinationPath);
+    await assertSameFile(sourcePath, destinationPath);
+  }
+}
+
+export async function verifyBuiltAdvisoryArtifacts({ publicDir = "public", distDir = "dist" } = {}) {
+  const requiredArtifacts = [
+    "checksums.json",
+    "checksums.sig",
+    "signing-public.pem",
+    "advisories/feed.json",
+    "advisories/feed.json.sig",
+    CHECKSUM_ALIAS,
+    CHECKSUM_SIGNATURE_ALIAS,
+    PUBLIC_KEY_ALIAS,
+  ];
+
+  if (await fs.stat(path.join(publicDir, "advisories/ghsa-without-cve.json")).catch(() => null)) {
+    requiredArtifacts.push("advisories/ghsa-without-cve.json", "advisories/ghsa-without-cve.json.sig");
+  }
+
+  for (const relativePath of requiredArtifacts) {
+    const publicPath = path.join(publicDir, relativePath);
+    const distPath = path.join(distDir, relativePath);
+    await requireFile(publicPath);
+    await requireFile(distPath);
+    await assertSameFile(publicPath, distPath);
+  }
+
+  await assertSameFile(path.join(distDir, "checksums.json"), path.join(distDir, CHECKSUM_ALIAS));
+  await assertSameFile(path.join(distDir, "checksums.sig"), path.join(distDir, CHECKSUM_SIGNATURE_ALIAS));
+  await assertSameFile(path.join(distDir, "signing-public.pem"), path.join(distDir, PUBLIC_KEY_ALIAS));
+}
+
+function parseOptions(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const option = args[index];
+    const value = args[index + 1];
+    if (!value || !option.startsWith("--")) {
+      throw new Error(`invalid option: ${option}`);
+    }
+    if (option === "--public-dir") options.publicDir = value;
+    else if (option === "--dist-dir") options.distDir = value;
+    else if (option === "--repository") options.repository = value;
+    else throw new Error(`unknown option: ${option}`);
+    index += 1;
+  }
+  return options;
+}
+
+async function main() {
+  const [command, ...args] = process.argv.slice(2);
+  const options = parseOptions(args);
+  if (command === "generate") {
+    const { outputPath } = await generateAdvisoryChecksums(options);
+    process.stdout.write(`Generated ${outputPath}\n`);
+  } else if (command === "publish-aliases") {
+    await publishAdvisoryAliases(options);
+    process.stdout.write("Published advisory checksum and signing-key aliases\n");
+  } else if (command === "verify-built") {
+    await verifyBuiltAdvisoryArtifacts(options);
+    process.stdout.write("Verified built advisory artifacts\n");
+  } else {
+    throw new Error("usage: advisory_pages_artifacts.mjs <generate|publish-aliases|verify-built> [options]");
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message || String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test-deploy-pages-checksums.mjs
+++ b/scripts/test-deploy-pages-checksums.mjs
@@ -3,10 +3,15 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
+  ADVISORY_PUBLIC_CONTRACT,
+  RELEASE_MIRROR_MAPPINGS,
   generateAdvisoryChecksums,
   publishAdvisoryAliases,
+  publishReleaseCompatibilityMirror,
+  smokeTestBuiltAdvisoryEndpoints,
   verifyBuiltAdvisoryArtifacts,
 } from "./ci/advisory_pages_artifacts.mjs";
 
@@ -34,6 +39,7 @@ function assertProductionOrdering(source, workflowName) {
   const signChecksumsIndex = stepIndex(source, "Sign checksums and verify");
   const aliasesIndex = stepIndex(source, "Publish advisory compatibility aliases");
   const buildIndex = stepIndex(source, workflowName === "Deploy Pages" ? "Build" : "Build site");
+  const smokeIndex = stepIndex(source, "Smoke-test built advisory endpoints");
 
   assert.ok(setupNodeIndex < generateChecksumsIndex, `${workflowName} must pin Node before running the artifact helper`);
   assert.ok(signFeedIndex < generateChecksumsIndex, `${workflowName} must checksum feed.json.sig`);
@@ -41,6 +47,7 @@ function assertProductionOrdering(source, workflowName) {
   assert.ok(generateChecksumsIndex < signChecksumsIndex, `${workflowName} must sign the refreshed checksum manifest`);
   assert.ok(signChecksumsIndex < aliasesIndex, `${workflowName} must publish aliases only after signing checksums.json`);
   assert.ok(aliasesIndex < buildIndex, `${workflowName} must publish aliases before Vite copies public assets`);
+  assert.ok(buildIndex < smokeIndex, `${workflowName} must smoke-test endpoints after the Vite build`);
 
   assert.match(
     stepBody(source, "Generate advisory checksums manifest"),
@@ -51,6 +58,11 @@ function assertProductionOrdering(source, workflowName) {
     stepBody(source, "Publish advisory compatibility aliases"),
     /node scripts\/ci\/advisory_pages_artifacts\.mjs publish-aliases/,
     `${workflowName} must use the shared alias publisher`,
+  );
+  assert.match(
+    stepBody(source, "Smoke-test built advisory endpoints"),
+    /node scripts\/ci\/advisory_pages_artifacts\.mjs smoke-http/,
+    `${workflowName} must exercise the built endpoints over HTTP`,
   );
 }
 
@@ -78,20 +90,69 @@ assert.match(
   "Pages Verify must validate the same built advisory artifacts as production",
 );
 
-const mirrorBlockIndex = workflow.indexOf(
-  "# Mirror advisories feed + signatures at the path referenced by suite docs/heartbeat",
-);
-assert.notEqual(mirrorBlockIndex, -1, "missing advisory release mirror block");
-const mirrorBlock = workflow.slice(mirrorBlockIndex, workflow.indexOf("if [ -f \"public/checksums.json\"", mirrorBlockIndex));
+const productionMirrorStep = stepBody(workflow, "Get latest clawsec-suite release URL");
 assert.match(
-  mirrorBlock,
-  /cp "public\/advisories\/ghsa-without-cve\.json" "\$MIRROR_LATEST_DIR\/ghsa-without-cve\.json"/,
-  "GHSA provisional feed must remain at the release-root compatibility path",
+  productionMirrorStep,
+  /advisory_pages_artifacts\.mjs publish-release-mirror/,
+  "Deploy Pages must use the tested release compatibility mirror",
+);
+assert.doesNotMatch(
+  productionMirrorStep,
+  /cp "public\/(?:advisories|checksums|signing-public)/,
+  "release compatibility files must not be maintained as duplicate workflow copy lists",
 );
 assert.match(
-  mirrorBlock,
-  /cp "public\/advisories\/ghsa-without-cve\.json\.sig" "\$MIRROR_LATEST_DIR\/ghsa-without-cve\.json\.sig"/,
-  "GHSA provisional signature must remain at the release-root compatibility path",
+  stepBody(verifyWorkflow, "Simulate release compatibility mirror"),
+  /advisory_pages_artifacts\.mjs publish-release-mirror/,
+  "Pages Verify must simulate the production release compatibility mirror",
+);
+
+async function collectContractSources(entryPath) {
+  const stat = await fs.stat(entryPath);
+  if (stat.isFile()) return [entryPath];
+  const files = [];
+  for (const entry of await fs.readdir(entryPath, { withFileTypes: true })) {
+    if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+    const childPath = path.join(entryPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await collectContractSources(childPath));
+    } else if (/\.(?:json|md|mjs|sh|ts)$/.test(entry.name) && !/^(?:feed|ghsa-without-cve)\.json$/.test(entry.name)) {
+      files.push(childPath);
+    }
+  }
+  return files;
+}
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const contractSources = [];
+for (const relativePath of ["README.md", "wiki", "skills"]) {
+  contractSources.push(...await collectContractSources(path.join(repositoryRoot, relativePath)));
+}
+const referencedAdvisoryArtifacts = new Set();
+const advisoryArtifactPattern = /advisories\/(?:feed\.json(?:\.sig)?|checksums\.json(?:\.sig)?|feed-signing-public\.pem)/g;
+for (const sourcePath of contractSources) {
+  const source = await fs.readFile(sourcePath, "utf8");
+  for (const match of source.matchAll(advisoryArtifactPattern)) referencedAdvisoryArtifacts.add(match[0]);
+}
+const documentedAdvisoryContract = ADVISORY_PUBLIC_CONTRACT.filter((artifact) => artifact.startsWith("advisories/"));
+for (const artifact of referencedAdvisoryArtifacts) {
+  assert.ok(documentedAdvisoryContract.includes(artifact), `skill or instruction expects unpublished artifact: ${artifact}`);
+}
+for (const artifact of documentedAdvisoryContract) {
+  assert.ok(referencedAdvisoryArtifacts.has(artifact), `published advisory artifact has no skill or instruction consumer: ${artifact}`);
+}
+assert.deepEqual(
+  [...new Set(RELEASE_MIRROR_MAPPINGS.map(([, destination]) => destination))].sort(),
+  [
+    "advisories/feed.json",
+    "advisories/feed.json.sig",
+    "checksums.json",
+    "checksums.sig",
+    "feed.json",
+    "feed.json.sig",
+    "signing-public.pem",
+  ],
+  "release compatibility mirror must preserve the documented root and nested artifacts",
 );
 
 const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "clawsec-pages-checksums-"));
@@ -101,11 +162,15 @@ try {
   const distDir = path.join(tempRoot, "dist");
   await fs.mkdir(advisoryDir, { recursive: true });
 
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const sign = (content) => `${crypto.sign(null, Buffer.from(content), privateKey).toString("base64")}\n`;
+  const feedRaw = "{\"advisories\":[]}\n";
+  const ghsaRaw = "{\"advisories\":[]}\n";
   const artifacts = {
-    "feed.json": "{\"advisories\":[]}\n",
-    "feed.json.sig": "feed-signature\n",
-    "ghsa-without-cve.json": "{\"advisories\":[]}\n",
-    "ghsa-without-cve.json.sig": "ghsa-signature\n",
+    "feed.json": feedRaw,
+    "feed.json.sig": sign(feedRaw),
+    "ghsa-without-cve.json": ghsaRaw,
+    "ghsa-without-cve.json.sig": sign(ghsaRaw),
   };
   await Promise.all(
     Object.entries(artifacts).map(([name, content]) => fs.writeFile(path.join(advisoryDir, name), content)),
@@ -131,11 +196,14 @@ try {
     assert.equal(entry.size, Buffer.byteLength(content));
   }
 
-  await fs.writeFile(path.join(publicDir, "checksums.sig"), "checksums-signature\n");
-  await fs.writeFile(path.join(publicDir, "signing-public.pem"), "public-key\n");
+  const checksumsRaw = await fs.readFile(path.join(publicDir, "checksums.json"));
+  await fs.writeFile(path.join(publicDir, "checksums.sig"), sign(checksumsRaw));
+  await fs.writeFile(path.join(publicDir, "signing-public.pem"), publicKey.export({ type: "spki", format: "pem" }));
   await publishAdvisoryAliases({ publicDir });
+  await publishReleaseCompatibilityMirror({ publicDir });
   await fs.cp(publicDir, distDir, { recursive: true });
   await verifyBuiltAdvisoryArtifacts({ publicDir, distDir });
+  await smokeTestBuiltAdvisoryEndpoints({ distDir });
 
   await fs.writeFile(path.join(distDir, "advisories/checksums.json"), "tampered\n");
   await assert.rejects(

--- a/scripts/test-deploy-pages-checksums.mjs
+++ b/scripts/test-deploy-pages-checksums.mjs
@@ -1,10 +1,17 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
-const workflowPath = new URL("../.github/workflows/deploy-pages.yml", import.meta.url);
-const workflow = await readFile(workflowPath, "utf8");
-const verifyWorkflowPath = new URL("../.github/workflows/pages-verify.yml", import.meta.url);
-const verifyWorkflow = await readFile(verifyWorkflowPath, "utf8");
+import {
+  generateAdvisoryChecksums,
+  publishAdvisoryAliases,
+  verifyBuiltAdvisoryArtifacts,
+} from "./ci/advisory_pages_artifacts.mjs";
+
+const workflow = await fs.readFile(new URL("../.github/workflows/deploy-pages.yml", import.meta.url), "utf8");
+const verifyWorkflow = await fs.readFile(new URL("../.github/workflows/pages-verify.yml", import.meta.url), "utf8");
 
 function stepIndex(source, name) {
   const marker = `- name: ${name}`;
@@ -13,92 +20,129 @@ function stepIndex(source, name) {
   return index;
 }
 
-function assertAdvisoryChecksumAliases(source, workflowName) {
-  const signChecksumsIndex = stepIndex(source, "Sign checksums and verify");
-  const aliasesIndex = stepIndex(source, "Publish advisory checksum aliases");
-  const nextStepIndex = source.indexOf("- name:", aliasesIndex + 1);
-  const aliasesStep = source.slice(aliasesIndex, nextStepIndex === -1 ? undefined : nextStepIndex);
+function stepBody(source, name) {
+  const start = stepIndex(source, name);
+  const end = source.indexOf("- name:", start + 1);
+  return source.slice(start, end === -1 ? undefined : end);
+}
 
-  assert.ok(
-    signChecksumsIndex < aliasesIndex,
-    `${workflowName} must publish advisory checksum aliases after checksums.json is signed`,
+function assertProductionOrdering(source, workflowName) {
+  const setupNodeIndex = stepIndex(source, "Setup Node.js");
+  const signFeedIndex = stepIndex(source, "Sign advisory feed and verify");
+  const signGhsaIndex = stepIndex(source, "Sign provisional GHSA feed and verify");
+  const generateChecksumsIndex = stepIndex(source, "Generate advisory checksums manifest");
+  const signChecksumsIndex = stepIndex(source, "Sign checksums and verify");
+  const aliasesIndex = stepIndex(source, "Publish advisory compatibility aliases");
+  const buildIndex = stepIndex(source, workflowName === "Deploy Pages" ? "Build" : "Build site");
+
+  assert.ok(setupNodeIndex < generateChecksumsIndex, `${workflowName} must pin Node before running the artifact helper`);
+  assert.ok(signFeedIndex < generateChecksumsIndex, `${workflowName} must checksum feed.json.sig`);
+  assert.ok(signGhsaIndex < generateChecksumsIndex, `${workflowName} must checksum the provisional feed signature`);
+  assert.ok(generateChecksumsIndex < signChecksumsIndex, `${workflowName} must sign the refreshed checksum manifest`);
+  assert.ok(signChecksumsIndex < aliasesIndex, `${workflowName} must publish aliases only after signing checksums.json`);
+  assert.ok(aliasesIndex < buildIndex, `${workflowName} must publish aliases before Vite copies public assets`);
+
+  assert.match(
+    stepBody(source, "Generate advisory checksums manifest"),
+    /node scripts\/ci\/advisory_pages_artifacts\.mjs generate/,
+    `${workflowName} must use the shared checksum generator`,
   );
   assert.match(
-    aliasesStep,
-    /cp public\/checksums\.json public\/advisories\/checksums\.json/,
-    `${workflowName} must publish checksums.json beside the advisory feed`,
-  );
-  assert.match(
-    aliasesStep,
-    /cp public\/checksums\.sig public\/advisories\/checksums\.json\.sig/,
-    `${workflowName} must publish the checksum signature at the URL derived by advisory clients`,
+    stepBody(source, "Publish advisory compatibility aliases"),
+    /node scripts\/ci\/advisory_pages_artifacts\.mjs publish-aliases/,
+    `${workflowName} must use the shared alias publisher`,
   );
 }
 
-const signFeedIndex = stepIndex(workflow, "Sign advisory feed and verify");
-const signGhsaIndex = stepIndex(workflow, "Sign provisional GHSA feed and verify");
-const generateChecksumsIndex = stepIndex(workflow, "Generate advisory checksums manifest");
-const signChecksumsIndex = stepIndex(workflow, "Sign checksums and verify");
+assertProductionOrdering(workflow, "Deploy Pages");
+assertProductionOrdering(verifyWorkflow, "Pages Verify");
 
-assert.ok(
-  signFeedIndex < generateChecksumsIndex,
-  "advisory checksums manifest must be generated after feed.json.sig is created",
+assert.doesNotMatch(
+  workflow,
+  /cp -r public\/(?:skills|advisories) dist\//,
+  "Vite already copies public directories into dist",
 );
-assert.ok(
-  signGhsaIndex < generateChecksumsIndex,
-  "advisory checksums manifest must be generated after ghsa-without-cve.json.sig is created",
+assert.doesNotMatch(
+  workflow,
+  /cp public\/(?:checksums\.(?:json|sig)|signing-public\.pem) dist\//,
+  "Vite already copies root public artifacts into dist",
 );
-assert.ok(
-  generateChecksumsIndex < signChecksumsIndex,
-  "checksums signature must be generated after checksums.json is refreshed",
-);
-
-const generateStepBody = workflow.slice(generateChecksumsIndex, signChecksumsIndex);
 assert.match(
-  generateStepBody,
-  /public\/advisories\/\*\.json\.sig/,
-  "advisory checksums manifest must include detached advisory signatures",
+  stepBody(workflow, "Verify built public artifacts"),
+  /advisory_pages_artifacts\.mjs verify-built/,
+  "Deploy Pages must verify Vite copied the advisory artifacts",
+);
+assert.match(
+  stepBody(verifyWorkflow, "Sanity-check generated artifacts"),
+  /advisory_pages_artifacts\.mjs verify-built/,
+  "Pages Verify must validate the same built advisory artifacts as production",
 );
 
 const mirrorBlockIndex = workflow.indexOf(
   "# Mirror advisories feed + signatures at the path referenced by suite docs/heartbeat",
 );
 assert.notEqual(mirrorBlockIndex, -1, "missing advisory release mirror block");
-
 const mirrorBlock = workflow.slice(mirrorBlockIndex, workflow.indexOf("if [ -f \"public/checksums.json\"", mirrorBlockIndex));
 assert.match(
   mirrorBlock,
   /cp "public\/advisories\/ghsa-without-cve\.json" "\$MIRROR_LATEST_DIR\/ghsa-without-cve\.json"/,
-  "GHSA provisional feed must be mirrored at the release-root compatibility path",
+  "GHSA provisional feed must remain at the release-root compatibility path",
 );
 assert.match(
   mirrorBlock,
   /cp "public\/advisories\/ghsa-without-cve\.json\.sig" "\$MIRROR_LATEST_DIR\/ghsa-without-cve\.json\.sig"/,
-  "GHSA provisional feed signature must be mirrored at the release-root compatibility path",
+  "GHSA provisional signature must remain at the release-root compatibility path",
 );
 
-assertAdvisoryChecksumAliases(workflow, "Deploy Pages");
-assertAdvisoryChecksumAliases(verifyWorkflow, "Pages Verify");
+const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "clawsec-pages-checksums-"));
+try {
+  const publicDir = path.join(tempRoot, "public");
+  const advisoryDir = path.join(publicDir, "advisories");
+  const distDir = path.join(tempRoot, "dist");
+  await fs.mkdir(advisoryDir, { recursive: true });
 
-const verifySanityIndex = stepIndex(verifyWorkflow, "Sanity-check generated artifacts");
-const verifySanityStep = verifyWorkflow.slice(verifySanityIndex);
-assert.match(
-  verifySanityStep,
-  /test -f dist\/advisories\/checksums\.json/,
-  "Pages Verify must require the advisory checksum manifest in the built site",
-);
-assert.match(
-  verifySanityStep,
-  /test -f dist\/advisories\/checksums\.json\.sig/,
-  "Pages Verify must require the advisory checksum signature in the built site",
-);
-assert.match(
-  verifySanityStep,
-  /cmp public\/checksums\.json dist\/advisories\/checksums\.json/,
-  "Pages Verify must keep the advisory checksum alias byte-identical to the signed root manifest",
-);
-assert.match(
-  verifySanityStep,
-  /cmp public\/checksums\.sig dist\/advisories\/checksums\.json\.sig/,
-  "Pages Verify must keep the advisory checksum signature alias byte-identical to the root signature",
-);
+  const artifacts = {
+    "feed.json": "{\"advisories\":[]}\n",
+    "feed.json.sig": "feed-signature\n",
+    "ghsa-without-cve.json": "{\"advisories\":[]}\n",
+    "ghsa-without-cve.json.sig": "ghsa-signature\n",
+  };
+  await Promise.all(
+    Object.entries(artifacts).map(([name, content]) => fs.writeFile(path.join(advisoryDir, name), content)),
+  );
+  await fs.writeFile(path.join(advisoryDir, "checksums.json"), "stale alias must not checksum itself\n");
+  await fs.writeFile(path.join(advisoryDir, "checksums.json.sig"), "stale signature alias\n");
+
+  const { manifest } = await generateAdvisoryChecksums({
+    publicDir,
+    repository: "prompt-security/clawsec-test",
+    generatedAt: "2026-07-12T00:00:00Z",
+  });
+  assert.equal(manifest.repository, "prompt-security/clawsec-test");
+  assert.deepEqual(Object.keys(manifest.files), [
+    "advisories/feed.json",
+    "advisories/feed.json.sig",
+    "advisories/ghsa-without-cve.json",
+    "advisories/ghsa-without-cve.json.sig",
+  ]);
+  for (const [name, content] of Object.entries(artifacts)) {
+    const entry = manifest.files[`advisories/${name}`];
+    assert.equal(entry.sha256, crypto.createHash("sha256").update(content).digest("hex"));
+    assert.equal(entry.size, Buffer.byteLength(content));
+  }
+
+  await fs.writeFile(path.join(publicDir, "checksums.sig"), "checksums-signature\n");
+  await fs.writeFile(path.join(publicDir, "signing-public.pem"), "public-key\n");
+  await publishAdvisoryAliases({ publicDir });
+  await fs.cp(publicDir, distDir, { recursive: true });
+  await verifyBuiltAdvisoryArtifacts({ publicDir, distDir });
+
+  await fs.writeFile(path.join(distDir, "advisories/checksums.json"), "tampered\n");
+  await assert.rejects(
+    verifyBuiltAdvisoryArtifacts({ publicDir, distDir }),
+    /files differ/,
+    "built verification must reject a changed advisory checksum alias",
+  );
+} finally {
+  await fs.rm(tempRoot, { recursive: true, force: true });
+}

--- a/scripts/test-deploy-pages-checksums.mjs
+++ b/scripts/test-deploy-pages-checksums.mjs
@@ -210,6 +210,11 @@ try {
   await fs.writeFile(path.join(publicDir, "checksums.sig"), sign(checksumsRaw));
   await fs.writeFile(path.join(publicDir, "signing-public.pem"), publicKey.export({ type: "spki", format: "pem" }));
   await publishAdvisoryAliases({ publicDir });
+
+  const distWithoutReleaseMirror = path.join(tempRoot, "dist-without-release-mirror");
+  await fs.cp(publicDir, distWithoutReleaseMirror, { recursive: true });
+  await smokeTestBuiltAdvisoryEndpoints({ distDir: distWithoutReleaseMirror });
+
   await publishReleaseCompatibilityMirror({ publicDir });
   await fs.cp(publicDir, distDir, { recursive: true });
   await verifyBuiltAdvisoryArtifacts({ publicDir, distDir });

--- a/scripts/test-deploy-pages-checksums.mjs
+++ b/scripts/test-deploy-pages-checksums.mjs
@@ -3,18 +3,42 @@ import { readFile } from "node:fs/promises";
 
 const workflowPath = new URL("../.github/workflows/deploy-pages.yml", import.meta.url);
 const workflow = await readFile(workflowPath, "utf8");
+const verifyWorkflowPath = new URL("../.github/workflows/pages-verify.yml", import.meta.url);
+const verifyWorkflow = await readFile(verifyWorkflowPath, "utf8");
 
-function stepIndex(name) {
+function stepIndex(source, name) {
   const marker = `- name: ${name}`;
-  const index = workflow.indexOf(marker);
+  const index = source.indexOf(marker);
   assert.notEqual(index, -1, `missing workflow step: ${name}`);
   return index;
 }
 
-const signFeedIndex = stepIndex("Sign advisory feed and verify");
-const signGhsaIndex = stepIndex("Sign provisional GHSA feed and verify");
-const generateChecksumsIndex = stepIndex("Generate advisory checksums manifest");
-const signChecksumsIndex = stepIndex("Sign checksums and verify");
+function assertAdvisoryChecksumAliases(source, workflowName) {
+  const signChecksumsIndex = stepIndex(source, "Sign checksums and verify");
+  const aliasesIndex = stepIndex(source, "Publish advisory checksum aliases");
+  const nextStepIndex = source.indexOf("- name:", aliasesIndex + 1);
+  const aliasesStep = source.slice(aliasesIndex, nextStepIndex === -1 ? undefined : nextStepIndex);
+
+  assert.ok(
+    signChecksumsIndex < aliasesIndex,
+    `${workflowName} must publish advisory checksum aliases after checksums.json is signed`,
+  );
+  assert.match(
+    aliasesStep,
+    /cp public\/checksums\.json public\/advisories\/checksums\.json/,
+    `${workflowName} must publish checksums.json beside the advisory feed`,
+  );
+  assert.match(
+    aliasesStep,
+    /cp public\/checksums\.sig public\/advisories\/checksums\.json\.sig/,
+    `${workflowName} must publish the checksum signature at the URL derived by advisory clients`,
+  );
+}
+
+const signFeedIndex = stepIndex(workflow, "Sign advisory feed and verify");
+const signGhsaIndex = stepIndex(workflow, "Sign provisional GHSA feed and verify");
+const generateChecksumsIndex = stepIndex(workflow, "Generate advisory checksums manifest");
+const signChecksumsIndex = stepIndex(workflow, "Sign checksums and verify");
 
 assert.ok(
   signFeedIndex < generateChecksumsIndex,
@@ -51,4 +75,30 @@ assert.match(
   mirrorBlock,
   /cp "public\/advisories\/ghsa-without-cve\.json\.sig" "\$MIRROR_LATEST_DIR\/ghsa-without-cve\.json\.sig"/,
   "GHSA provisional feed signature must be mirrored at the release-root compatibility path",
+);
+
+assertAdvisoryChecksumAliases(workflow, "Deploy Pages");
+assertAdvisoryChecksumAliases(verifyWorkflow, "Pages Verify");
+
+const verifySanityIndex = stepIndex(verifyWorkflow, "Sanity-check generated artifacts");
+const verifySanityStep = verifyWorkflow.slice(verifySanityIndex);
+assert.match(
+  verifySanityStep,
+  /test -f dist\/advisories\/checksums\.json/,
+  "Pages Verify must require the advisory checksum manifest in the built site",
+);
+assert.match(
+  verifySanityStep,
+  /test -f dist\/advisories\/checksums\.json\.sig/,
+  "Pages Verify must require the advisory checksum signature in the built site",
+);
+assert.match(
+  verifySanityStep,
+  /cmp public\/checksums\.json dist\/advisories\/checksums\.json/,
+  "Pages Verify must keep the advisory checksum alias byte-identical to the signed root manifest",
+);
+assert.match(
+  verifySanityStep,
+  /cmp public\/checksums\.sig dist\/advisories\/checksums\.json\.sig/,
+  "Pages Verify must keep the advisory checksum signature alias byte-identical to the root signature",
 );

--- a/scripts/test-deploy-pages-checksums.mjs
+++ b/scripts/test-deploy-pages-checksums.mjs
@@ -106,6 +106,16 @@ assert.match(
   /advisory_pages_artifacts\.mjs publish-release-mirror/,
   "Pages Verify must simulate the production release compatibility mirror",
 );
+assert.match(
+  stepBody(workflow, "Verify deployed advisory endpoints"),
+  /advisory_pages_artifacts\.mjs verify-url/,
+  "Deploy Pages must verify the real custom-domain endpoints after deployment",
+);
+assert.match(
+  stepBody(workflow, "Verify deployed advisory endpoints"),
+  /--base-url https:\/\/clawsec\.prompt\.security/,
+  "post-deploy verification must target the production custom domain",
+);
 
 async function collectContractSources(entryPath) {
   const stat = await fs.stat(entryPath);


### PR DESCRIPTION
### Summary

- publish `checksums.json` beside the advisory feed at `/advisories/checksums.json`
- publish its detached signature at `/advisories/checksums.json.sig`
- preserve the existing root checksum endpoints for compatibility
- consolidate advisory manifest generation, compatibility aliases, and built-output verification in one tested helper
- make Pages Verify follow the same sign -> checksum -> sign manifest -> publish aliases order as production
- remove the legacy post-build copies from `public/` to `dist/`; Vite already performs that copy, so the workflow now verifies the built files instead
- simulate the `releases/latest/download` compatibility mirror during PR validation
- serve the built tree over HTTP and verify status, JSON content type, signatures, checksums, aliases, and release mirrors
- scan all skill and instruction sources so every documented advisory artifact must remain in the published contract
- verify the real custom-domain endpoints automatically after every successful Pages deployment, with retries for propagation delay and runtime detection of the optional release mirror

### Root cause

The Pages workflow publishes the advisory feed under `public/advisories/`, but published its checksum manifest and signature only at the site root. Advisory clients derive their default checksum URL relative to the configured feed URL, so `/advisories/feed.json` becomes `/advisories/checksums.json`. That endpoint currently returns the GitHub Pages 404 document.

The production and PR-only workflows also had separate checksum-generation implementations. Pages Verify generated its manifest before advisory signatures existed, so it did not test the same manifest contents as production. An initial-repository workaround then recopied all dynamic `public/` content into `dist/` after Vite had already copied it.

The shared helper now owns the Pages advisory artifact contract. It excludes checksum aliases from manifest inputs to prevent self-checksumming, publishes byte-identical checksum/signature/signing-key aliases after signing, builds the release compatibility mirror, and verifies the exact built output. Skill-local checksum generation remains separate because it serves independently packaged skills and emits a different manifest schema.

### Live verification

- `/advisories/feed.json`: HTTP 200
- `/advisories/checksums.json`: HTTP 404
- `/advisories/checksums.json.sig`: HTTP 404
- `/checksums.json`: HTTP 200
- `/checksums.sig`: HTTP 200

### Tests

- `node scripts/test-deploy-pages-checksums.mjs`
- `node skills/clawsec-suite/test/feed_verification.test.mjs`
- `node skills/clawsec-suite/test/guarded_install.test.mjs`
- `node skills/hermes-attestation-guardian/test/feed_verification.test.mjs`
- `node skills/clawsec-nanoclaw/test/security-hardening.test.mjs`
- `npx eslint scripts/ci/advisory_pages_artifacts.mjs scripts/test-deploy-pages-checksums.mjs --max-warnings 0`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

### Post-merge production verification

The push to `main` automatically triggers Deploy Pages. A new post-deploy job then retries the real custom domain and verifies HTTP responses, content type, signatures, checksums, aliases, and the release mirror when one exists. A 404 from the mirror probe is treated as the supported no-release fallback while the core advisory contract is still fully verified. After that job succeeds, run one default-config advisory refresh as the final consumer-level confirmation. If the automatic Pages run fails, rerun it with `workflow_dispatch`; no skill release or version bump is required.

Fixes #293.
