### PR TITLE
fix(clawsec-suite): checksum embedded feed key

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -340,11 +340,17 @@ jobs:
             rm -f "$tmp_sig_bin"
             echo "  [Dry-run] Verified feed.json signature"
 
+            # Copy the public key before generating the manifest so the exact
+            # key used by the runtime fallback is covered by the signed hashes.
+            cp "$pub_file" "$advisory_dir/feed-signing-public.pem"
+
             # Generate checksums.json
             local feed_sha=$(sha256sum "$advisory_dir/feed.json" | awk '{print $1}')
             local feed_size=$(stat -c%s "$advisory_dir/feed.json" 2>/dev/null || stat -f%z "$advisory_dir/feed.json")
             local feed_sig_sha=$(sha256sum "$advisory_dir/feed.json.sig" | awk '{print $1}')
             local feed_sig_size=$(stat -c%s "$advisory_dir/feed.json.sig" 2>/dev/null || stat -f%z "$advisory_dir/feed.json.sig")
+            local public_key_sha=$(sha256sum "$advisory_dir/feed-signing-public.pem" | awk '{print $1}')
+            local public_key_size=$(stat -c%s "$advisory_dir/feed-signing-public.pem" 2>/dev/null || stat -f%z "$advisory_dir/feed-signing-public.pem")
 
             jq -n \
               --arg schema_version "1" \
@@ -355,6 +361,8 @@ jobs:
               --argjson feed_size "$feed_size" \
               --arg feed_sig_sha "$feed_sig_sha" \
               --argjson feed_sig_size "$feed_sig_size" \
+              --arg public_key_sha "$public_key_sha" \
+              --argjson public_key_size "$public_key_size" \
               '{
                 schema_version: $schema_version,
                 algorithm: $algorithm,
@@ -362,7 +370,8 @@ jobs:
                 generated_at: $generated,
                 files: {
                   "advisories/feed.json": {sha256: $feed_sha, size: $feed_size},
-                  "advisories/feed.json.sig": {sha256: $feed_sig_sha, size: $feed_sig_size}
+                  "advisories/feed.json.sig": {sha256: $feed_sig_sha, size: $feed_sig_size},
+                  "advisories/feed-signing-public.pem": {sha256: $public_key_sha, size: $public_key_size}
                 }
               }' > "$advisory_dir/checksums.json"
 
@@ -380,9 +389,6 @@ jobs:
             fi
             rm -f "$tmp_sig_bin"
             echo "  [Dry-run] Verified checksums.json signature"
-
-            # Copy public key
-            cp "$pub_file" "$advisory_dir/feed-signing-public.pem"
 
             echo "  [Dry-run] Advisory artifacts signed and verified with test key"
           }
@@ -1211,6 +1217,8 @@ jobs:
           FEED_SIZE=$(stat -c%s "$ADVISORY_DIR/feed.json" 2>/dev/null || stat -f%z "$ADVISORY_DIR/feed.json")
           FEED_SIG_SHA=$(sha256sum "$ADVISORY_DIR/feed.json.sig" | awk '{print $1}')
           FEED_SIG_SIZE=$(stat -c%s "$ADVISORY_DIR/feed.json.sig" 2>/dev/null || stat -f%z "$ADVISORY_DIR/feed.json.sig")
+          PUBLIC_KEY_SHA=$(sha256sum "$ADVISORY_DIR/feed-signing-public.pem" | awk '{print $1}')
+          PUBLIC_KEY_SIZE=$(stat -c%s "$ADVISORY_DIR/feed-signing-public.pem" 2>/dev/null || stat -f%z "$ADVISORY_DIR/feed-signing-public.pem")
 
           jq -n \
             --arg schema_version "1" \
@@ -1222,6 +1230,8 @@ jobs:
             --argjson feed_size "$FEED_SIZE" \
             --arg feed_sig_sha "$FEED_SIG_SHA" \
             --argjson feed_sig_size "$FEED_SIG_SIZE" \
+            --arg public_key_sha "$PUBLIC_KEY_SHA" \
+            --argjson public_key_size "$PUBLIC_KEY_SIZE" \
             '{
               schema_version: $schema_version,
               algorithm: $algorithm,
@@ -1238,6 +1248,11 @@ jobs:
                   sha256: $feed_sig_sha,
                   size: $feed_sig_size,
                   path: "advisories/feed.json.sig"
+                },
+                "advisories/feed-signing-public.pem": {
+                  sha256: $public_key_sha,
+                  size: $public_key_size,
+                  path: "advisories/feed-signing-public.pem"
                 }
               }
             }' > "$ADVISORY_DIR/checksums.json"

--- a/scripts/ci/simulate_skill_tag_release.mjs
+++ b/scripts/ci/simulate_skill_tag_release.mjs
@@ -274,6 +274,8 @@ async function signAdvisoryArtifacts(skillDir, tempRoot) {
     tempRoot,
   });
 
+  await cp(publicKeyPath, publicKeyOutputPath);
+
   await writeJson(checksumsPath, {
     schema_version: "1",
     algorithm: "sha256",
@@ -282,6 +284,10 @@ async function signAdvisoryArtifacts(skillDir, tempRoot) {
     files: {
       "advisories/feed.json": await checksumEntry(feedPath, "advisories/feed.json"),
       "advisories/feed.json.sig": await checksumEntry(feedSignaturePath, "advisories/feed.json.sig"),
+      "advisories/feed-signing-public.pem": await checksumEntry(
+        publicKeyOutputPath,
+        "advisories/feed-signing-public.pem",
+      ),
     },
   });
 
@@ -297,8 +303,6 @@ async function signAdvisoryArtifacts(skillDir, tempRoot) {
     signaturePath: checksumsSignaturePath,
     tempRoot,
   });
-
-  await cp(publicKeyPath, publicKeyOutputPath);
 }
 
 async function addReleaseAssetChecksum({ releaseAssetsDir, manifest, asset }) {

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -125,6 +125,24 @@ assert.match(
   'Skill release workflow must install SkillSpector before publishing release evidence',
 );
 
+assert.equal(
+  (workflow.match(/"advisories\/feed-signing-public\.pem": \{/g) || []).length,
+  2,
+  'PR dry-run and tag release embedded manifests must both checksum the feed signing public key',
+);
+
+assert.match(
+  workflow,
+  /cp "\$pub_file" "\$advisory_dir\/feed-signing-public\.pem"[\s\S]*local public_key_sha=[\s\S]*"advisories\/feed-signing-public\.pem": \{sha256: \$public_key_sha, size: \$public_key_size\}/,
+  'PR dry-run must stage the embedded public key before checksumming it',
+);
+
+assert.match(
+  workflow,
+  /PUBLIC_KEY_SHA=\$\(sha256sum "\$ADVISORY_DIR\/feed-signing-public\.pem"[\s\S]*"advisories\/feed-signing-public\.pem": \{[\s\S]*sha256: \$public_key_sha/,
+  'Tag releases must include the embedded public key digest in the signed advisory manifest',
+);
+
 assert.match(
   workflow,
   /Generate SkillSpector report/,

--- a/scripts/test-skill-tag-release-simulation.mjs
+++ b/scripts/test-skill-tag-release-simulation.mjs
@@ -5,6 +5,7 @@ import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
 const tempRoot = await mkdtemp(path.join(tmpdir(), "clawsec-tag-release-sim-"));
 const fakeSkillspector = path.join(tempRoot, "skillspector");
@@ -127,11 +128,12 @@ async function runSimulation({
     };
 
     const canonicalFeed = await readFile("advisories/feed.json");
+    const canonicalFeedPayload = JSON.parse(canonicalFeed.toString("utf8"));
     const packagedFeed = readArchiveEntry(`${skillName}/advisories/feed.json`);
     const packagedFeedSignature = readArchiveEntry(`${skillName}/advisories/feed.json.sig`);
     const packagedChecksumsRaw = readArchiveEntry(`${skillName}/advisories/checksums.json`);
     readArchiveEntry(`${skillName}/advisories/checksums.json.sig`);
-    readArchiveEntry(`${skillName}/advisories/feed-signing-public.pem`);
+    const packagedPublicKey = readArchiveEntry(`${skillName}/advisories/feed-signing-public.pem`);
 
     assert.deepEqual(packagedFeed, canonicalFeed, "simulated release must package the canonical advisory feed");
     const embeddedChecksums = JSON.parse(packagedChecksumsRaw.toString("utf8"));
@@ -145,6 +147,40 @@ async function runSimulation({
       sha256(packagedFeedSignature),
       "embedded manifest must checksum the packaged feed signature",
     );
+    assert.equal(
+      embeddedChecksums.files["advisories/feed-signing-public.pem"].sha256,
+      sha256(packagedPublicKey),
+      "embedded manifest must checksum the packaged feed signing key",
+    );
+
+    const extractedReleaseDir = path.join(outputDir, "extracted-release");
+    const extracted = spawnSync("unzip", ["-q", "-o", archivePath, "-d", extractedReleaseDir]);
+    assert.equal(
+      extracted.status,
+      0,
+      `failed to extract simulated release archive: ${extracted.stderr?.toString() || ""}`,
+    );
+
+    const extractedSkillDir = path.join(extractedReleaseDir, skillName);
+    const extractedAdvisoryDir = path.join(extractedSkillDir, "advisories");
+    const extractedFeedPath = path.join(extractedAdvisoryDir, "feed.json");
+    const extractedPublicKeyPath = path.join(extractedAdvisoryDir, "feed-signing-public.pem");
+    const extractedPublicKeyPem = await readFile(extractedPublicKeyPath, "utf8");
+    const feedModuleUrl = pathToFileURL(
+      path.join(extractedSkillDir, "hooks", "clawsec-advisory-guardian", "lib", "feed.mjs"),
+    );
+    const { loadLocalFeed } = await import(feedModuleUrl.href);
+    const loadedFeed = await loadLocalFeed(extractedFeedPath, {
+      signaturePath: `${extractedFeedPath}.sig`,
+      checksumsPath: path.join(extractedAdvisoryDir, "checksums.json"),
+      checksumsSignaturePath: path.join(extractedAdvisoryDir, "checksums.json.sig"),
+      publicKeyPem: extractedPublicKeyPem,
+      checksumsPublicKeyPem: extractedPublicKeyPem,
+      verifyChecksumManifest: true,
+      checksumPublicKeyEntry: path.basename(extractedPublicKeyPath),
+    });
+    assert.equal(loadedFeed.version, canonicalFeedPayload.version);
+    assert.equal(loadedFeed.advisories.length, canonicalFeedPayload.advisories.length);
   }
 
   const install = await readFile(path.join(releaseAssetsDir, "install.md"), "utf8");
@@ -207,8 +243,8 @@ writeFileSync(process.argv[outputIndex + 1], "# Fake SkillSpector Report\\n\\nNo
   await runSimulation({
     skillDir: "skills/clawsec-suite",
     outputDir: path.join(tempRoot, "stable"),
-    expectedOriginal: "0.1.13",
-    expectedSimulated: "0.1.14",
+    expectedOriginal: "0.1.14",
+    expectedSimulated: "0.1.15",
     expectedAgent: "openclaw",
     verifyEmbeddedAdvisory: true,
   });

--- a/scripts/test-skill-trust-packet.mjs
+++ b/scripts/test-skill-trust-packet.mjs
@@ -25,7 +25,7 @@ function runTrustPacket(skillDir, targetDir, tag) {
 }
 
 try {
-  const result = runTrustPacket("skills/clawsec-suite", outputDir, "clawsec-suite-v0.1.13");
+  const result = runTrustPacket("skills/clawsec-suite", outputDir, "clawsec-suite-v0.1.14");
 
   assert.equal(
     result.status,
@@ -41,10 +41,10 @@ try {
   assert.match(skillCard, /## License\/Terms of Use/);
   assert.match(skillCard, /AGPL-3\.0-or-later/);
   assert.match(skillCard, /skillspector-report\.md/);
-  assert.match(skillCard, /clawsec-suite-v0\.1\.13/);
+  assert.match(skillCard, /clawsec-suite-v0\.1\.14/);
 
   assert.equal(permissions.skill, "clawsec-suite");
-  assert.equal(permissions.version, "0.1.13");
+  assert.equal(permissions.version, "0.1.14");
   assert.equal(permissions.platform, "openclaw");
   assert.deepEqual(
     permissions.required_binaries,

--- a/skills/clawsec-suite/CHANGELOG.md
+++ b/skills/clawsec-suite/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.14] - 2026-07-13
+
+### Fixed
+
+- Included the embedded feed signing public key in the signed advisory checksum manifest generated for both PR simulations and tag releases.
+- Exercised the packaged local fallback through the runtime checksum-verification path so releases fail before publication if any required trust artifact is absent from the manifest.
+
 ## [0.1.13] - 2026-07-13
 
 ### Fixed

--- a/skills/clawsec-suite/SKILL.md
+++ b/skills/clawsec-suite/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawsec-suite
-version: 0.1.13
+version: 0.1.14
 description: ClawSec suite manager with embedded advisory-feed monitoring, cryptographic signature verification, approval-gated malicious-skill response, and guided setup for additional security skills.
 homepage: https://clawsec.prompt.security
 clawdis:

--- a/skills/clawsec-suite/skill.json
+++ b/skills/clawsec-suite/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawsec-suite",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "ClawSec suite manager with embedded advisory-feed monitoring, cryptographic signature verification, approval-gated malicious-skill response, and guided setup for additional security skills.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
# User description
### Summary

- Add `advisories/feed-signing-public.pem` to the signed embedded advisory checksum manifest generated by both PR simulations and tag releases.
- Stage the dry-run public key before manifest generation so the simulated and production release paths have the same trust contract.
- Extract the simulated release archive and load its signed fallback feed through the packaged runtime API with public-key checksum enforcement enabled.
- Bump only ClawSec Suite to 0.1.14 and document the repair.

---

### Root cause

ClawSec Suite passes `checksumPublicKeyEntry: feed-signing-public.pem` whenever it loads the packaged local fallback. Release 0.1.13 contained the public key, feed, feed signature, checksum manifest, and valid signatures, but its manifest only checksummed the feed and feed signature.

The release workflow therefore passed while the exact packaged fallback failed with:

```text
Checksum manifest missing required entry: feed-signing-public.pem
```

The previous release simulation checked that the public key existed in the archive but did not call `loadLocalFeed()` through the real fallback contract.

---

### Security behavior

This does not weaken verification or remove the runtime requirement. It makes the signed manifest cover the exact public key used to verify the embedded feed and manifest, then proves that contract from the packaged archive before publication.

---

### Verification

- Reproduced the failure from the published `clawsec-suite-v0.1.13` archive.
- The updated tag-release simulation extracts the Suite archive and successfully loads all 706 advisories with feed signature, manifest signature, feed checksum, feed-signature checksum, and public-key checksum verification enabled.
- All `scripts/test-skill-*.mjs` release-tooling tests pass.
- All ClawSec Suite tests pass.
- Advisory mirror propagation and 1,919-probe cross-consumer compatibility tests pass.
- Suite skill validation and workflow YAML parsing pass.
- Tracked-source ESLint, TypeScript, Vite production build, and `git diff --check` pass.

---

### Post-merge release

After merge, create `clawsec-suite-v0.1.14` from the merged `main` commit and verify the workflow, ClawHub publication, 11 release assets, external release signature, every manifest hash, and the exact packaged local-fallback load before considering the release complete.

Follow-up to #297.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add staging of the embedded <code>feed-signing-public.pem</code> key and checksum manifest entries in the skill release workflow so both dry-run and tag paths sign the same trust contract. Validate the packaged artifact by exercising the fallback loader in the tag-release simulation and refresh the ClawSec Suite version metadata and changelog for 0.1.14.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/298?tool=ast&topic=Checksum+coverage>Checksum coverage</a>
        </td><td>Extend the release workflow to stage <code>feed-signing-public.pem</code> before manifest generation and include its digest in every signed checksum manifest so the dry-run and tag paths share the same trust contract.<details><summary>Modified files (3)</summary><ul><li>.github/workflows/skill-release.yml</li>
<li>scripts/ci/simulate_skill_tag_release.mjs</li>
<li>scripts/test-skill-release-workflow.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(clawsec-suite): ch...</td><td>July 13, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(advisories): align...</td><td>July 13, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/298?tool=ast&topic=Simulation+%26+version>Simulation &amp; version</a>
        </td><td>Exercise the packaged fallback loader with checksum enforcement during the tag-release simulation and bump ClawSec Suite metadata/tests to 0.1.14 plus document the fix.<details><summary>Modified files (5)</summary><ul><li>scripts/test-skill-tag-release-simulation.mjs</li>
<li>scripts/test-skill-trust-packet.mjs</li>
<li>skills/clawsec-suite/CHANGELOG.md</li>
<li>skills/clawsec-suite/SKILL.md</li>
<li>skills/clawsec-suite/skill.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(clawsec-suite): ch...</td><td>July 13, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(advisories): align...</td><td>July 13, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/298?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>