### PR TITLE
fix(clawsec-suite): publish signed 0.1.15 package

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -2040,6 +2040,20 @@ jobs:
           OUTPUT_DIR="$RUNNER_TEMP/clawhub-package"
 
           mkdir -p "$RELEASE_DIR" "$OUTPUT_DIR"
+          release_assets="$(gh release view "$TAG" --repo "${{ github.repository }}" --json assets --jq '.assets[].name')"
+          required_release_assets=(
+            "${SKILL_NAME}-v${VERSION}.zip"
+            "checksums.json"
+            "checksums.sig"
+            "signing-public.pem"
+          )
+          for asset in "${required_release_assets[@]}"; do
+            if ! grep -Fxq "$asset" <<< "$release_assets"; then
+              echo "::error::Release ${TAG} lacks required signed asset ${asset}. Legacy unsigned releases cannot be safely republished; create a new patch release."
+              exit 1
+            fi
+          done
+
           gh release download "$TAG" \
             --repo "${{ github.repository }}" \
             --dir "$RELEASE_DIR" \
@@ -2068,7 +2082,7 @@ jobs:
         run: node scripts/ci/patch_clawhub_publish_payload.mjs
 
       - name: Allow signed trust artifacts in ClawHub packages
-        # Use the current helper even when republishing a tag created before this packaging fix.
+        # Use the current helper for signed tags created before the client-extension fix.
         run: node "$RUNNER_TEMP/patch_clawhub_trust_extensions.mjs"
 
       - name: Login to ClawHub

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -198,6 +198,14 @@ jobs:
               continue
             fi
 
+            if [ "${base_has_json}" = "true" ] && [ "${json_version_changed}" = "true" ]; then
+              if ! node scripts/ci/semver_increment.mjs "${base_json_version}" "${head_json_version}"; then
+                echo "::error file=${json_path}::Skill version increment does not satisfy release policy. Stable releases must advance by at least a patch. base=${base_json_version}, head=${head_json_version}"
+                failures=$((failures + 1))
+                continue
+              fi
+            fi
+
             skill_release_name="$(basename "${skill_dir}")"
             release_tag="${skill_release_name}-v${head_json_version}"
             if [ "${json_version_changed}" != "true" ] && [ "${md_version_changed}" != "true" ]; then
@@ -591,13 +599,6 @@ jobs:
             out_assets="${out_root}/release-assets"
             mkdir -p "${out_assets}"
 
-            # --- Sign advisory artifacts if present (dry-run with test key) ---
-            if ! sign_advisory_artifacts "${skill_dir}"; then
-              failures=$((failures + 1))
-              echo "::endgroup::"
-              continue
-            fi
-
             # --- Stage SBOM files preserving directory structure ---
             staging_dir="$(mktemp -d)"
             inner_dir="${staging_dir}/${skill_name}"
@@ -620,6 +621,8 @@ jobs:
               if [ -f "${full_path}" ]; then
                 mkdir -p "${inner_dir}/$(dirname "${file}")"
                 cp "${full_path}" "${inner_dir}/${file}"
+              elif [[ "${file}" == "advisories/checksums.json" || "${file}" == "advisories/checksums.json.sig" ]] && [ -f "${skill_dir}/advisories/feed.json" ]; then
+                echo "  [Dry-run] ${file} will be generated inside the staged package"
               else
                 echo "::error file=${json_path}::SBOM references missing file: ${file}"
                 failures=$((failures + 1))
@@ -628,14 +631,14 @@ jobs:
 
             cp "${json_path}" "${inner_dir}/skill.json"
 
-            # --- Remove test-only artifacts from staging (don't include in release zip) ---
-            # The test signatures/keys were needed for SBOM validation but shouldn't ship
-            if [ -d "${inner_dir}/advisories" ]; then
-              rm -f "${inner_dir}/advisories/feed.json.sig"
-              rm -f "${inner_dir}/advisories/checksums.json"
-              rm -f "${inner_dir}/advisories/checksums.json.sig"
-              rm -f "${inner_dir}/advisories/feed-signing-public.pem"
-              echo "  [Dry-run] Removed test signatures from release staging"
+            # --- Generate signed advisory trust artifacts inside staging only ---
+            # This keeps tracked source files untouched and exercises the package shape
+            # that the real tag release publishes.
+            if ! sign_advisory_artifacts "${inner_dir}"; then
+              failures=$((failures + 1))
+              rm -rf "${staging_dir}"
+              echo "::endgroup::"
+              continue
             fi
 
             # --- Verify staged runtime import closure before archiving ---
@@ -650,14 +653,6 @@ jobs:
               failures=$((failures + 1))
             fi
 
-            # --- Clean up test artifacts from source directory ---
-            if [ -d "${skill_dir}/advisories" ]; then
-              rm -f "${skill_dir}/advisories/feed.json.sig"
-              rm -f "${skill_dir}/advisories/checksums.json"
-              rm -f "${skill_dir}/advisories/checksums.json.sig"
-              rm -f "${skill_dir}/advisories/feed-signing-public.pem"
-            fi
-
             # --- Generate checksums.json via jq ---
             files_json="{}"
             while IFS= read -r raw_file; do
@@ -668,7 +663,7 @@ jobs:
               if is_test_release_path "${file}"; then
                 continue
               fi
-              full_path="${skill_dir}/${file}"
+              full_path="${inner_dir}/${file}"
               if [ -f "${full_path}" ]; then
                 sha256="$(sha256sum "${full_path}" | awk '{print $1}')"
                 size="$(stat -c%s "${full_path}" 2>/dev/null || stat -f%z "${full_path}")"
@@ -1039,6 +1034,12 @@ jobs:
           echo "/tmp/skillspector-venv/bin" >> "$GITHUB_PATH"
           skillspector --help >/dev/null
 
+      - name: Install pinned ClawHub client for package simulation
+        run: bash scripts/ci/install_clawhub_cli.sh
+
+      - name: Allow signed trust artifacts in simulated ClawHub packages
+        run: node scripts/ci/patch_clawhub_trust_extensions.mjs
+
       - name: Simulate tag release build
         run: |
           set -euo pipefail
@@ -1059,6 +1060,19 @@ jobs:
             test -s "dist/tag-release-simulation/${skill_name}/release-assets/checksums.sig"
             test -s "dist/tag-release-simulation/${skill_name}/release-assets/signing-public.pem"
             test -s "dist/tag-release-simulation/${skill_name}/release-assets/skillspector-report.md"
+
+            simulated_version="$(jq -r '.simulated_version' "dist/tag-release-simulation/${skill_name}/simulation-summary.json")"
+            release_dir="dist/tag-release-simulation/${skill_name}/release-assets"
+            clawhub_output="dist/tag-release-simulation/${skill_name}/clawhub-package"
+            node scripts/ci/clawhub_release_package.mjs prepare \
+              --release-dir "$release_dir" \
+              --output-dir "$clawhub_output" \
+              --skill "$skill_name" \
+              --version "$simulated_version" \
+              --canonical-key "$release_dir/signing-public.pem"
+            node scripts/ci/clawhub_release_package.mjs verify-client-selection \
+              --package-dir "$clawhub_output/$skill_name" \
+              --cli-prefix .github/clawhub-cli
             echo "::endgroup::"
           done
 
@@ -1751,13 +1765,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-clawhub:
-    # Separate job for ClawHub publishing - runs after GitHub release
-    # Non-blocking: if this fails, the release is still successful
-    # Retriggerable: can be manually triggered for failed publishes
+    # Separate blocking job for ClawHub publishing - runs after GitHub release.
+    # It publishes the verified GitHub release payload, never the raw source directory.
+    # Retriggerable: can be manually triggered for failed publishes.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs: release-tag
     runs-on: ubuntu-latest
-    continue-on-error: true
     permissions:
       contents: read
     env:
@@ -1779,17 +1792,61 @@ jobs:
         with:
           node-version: 20
 
+      - name: Prepare verified ClawHub release package
+        id: clawhub-package
+        if: needs.release-tag.outputs.publish_clawhub == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          SKILL_NAME="${{ needs.release-tag.outputs.skill_name }}"
+          VERSION="${{ needs.release-tag.outputs.version }}"
+          TAG="${{ github.ref_name }}"
+          RELEASE_DIR="$RUNNER_TEMP/clawhub-release"
+          OUTPUT_DIR="$RUNNER_TEMP/clawhub-package"
+
+          mkdir -p "$RELEASE_DIR" "$OUTPUT_DIR"
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --dir "$RELEASE_DIR" \
+            --pattern "${SKILL_NAME}-v${VERSION}.zip" \
+            --pattern "checksums.json" \
+            --pattern "checksums.sig" \
+            --pattern "signing-public.pem"
+
+          node scripts/ci/clawhub_release_package.mjs prepare \
+            --release-dir "$RELEASE_DIR" \
+            --output-dir "$OUTPUT_DIR" \
+            --skill "$SKILL_NAME" \
+            --version "$VERSION" \
+            --canonical-key clawsec-signing-public.pem
+
+          echo "skill_path=$OUTPUT_DIR/$SKILL_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Require ClawHub token
+        if: needs.release-tag.outputs.publish_clawhub == 'true'
+        run: |
+          if [ -z "$CLAWHUB_TOKEN" ]; then
+            echo "::error::CLAWHUB_TOKEN secret is not set"
+            exit 1
+          fi
+
       - name: Install clawhub CLI
-        if: needs.release-tag.outputs.publish_clawhub == 'true' && env.CLAWHUB_TOKEN != ''
+        if: needs.release-tag.outputs.publish_clawhub == 'true'
         run: bash scripts/ci/install_clawhub_cli.sh
 
       - name: Patch clawhub publish payload workaround
         # Idempotent compatibility guard: older clawhub@0.7.0 builds omitted acceptLicenseTerms.
-        if: needs.release-tag.outputs.publish_clawhub == 'true' && env.CLAWHUB_TOKEN != ''
+        if: needs.release-tag.outputs.publish_clawhub == 'true'
         run: node scripts/ci/patch_clawhub_publish_payload.mjs
 
+      - name: Allow signed trust artifacts in ClawHub packages
+        # ClawHub's text-file allowlist omits .sig and .pem, which silently drops verification assets.
+        if: needs.release-tag.outputs.publish_clawhub == 'true'
+        run: node scripts/ci/patch_clawhub_trust_extensions.mjs
+
       - name: Login to ClawHub
-        if: needs.release-tag.outputs.publish_clawhub == 'true' && env.CLAWHUB_TOKEN != ''
+        if: needs.release-tag.outputs.publish_clawhub == 'true'
         run: |
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
@@ -1800,7 +1857,7 @@ jobs:
             clawhub login --token "$CLAWHUB_TOKEN" --site "$SITE" --no-input
 
       - name: Guard ClawHub slug ownership
-        if: needs.release-tag.outputs.publish_clawhub == 'true' && env.CLAWHUB_TOKEN != ''
+        if: needs.release-tag.outputs.publish_clawhub == 'true'
         run: |
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
@@ -1811,8 +1868,9 @@ jobs:
           bash scripts/ci/guard_clawhub_slug_owner.sh \
             "${{ needs.release-tag.outputs.clawhub_slug }}"
 
-      - name: Guard duplicate ClawHub version
-        if: needs.release-tag.outputs.publish_clawhub == 'true' && env.CLAWHUB_TOKEN != ''
+      - name: Check existing ClawHub version
+        id: clawhub-version
+        if: needs.release-tag.outputs.publish_clawhub == 'true'
         run: |
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
@@ -1830,11 +1888,13 @@ jobs:
           set -e
 
           if [ "$STATUS" -eq 0 ]; then
-            echo "::error::ClawHub already contains ${CLAWHUB_SLUG}@${VERSION}. Bump the version before tagging."
-            exit 1
+            echo "already_exists=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::ClawHub already contains ${CLAWHUB_SLUG}@${VERSION}; skipping upload and verifying exact registry contents."
+            exit 0
           fi
 
           if grep -Eqi "Version not found|Skill not found" /tmp/clawhub-existing-version.err; then
+            echo "already_exists=false" >> "$GITHUB_OUTPUT"
             echo "No existing ${CLAWHUB_SLUG}@${VERSION} detected in ClawHub. Proceeding."
           else
             echo "::error::Failed to verify ClawHub version precondition."
@@ -1843,12 +1903,12 @@ jobs:
           fi
 
       - name: Publish to ClawHub
-        if: needs.release-tag.outputs.publish_clawhub == 'true' && env.CLAWHUB_TOKEN != ''
+        if: needs.release-tag.outputs.publish_clawhub == 'true' && steps.clawhub-version.outputs.already_exists != 'true'
         run: |
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          SKILL_PATH="${{ needs.release-tag.outputs.skill_path }}"
+          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
           SKILL_NAME="${{ needs.release-tag.outputs.skill_name }}"
           CLAWHUB_SLUG="${{ needs.release-tag.outputs.clawhub_slug }}"
           VERSION="${{ needs.release-tag.outputs.version }}"
@@ -1865,11 +1925,34 @@ jobs:
               --changelog "$CHANGELOG" \
               --tags "latest" \
               --no-input 2>&1 | tee /tmp/clawhub-publish.log; then
-            echo "::error::ClawHub publish failed. Check logs above for details."
-            exit 1
+            if grep -Eqi "version .*already exists" /tmp/clawhub-publish.log; then
+              echo "::warning::ClawHub reported an existing version after publish; verifying registry contents before accepting the retry."
+            else
+              echo "::error::ClawHub publish failed. Check logs above for details."
+              exit 1
+            fi
           fi
 
-          echo "✓ Successfully published $SKILL_NAME@$VERSION to ClawHub as $CLAWHUB_SLUG"
+          echo "ClawHub publish request completed for $SKILL_NAME@$VERSION as $CLAWHUB_SLUG"
+
+      - name: Verify published ClawHub package
+        if: needs.release-tag.outputs.publish_clawhub == 'true'
+        run: |
+          set -euo pipefail
+          SITE=${CLAWHUB_SITE:-https://clawhub.ai}
+          REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
+          CLAWHUB_SLUG="${{ needs.release-tag.outputs.clawhub_slug }}"
+          VERSION="${{ needs.release-tag.outputs.version }}"
+          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
+          export CLAWHUB_CONFIG_PATH="$HOME/.clawhub-ci/config.json"
+          export CLAWHUB_SITE="$SITE"
+          export CLAWHUB_REGISTRY="$REGISTRY"
+
+          node scripts/ci/clawhub_release_package.mjs verify-registry \
+            --package-dir "$SKILL_PATH" \
+            --slug "$CLAWHUB_SLUG" \
+            --version "$VERSION"
+          echo "✓ Verified published ClawHub package matches the signed release payload"
 
   republish-clawhub:
     # Manual workflow to republish a specific tag to ClawHub
@@ -1899,10 +1982,12 @@ jobs:
       - name: Checkout workflow helpers
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Prepare ClawHub slug helper
+      - name: Prepare current ClawHub workflow helpers
         run: |
           cp scripts/ci/resolve_clawhub_slug.mjs "$RUNNER_TEMP/resolve_clawhub_slug.mjs"
           cp scripts/ci/skill_platforms.mjs "$RUNNER_TEMP/skill_platforms.mjs"
+          cp scripts/ci/clawhub_release_package.mjs "$RUNNER_TEMP/clawhub_release_package.mjs"
+          cp scripts/ci/patch_clawhub_trust_extensions.mjs "$RUNNER_TEMP/patch_clawhub_trust_extensions.mjs"
 
       - name: Checkout tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1942,6 +2027,36 @@ jobs:
         with:
           node-version: 20
 
+      - name: Prepare verified ClawHub release package
+        id: clawhub-package
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
+          VERSION="${{ steps.parse.outputs.version }}"
+          TAG="${{ github.event.inputs.tag }}"
+          RELEASE_DIR="$RUNNER_TEMP/clawhub-release"
+          OUTPUT_DIR="$RUNNER_TEMP/clawhub-package"
+
+          mkdir -p "$RELEASE_DIR" "$OUTPUT_DIR"
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --dir "$RELEASE_DIR" \
+            --pattern "${SKILL_NAME}-v${VERSION}.zip" \
+            --pattern "checksums.json" \
+            --pattern "checksums.sig" \
+            --pattern "signing-public.pem"
+
+          node "$RUNNER_TEMP/clawhub_release_package.mjs" prepare \
+            --release-dir "$RELEASE_DIR" \
+            --output-dir "$OUTPUT_DIR" \
+            --skill "$SKILL_NAME" \
+            --version "$VERSION" \
+            --canonical-key clawsec-signing-public.pem
+
+          echo "skill_path=$OUTPUT_DIR/$SKILL_NAME" >> "$GITHUB_OUTPUT"
+
       - name: Validate npx skills install docs
         run: node scripts/ci/validate_skill_install_docs.mjs --skills "${{ steps.parse.outputs.skill_path }}"
 
@@ -1951,6 +2066,10 @@ jobs:
       - name: Patch clawhub publish payload workaround
         # Idempotent compatibility guard: older clawhub@0.7.0 builds omitted acceptLicenseTerms.
         run: node scripts/ci/patch_clawhub_publish_payload.mjs
+
+      - name: Allow signed trust artifacts in ClawHub packages
+        # Use the current helper even when republishing a tag created before this packaging fix.
+        run: node "$RUNNER_TEMP/patch_clawhub_trust_extensions.mjs"
 
       - name: Login to ClawHub
         run: |
@@ -1983,7 +2102,7 @@ jobs:
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
           SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
           CLAWHUB_SLUG="${{ steps.publishable.outputs.clawhub_slug }}"
           VERSION="${{ steps.parse.outputs.version }}"
@@ -2005,7 +2124,7 @@ jobs:
               --no-input 2>&1 | tee /tmp/clawhub-publish.log; then
 
             # Check if it's a "version already exists" error (which is OK on retry)
-            if grep -qi "version already exists" /tmp/clawhub-publish.log; then
+            if grep -Eqi "version .*already exists" /tmp/clawhub-publish.log; then
               echo "::warning::Version $VERSION already published to ClawHub"
               echo "This is expected if you're retrying a failed publish."
               echo "✓ Skill is available on ClawHub"
@@ -2018,3 +2137,21 @@ jobs:
           fi
 
           echo "✓ Successfully published $SKILL_NAME@$VERSION to ClawHub"
+
+      - name: Verify published ClawHub package
+        run: |
+          set -euo pipefail
+          SITE=${CLAWHUB_SITE:-https://clawhub.ai}
+          REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
+          CLAWHUB_SLUG="${{ steps.publishable.outputs.clawhub_slug }}"
+          VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
+          export CLAWHUB_CONFIG_PATH="$HOME/.clawhub-ci/config.json"
+          export CLAWHUB_SITE="$SITE"
+          export CLAWHUB_REGISTRY="$REGISTRY"
+
+          node "$RUNNER_TEMP/clawhub_release_package.mjs" verify-registry \
+            --package-dir "$SKILL_PATH" \
+            --slug "$CLAWHUB_SLUG" \
+            --version "$VERSION"
+          echo "✓ Verified published ClawHub package matches the signed release payload"

--- a/scripts/ci/clawhub_release_package.mjs
+++ b/scripts/ci/clawhub_release_package.mjs
@@ -5,8 +5,11 @@ import { spawnSync } from "node:child_process";
 import {
   lstat,
   mkdir,
+  mkdtemp,
   readFile,
   readdir,
+  rename,
+  rm,
   stat,
 } from "node:fs/promises";
 import path from "node:path";
@@ -325,49 +328,58 @@ export async function prepareReleasePackage({
   if (existingOutputEntries.length > 0) {
     throw new Error(`ClawHub package output directory must be empty: ${resolvedOutputDir}`);
   }
-  run("unzip", ["-q", archivePath, "-d", resolvedOutputDir]);
+  const stagingDir = await mkdtemp(path.join(resolvedOutputDir, ".staging-"));
+  try {
+    run("unzip", ["-q", archivePath, "-d", stagingDir]);
 
-  const packageDir = path.join(resolvedOutputDir, skillName);
-  const packageMetadata = await stat(packageDir).catch(() => null);
-  if (!packageMetadata?.isDirectory()) {
-    throw new Error(`Release archive did not create expected package directory: ${packageDir}`);
-  }
-
-  const packageFiles = await collectPackageFiles(packageDir);
-  for (const [filePath, actual] of packageFiles) {
-    const expected = checksums.files?.[filePath];
-    if (!expected) {
-      throw new Error(`Signed release manifest is missing packaged file: ${filePath}`);
+    const packageDir = path.join(stagingDir, skillName);
+    const packageMetadata = await stat(packageDir).catch(() => null);
+    if (!packageMetadata?.isDirectory()) {
+      throw new Error(`Release archive did not create expected package directory: ${packageDir}`);
     }
-    if (expected.sha256 !== actual.sha256 || expected.size !== actual.size) {
-      throw new Error(`Signed release manifest mismatch for packaged file: ${filePath}`);
+
+    const packageFiles = await collectPackageFiles(packageDir);
+    for (const [filePath, actual] of packageFiles) {
+      const expected = checksums.files?.[filePath];
+      if (!expected) {
+        throw new Error(`Signed release manifest is missing packaged file: ${filePath}`);
+      }
+      if (expected.sha256 !== actual.sha256 || expected.size !== actual.size) {
+        throw new Error(`Signed release manifest mismatch for packaged file: ${filePath}`);
+      }
     }
-  }
 
-  const skill = JSON.parse(await readFile(path.join(packageDir, "skill.json"), "utf8"));
-  if (skill.version !== version) {
-    throw new Error(`Packaged skill.json version mismatch: expected ${version}, got ${skill.version}`);
-  }
+    const skill = JSON.parse(await readFile(path.join(packageDir, "skill.json"), "utf8"));
+    if (skill.version !== version) {
+      throw new Error(`Packaged skill.json version mismatch: expected ${version}, got ${skill.version}`);
+    }
 
-  const declaredPackageFiles = new Set(
-    (skill.sbom?.files ?? []).map((entry) => entry.path.replaceAll("\\", "/").replace(/^\.\//, "")),
-  );
-  const requiresEmbeddedAdvisoryTrust = ADVISORY_TRUST_ARTIFACTS.every(
-    (artifact) => declaredPackageFiles.has(artifact),
-  );
-  const advisoryTrust = await verifyEmbeddedAdvisoryTrust(
-    packageDir,
-    releaseKeyFingerprint,
-    requiresEmbeddedAdvisoryTrust,
-  );
-  const clawhubFiles = await collectClawhubPackageFiles(packageDir);
-  return {
-    packageDir,
-    files: packageFiles.size,
-    clawhubFiles: clawhubFiles.size,
-    releaseKeyFingerprint,
-    embeddedAdvisoryTrust: advisoryTrust,
-  };
+    const declaredPackageFiles = new Set(
+      (skill.sbom?.files ?? []).map((entry) => entry.path.replaceAll("\\", "/").replace(/^\.\//, "")),
+    );
+    const requiresEmbeddedAdvisoryTrust = ADVISORY_TRUST_ARTIFACTS.every(
+      (artifact) => declaredPackageFiles.has(artifact),
+    );
+    const advisoryTrust = await verifyEmbeddedAdvisoryTrust(
+      packageDir,
+      releaseKeyFingerprint,
+      requiresEmbeddedAdvisoryTrust,
+    );
+    const clawhubFiles = await collectClawhubPackageFiles(packageDir);
+    const finalPackageDir = path.join(resolvedOutputDir, skillName);
+    await rename(packageDir, finalPackageDir);
+    await rm(stagingDir, { recursive: true, force: true });
+    return {
+      packageDir: finalPackageDir,
+      files: packageFiles.size,
+      clawhubFiles: clawhubFiles.size,
+      releaseKeyFingerprint,
+      embeddedAdvisoryTrust: advisoryTrust,
+    };
+  } catch (error) {
+    await rm(stagingDir, { recursive: true, force: true });
+    throw error;
+  }
 }
 
 export async function verifyClawhubClientSelection({ packageDir, cliPrefix }) {

--- a/scripts/ci/clawhub_release_package.mjs
+++ b/scripts/ci/clawhub_release_package.mjs
@@ -368,7 +368,6 @@ export async function prepareReleasePackage({
     const clawhubFiles = await collectClawhubPackageFiles(packageDir);
     const finalPackageDir = path.join(resolvedOutputDir, skillName);
     await rename(packageDir, finalPackageDir);
-    await rm(stagingDir, { recursive: true, force: true });
     return {
       packageDir: finalPackageDir,
       files: packageFiles.size,
@@ -376,9 +375,8 @@ export async function prepareReleasePackage({
       releaseKeyFingerprint,
       embeddedAdvisoryTrust: advisoryTrust,
     };
-  } catch (error) {
+  } finally {
     await rm(stagingDir, { recursive: true, force: true });
-    throw error;
   }
 }
 

--- a/scripts/ci/clawhub_release_package.mjs
+++ b/scripts/ci/clawhub_release_package.mjs
@@ -1,0 +1,555 @@
+#!/usr/bin/env node
+
+import { createHash, createPublicKey, verify as verifySignature } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  stat,
+} from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const CLAWHUB_TEXT_EXTENSIONS = new Set([
+  "c", "cfg", "cjs", "cpp", "cs", "css", "csv", "env", "go", "h", "hpp",
+  "html", "ini", "java", "js", "json", "json5", "jsx", "kt", "md", "mdx",
+  "mjs", "pem", "py", "rb", "rs", "sass", "scss", "sh", "sig", "sql", "svg",
+  "swift", "toml", "ts", "tsx", "txt", "xml", "yaml", "yml",
+]);
+const ADVISORY_TRUST_ARTIFACTS = [
+  "advisories/feed.json",
+  "advisories/feed.json.sig",
+  "advisories/checksums.json",
+  "advisories/checksums.json.sig",
+  "advisories/feed-signing-public.pem",
+];
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/ci/clawhub_release_package.mjs prepare --release-dir <dir> --output-dir <dir> --skill <name> --version <semver> --canonical-key <pem>",
+    "  node scripts/ci/clawhub_release_package.mjs verify-client-selection --package-dir <dir> --cli-prefix <dir>",
+    "  node scripts/ci/clawhub_release_package.mjs verify-published --package-dir <dir> --inspect-json <file> --version <semver>",
+    "  node scripts/ci/clawhub_release_package.mjs verify-registry --package-dir <dir> --slug <slug> --version <semver>",
+  ].join("\n");
+}
+
+function parseOptions(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${token}\n${usage()}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for ${token}\n${usage()}`);
+    }
+    options[token.slice(2)] = value;
+    index += 1;
+  }
+  return options;
+}
+
+function requireOptions(options, names) {
+  for (const name of names) {
+    if (!options[name]) {
+      throw new Error(`Missing required option --${name}\n${usage()}`);
+    }
+  }
+}
+
+function sha256(content) {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function publicKeyFingerprint(publicKeyPem) {
+  const publicKey = createPublicKey(publicKeyPem);
+  return sha256(publicKey.export({ type: "spki", format: "der" }));
+}
+
+function decodeBase64Signature(rawSignature, label) {
+  const normalized = String(rawSignature ?? "").trim().replace(/\s+/g, "");
+  if (!normalized || !/^[A-Za-z0-9+/]+={0,2}$/.test(normalized)) {
+    throw new Error(`${label} is not a valid base64 signature`);
+  }
+  return Buffer.from(normalized, "base64");
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      [
+        `Command failed: ${command} ${args.join(" ")}`,
+        result.stdout ? `stdout:\n${result.stdout}` : "",
+        result.stderr ? `stderr:\n${result.stderr}` : "",
+      ].filter(Boolean).join("\n"),
+    );
+  }
+  return result.stdout;
+}
+
+function normalizeArchiveEntry(entry) {
+  const normalized = String(entry ?? "").trim().replace(/\/+$/, "");
+  if (
+    !normalized
+    || normalized.includes("\\")
+    || normalized.startsWith("/")
+    || /^[A-Za-z]:/.test(normalized)
+    || normalized === ".."
+    || normalized.startsWith("../")
+    || normalized.endsWith("/..")
+    || normalized.includes("/../")
+  ) {
+    throw new Error(`Unsafe release archive entry: ${entry}`);
+  }
+  return normalized;
+}
+
+export async function collectPackageFiles(rootDir) {
+  const files = new Map();
+
+  async function visit(currentDir, relativeDir = "") {
+    const entries = await readdir(currentDir, { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      const relativePath = path.posix.join(relativeDir.replaceAll("\\", "/"), entry.name);
+      const metadata = await lstat(fullPath);
+      if (metadata.isSymbolicLink()) {
+        throw new Error(`ClawHub package must not contain symbolic links: ${relativePath}`);
+      }
+      if (metadata.isDirectory()) {
+        await visit(fullPath, relativePath);
+        continue;
+      }
+      if (!metadata.isFile()) {
+        throw new Error(`ClawHub package contains unsupported entry type: ${relativePath}`);
+      }
+      const content = await readFile(fullPath);
+      files.set(relativePath, {
+        path: relativePath,
+        sha256: sha256(content),
+        size: content.length,
+      });
+    }
+  }
+
+  await visit(rootDir);
+  return files;
+}
+
+export async function collectClawhubPackageFiles(rootDir) {
+  const packageFiles = await collectPackageFiles(rootDir);
+  const skill = JSON.parse(await readFile(path.join(rootDir, "skill.json"), "utf8"));
+  const optionalPlaceholders = new Set(
+    (skill.sbom?.files ?? [])
+      .filter((entry) => entry.required === false && path.posix.basename(entry.path) === ".gitkeep")
+      .map((entry) => entry.path.replaceAll("\\", "/").replace(/^\.\//, "")),
+  );
+  const publishedFiles = new Map();
+
+  for (const [filePath, metadata] of packageFiles) {
+    const parts = filePath.split("/");
+    const extension = path.posix.extname(filePath).slice(1).toLowerCase();
+    const clientWouldOmit = parts.some((part) => part.startsWith("."))
+      || !extension
+      || !CLAWHUB_TEXT_EXTENSIONS.has(extension);
+
+    if (!clientWouldOmit) {
+      publishedFiles.set(filePath, metadata);
+      continue;
+    }
+    if (optionalPlaceholders.has(filePath)) {
+      continue;
+    }
+    throw new Error(
+      `ClawHub client would omit non-placeholder package file: ${filePath}`,
+    );
+  }
+
+  return publishedFiles;
+}
+
+async function verifyEmbeddedAdvisoryTrust(packageDir, releaseKeyFingerprint, required) {
+  const advisoryDir = path.join(packageDir, "advisories");
+  const feedPath = path.join(advisoryDir, "feed.json");
+  try {
+    await stat(feedPath);
+  } catch (error) {
+    if (error?.code === "ENOENT" && !required) return { verified: false, files: 0 };
+    if (error?.code === "ENOENT") {
+      throw new Error("Embedded advisory trust artifact is missing: advisories/feed.json");
+    }
+    throw error;
+  }
+
+  if (!required) {
+    return { verified: false, files: 1 };
+  }
+
+  const requiredArtifacts = ADVISORY_TRUST_ARTIFACTS.map((artifact) => artifact.slice("advisories/".length));
+  for (const artifact of requiredArtifacts) {
+    const artifactPath = path.join(advisoryDir, artifact);
+    const metadata = await stat(artifactPath).catch(() => null);
+    if (!metadata?.isFile() || metadata.size === 0) {
+      throw new Error(`Embedded advisory trust artifact is missing or empty: advisories/${artifact}`);
+    }
+  }
+
+  const feedRaw = await readFile(feedPath);
+  const feedSignatureRaw = await readFile(path.join(advisoryDir, "feed.json.sig"), "utf8");
+  const checksumsRaw = await readFile(path.join(advisoryDir, "checksums.json"));
+  const checksumsSignatureRaw = await readFile(path.join(advisoryDir, "checksums.json.sig"), "utf8");
+  const feedPublicKeyPem = await readFile(path.join(advisoryDir, "feed-signing-public.pem"));
+  const feedPublicKey = createPublicKey(feedPublicKeyPem);
+
+  const feedKeyFingerprint = publicKeyFingerprint(feedPublicKeyPem);
+  if (feedKeyFingerprint !== releaseKeyFingerprint) {
+    throw new Error(
+      `Embedded feed key fingerprint ${feedKeyFingerprint} does not match release key ${releaseKeyFingerprint}`,
+    );
+  }
+
+  if (!verifySignature(
+    null,
+    feedRaw,
+    feedPublicKey,
+    decodeBase64Signature(feedSignatureRaw, "advisories/feed.json.sig"),
+  )) {
+    throw new Error("Embedded advisory feed signature verification failed");
+  }
+
+  if (!verifySignature(
+    null,
+    checksumsRaw,
+    feedPublicKey,
+    decodeBase64Signature(checksumsSignatureRaw, "advisories/checksums.json.sig"),
+  )) {
+    throw new Error("Embedded advisory checksum signature verification failed");
+  }
+
+  const checksums = JSON.parse(checksumsRaw);
+  const expectedFiles = new Map([
+    ["advisories/feed.json", feedRaw],
+    ["advisories/feed.json.sig", Buffer.from(feedSignatureRaw)],
+    ["advisories/feed-signing-public.pem", feedPublicKeyPem],
+  ]);
+  for (const [entry, content] of expectedFiles) {
+    const expected = checksums.files?.[entry];
+    if (!expected) {
+      throw new Error(`Embedded advisory checksum manifest is missing ${entry}`);
+    }
+    if (expected.sha256 !== sha256(content) || expected.size !== content.length) {
+      throw new Error(`Embedded advisory checksum mismatch for ${entry}`);
+    }
+  }
+
+  return { verified: true, files: requiredArtifacts.length };
+}
+
+export async function prepareReleasePackage({
+  releaseDir,
+  outputDir,
+  skillName,
+  version,
+  canonicalKeyPath,
+}) {
+  const resolvedReleaseDir = path.resolve(releaseDir);
+  const resolvedOutputDir = path.resolve(outputDir);
+  const archiveName = `${skillName}-v${version}.zip`;
+  const archivePath = path.join(resolvedReleaseDir, archiveName);
+  const checksumsPath = path.join(resolvedReleaseDir, "checksums.json");
+  const checksumsSignaturePath = path.join(resolvedReleaseDir, "checksums.sig");
+  const releaseKeyPath = path.join(resolvedReleaseDir, "signing-public.pem");
+
+  const [archive, checksumsRaw, checksumsSignatureRaw, releaseKeyPem, canonicalKeyPem] = await Promise.all([
+    readFile(archivePath),
+    readFile(checksumsPath),
+    readFile(checksumsSignaturePath, "utf8"),
+    readFile(releaseKeyPath),
+    readFile(path.resolve(canonicalKeyPath)),
+  ]);
+
+  const releaseKeyFingerprint = publicKeyFingerprint(releaseKeyPem);
+  const canonicalKeyFingerprint = publicKeyFingerprint(canonicalKeyPem);
+  if (releaseKeyFingerprint !== canonicalKeyFingerprint) {
+    throw new Error(
+      `Release signing key fingerprint ${releaseKeyFingerprint} does not match canonical key ${canonicalKeyFingerprint}`,
+    );
+  }
+
+  const releaseKey = createPublicKey(releaseKeyPem);
+  if (!verifySignature(
+    null,
+    checksumsRaw,
+    releaseKey,
+    decodeBase64Signature(checksumsSignatureRaw, "checksums.sig"),
+  )) {
+    throw new Error("Release checksums signature verification failed");
+  }
+
+  const checksums = JSON.parse(checksumsRaw);
+  if (checksums.skill !== skillName || checksums.version !== version) {
+    throw new Error(
+      `Release manifest identity mismatch: expected ${skillName}@${version}, got ${checksums.skill}@${checksums.version}`,
+    );
+  }
+  if (checksums.archive?.filename !== archiveName) {
+    throw new Error(`Release manifest archive mismatch: expected ${archiveName}`);
+  }
+  if (checksums.archive.sha256 !== sha256(archive) || checksums.archive.size !== archive.length) {
+    throw new Error(`Release archive checksum mismatch: ${archiveName}`);
+  }
+
+  const archiveEntries = run("unzip", ["-Z1", archivePath])
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(normalizeArchiveEntry);
+  const expectedPrefix = `${skillName}/`;
+  for (const entry of archiveEntries) {
+    if (entry !== skillName && !entry.startsWith(expectedPrefix)) {
+      throw new Error(`Release archive entry is outside ${expectedPrefix}: ${entry}`);
+    }
+  }
+
+  await mkdir(resolvedOutputDir, { recursive: true });
+  const existingOutputEntries = await readdir(resolvedOutputDir);
+  if (existingOutputEntries.length > 0) {
+    throw new Error(`ClawHub package output directory must be empty: ${resolvedOutputDir}`);
+  }
+  run("unzip", ["-q", archivePath, "-d", resolvedOutputDir]);
+
+  const packageDir = path.join(resolvedOutputDir, skillName);
+  const packageMetadata = await stat(packageDir).catch(() => null);
+  if (!packageMetadata?.isDirectory()) {
+    throw new Error(`Release archive did not create expected package directory: ${packageDir}`);
+  }
+
+  const packageFiles = await collectPackageFiles(packageDir);
+  for (const [filePath, actual] of packageFiles) {
+    const expected = checksums.files?.[filePath];
+    if (!expected) {
+      throw new Error(`Signed release manifest is missing packaged file: ${filePath}`);
+    }
+    if (expected.sha256 !== actual.sha256 || expected.size !== actual.size) {
+      throw new Error(`Signed release manifest mismatch for packaged file: ${filePath}`);
+    }
+  }
+
+  const skill = JSON.parse(await readFile(path.join(packageDir, "skill.json"), "utf8"));
+  if (skill.version !== version) {
+    throw new Error(`Packaged skill.json version mismatch: expected ${version}, got ${skill.version}`);
+  }
+
+  const declaredPackageFiles = new Set(
+    (skill.sbom?.files ?? []).map((entry) => entry.path.replaceAll("\\", "/").replace(/^\.\//, "")),
+  );
+  const requiresEmbeddedAdvisoryTrust = ADVISORY_TRUST_ARTIFACTS.every(
+    (artifact) => declaredPackageFiles.has(artifact),
+  );
+  const advisoryTrust = await verifyEmbeddedAdvisoryTrust(
+    packageDir,
+    releaseKeyFingerprint,
+    requiresEmbeddedAdvisoryTrust,
+  );
+  const clawhubFiles = await collectClawhubPackageFiles(packageDir);
+  return {
+    packageDir,
+    files: packageFiles.size,
+    clawhubFiles: clawhubFiles.size,
+    releaseKeyFingerprint,
+    embeddedAdvisoryTrust: advisoryTrust,
+  };
+}
+
+export async function verifyClawhubClientSelection({ packageDir, cliPrefix }) {
+  const resolvedPackageDir = path.resolve(packageDir);
+  const expectedFiles = await collectClawhubPackageFiles(resolvedPackageDir);
+  const skillsModulePath = path.resolve(
+    cliPrefix,
+    "node_modules",
+    "clawhub",
+    "dist",
+    "skills.js",
+  );
+  const skillsModule = await import(`${pathToFileURL(skillsModulePath).href}?selection=${Date.now()}`);
+  if (typeof skillsModule.listTextFiles !== "function") {
+    throw new Error(`ClawHub client does not export listTextFiles: ${skillsModulePath}`);
+  }
+
+  const selectedFiles = await skillsModule.listTextFiles(resolvedPackageDir);
+  const actualFiles = new Map(selectedFiles.map((entry) => [entry.relPath, {
+    path: entry.relPath,
+    sha256: sha256(Buffer.from(entry.bytes)),
+    size: entry.bytes.byteLength,
+  }]));
+  if (actualFiles.size !== selectedFiles.length) {
+    throw new Error("ClawHub client selected duplicate file paths");
+  }
+
+  for (const [filePath, expected] of expectedFiles) {
+    const actual = actualFiles.get(filePath);
+    if (!actual) {
+      throw new Error(`ClawHub client would omit expected package file: ${filePath}`);
+    }
+    if (actual.sha256 !== expected.sha256 || actual.size !== expected.size) {
+      throw new Error(`ClawHub client selected mismatched package file: ${filePath}`);
+    }
+  }
+  for (const filePath of actualFiles.keys()) {
+    if (!expectedFiles.has(filePath)) {
+      throw new Error(`ClawHub client selected unexpected package file: ${filePath}`);
+    }
+  }
+
+  return { files: expectedFiles.size };
+}
+
+async function verifyPublishedInspect({ packageDir, inspect, version }) {
+  const expectedFiles = await collectClawhubPackageFiles(path.resolve(packageDir));
+  const publishedVersion = inspect.version?.version;
+  if (publishedVersion !== version) {
+    throw new Error(`Published ClawHub version mismatch: expected ${version}, got ${publishedVersion}`);
+  }
+
+  if (!Array.isArray(inspect.version?.files)) {
+    throw new Error("ClawHub inspect response is missing version.files");
+  }
+  const publishedFiles = new Map(inspect.version.files.map((entry) => [entry.path, entry]));
+  if (publishedFiles.size !== inspect.version.files.length) {
+    throw new Error("ClawHub inspect response contains duplicate file paths");
+  }
+
+  for (const [filePath, expected] of expectedFiles) {
+    const published = publishedFiles.get(filePath);
+    if (!published) {
+      throw new Error(`Published ClawHub package is missing ${filePath}`);
+    }
+    if (published.sha256 !== expected.sha256 || published.size !== expected.size) {
+      throw new Error(`Published ClawHub package mismatch for ${filePath}`);
+    }
+  }
+
+  for (const filePath of publishedFiles.keys()) {
+    if (!expectedFiles.has(filePath)) {
+      throw new Error(`Published ClawHub package contains unexpected file: ${filePath}`);
+    }
+  }
+
+  return { version, files: expectedFiles.size };
+}
+
+export async function verifyPublishedPackage({ packageDir, inspectJsonPath, version }) {
+  const inspect = JSON.parse(await readFile(path.resolve(inspectJsonPath), "utf8"));
+  return verifyPublishedInspect({ packageDir, inspect, version });
+}
+
+export async function verifyRegistryPackage({
+  packageDir,
+  slug,
+  version,
+  attempts = 6,
+  delayMs = 5000,
+}) {
+  const site = process.env.CLAWHUB_SITE || "https://clawhub.ai";
+  const registry = process.env.CLAWHUB_REGISTRY || site;
+  let lastError = "";
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const result = spawnSync(
+      "clawhub",
+      ["inspect", slug, "--version", version, "--json"],
+      {
+        encoding: "utf8",
+        maxBuffer: 64 * 1024 * 1024,
+        env: {
+          ...process.env,
+          CLAWHUB_DISABLE_TELEMETRY: "1",
+          CLAWHUB_SITE: site,
+          CLAWHUB_REGISTRY: registry,
+        },
+      },
+    );
+    if (result.status === 0) {
+      const inspect = JSON.parse(result.stdout);
+      return verifyPublishedInspect({ packageDir, inspect, version });
+    }
+
+    lastError = result.stderr || result.stdout || `clawhub inspect exited ${result.status}`;
+    if (attempt < attempts) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  throw new Error(`Unable to inspect published ClawHub package after ${attempts} attempts:\n${lastError}`);
+}
+
+async function main() {
+  const [command, ...argv] = process.argv.slice(2);
+  const options = parseOptions(argv);
+
+  if (command === "prepare") {
+    requireOptions(options, ["release-dir", "output-dir", "skill", "version", "canonical-key"]);
+    const result = await prepareReleasePackage({
+      releaseDir: options["release-dir"],
+      outputDir: options["output-dir"],
+      skillName: options.skill,
+      version: options.version,
+      canonicalKeyPath: options["canonical-key"],
+    });
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  if (command === "verify-published") {
+    requireOptions(options, ["package-dir", "inspect-json", "version"]);
+    const result = await verifyPublishedPackage({
+      packageDir: options["package-dir"],
+      inspectJsonPath: options["inspect-json"],
+      version: options.version,
+    });
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  if (command === "verify-client-selection") {
+    requireOptions(options, ["package-dir", "cli-prefix"]);
+    const result = await verifyClawhubClientSelection({
+      packageDir: options["package-dir"],
+      cliPrefix: options["cli-prefix"],
+    });
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  if (command === "verify-registry") {
+    requireOptions(options, ["package-dir", "slug", "version"]);
+    const result = await verifyRegistryPackage({
+      packageDir: options["package-dir"],
+      slug: options.slug,
+      version: options.version,
+    });
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  throw new Error(usage());
+}
+
+const invokedUrl = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : "";
+if (import.meta.url === invokedUrl) {
+  main().catch((error) => {
+    process.stderr.write(`${error.stack || error.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/ci/patch_clawhub_trust_extensions.mjs
+++ b/scripts/ci/patch_clawhub_trust_extensions.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const REQUIRED_TRUST_EXTENSIONS = ["pem", "sig"];
+
+function resolveTextFilesPath(cliPrefix) {
+  return path.join(
+    path.resolve(cliPrefix),
+    "node_modules",
+    "clawhub",
+    "dist",
+    "schema",
+    "textFiles.js",
+  );
+}
+
+function extensionPattern(extension) {
+  return new RegExp(`["']${extension}["']\\s*,`);
+}
+
+export async function patchClawhubTrustExtensions(cliPrefix) {
+  const textFilesPath = resolveTextFilesPath(cliPrefix);
+  if (!existsSync(textFilesPath)) {
+    throw new Error(`ClawHub text-file schema not found: ${textFilesPath}`);
+  }
+
+  const original = await readFile(textFilesPath, "utf8");
+  const listPattern = /(const RAW_TEXT_FILE_EXTENSIONS\s*=\s*\[)([\s\S]*?)(\n\s*\];)/;
+  const match = original.match(listPattern);
+  if (!match) {
+    throw new Error(`Could not find ClawHub text extension allowlist in ${textFilesPath}`);
+  }
+
+  const entries = match[2];
+  const missingExtensions = REQUIRED_TRUST_EXTENSIONS.filter(
+    (extension) => !extensionPattern(extension).test(entries),
+  );
+  if (missingExtensions.length === 0) {
+    return { patched: false, path: textFilesPath, extensions: REQUIRED_TRUST_EXTENSIONS };
+  }
+
+  const indentation = entries.match(/\n([ \t]+)["']/)?.[1] ?? "    ";
+  const quote = entries.match(/["']/)?.[0] ?? "'";
+  const additions = missingExtensions
+    .map((extension) => `${indentation}${quote}${extension}${quote},`)
+    .join("\n");
+  const patchedEntries = `${entries.replace(/\s*$/, "")}\n${additions}`;
+  const patched = original.replace(listPattern, `$1${patchedEntries}$3`);
+
+  const verifiedEntries = patched.match(listPattern)?.[2] ?? "";
+  for (const extension of REQUIRED_TRUST_EXTENSIONS) {
+    if (!extensionPattern(extension).test(verifiedEntries)) {
+      throw new Error(`Failed to add .${extension} to ClawHub text extension allowlist`);
+    }
+  }
+
+  await writeFile(textFilesPath, patched, "utf8");
+  return { patched: true, path: textFilesPath, extensions: REQUIRED_TRUST_EXTENSIONS };
+}
+
+async function main() {
+  const prefixIndex = process.argv.indexOf("--cli-prefix");
+  if (prefixIndex !== -1 && !process.argv[prefixIndex + 1]) {
+    throw new Error("--cli-prefix requires a directory");
+  }
+  const cliPrefix = prefixIndex === -1
+    ? (process.env.CLAWHUB_CLI_PREFIX || ".github/clawhub-cli")
+    : process.argv[prefixIndex + 1];
+  const result = await patchClawhubTrustExtensions(cliPrefix);
+  const action = result.patched ? "Patched" : "Already patched";
+  process.stdout.write(`[patch-clawhub-trust] ${action}: ${result.path}\n`);
+}
+
+const invokedUrl = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : "";
+if (import.meta.url === invokedUrl) {
+  main().catch((error) => {
+    process.stderr.write(`${error.stack || error.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/ci/semver_increment.mjs
+++ b/scripts/ci/semver_increment.mjs
@@ -85,6 +85,21 @@ export function assertSemverIncrement(baseVersion, nextVersion) {
   return true;
 }
 
+export function nextSimulatedReleaseVersion(version) {
+  const parsed = parseSemver(version);
+  const [major, minor, patch] = parsed.core;
+  if (parsed.prerelease.length === 0) {
+    return `${major}.${minor}.${patch + 1}`;
+  }
+
+  const rawPrerelease = parsed.raw.slice(parsed.raw.indexOf("-") + 1);
+  const numberedPrerelease = rawPrerelease.match(/^(.*?)(\d+)$/);
+  if (numberedPrerelease) {
+    return `${major}.${minor}.${patch}-${numberedPrerelease[1]}${Number(numberedPrerelease[2]) + 1}`;
+  }
+  return `${major}.${minor}.${patch}-${rawPrerelease}1`;
+}
+
 async function main() {
   const [baseVersion, nextVersion] = process.argv.slice(2);
   if (!baseVersion || !nextVersion) {

--- a/scripts/ci/semver_increment.mjs
+++ b/scripts/ci/semver_increment.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+function parseIdentifier(identifier) {
+  if (/^\d+$/.test(identifier)) {
+    if (identifier.length > 1 && identifier.startsWith("0")) {
+      throw new Error(`Invalid numeric prerelease identifier with leading zero: ${identifier}`);
+    }
+    return Number(identifier);
+  }
+  return identifier;
+}
+
+export function parseSemver(version) {
+  const normalized = String(version ?? "").trim();
+  const match = normalized.match(
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/,
+  );
+  if (!match) {
+    throw new Error(`Invalid semantic version: ${version}`);
+  }
+  return {
+    raw: normalized,
+    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4] ? match[4].split(".").map(parseIdentifier) : [],
+  };
+}
+
+export function compareSemver(leftVersion, rightVersion) {
+  const left = parseSemver(leftVersion);
+  const right = parseSemver(rightVersion);
+
+  for (let index = 0; index < left.core.length; index += 1) {
+    if (left.core[index] !== right.core[index]) {
+      return left.core[index] < right.core[index] ? -1 : 1;
+    }
+  }
+
+  if (left.prerelease.length === 0 && right.prerelease.length === 0) return 0;
+  if (left.prerelease.length === 0) return 1;
+  if (right.prerelease.length === 0) return -1;
+
+  const length = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftIdentifier = left.prerelease[index];
+    const rightIdentifier = right.prerelease[index];
+    if (leftIdentifier === undefined) return -1;
+    if (rightIdentifier === undefined) return 1;
+    if (leftIdentifier === rightIdentifier) continue;
+    if (typeof leftIdentifier === "number" && typeof rightIdentifier === "number") {
+      return leftIdentifier < rightIdentifier ? -1 : 1;
+    }
+    if (typeof leftIdentifier === "number") return -1;
+    if (typeof rightIdentifier === "number") return 1;
+    return leftIdentifier < rightIdentifier ? -1 : 1;
+  }
+
+  return 0;
+}
+
+export function assertSemverIncrement(baseVersion, nextVersion) {
+  const base = parseSemver(baseVersion);
+  const next = parseSemver(nextVersion);
+  if (base.prerelease.length > 0) {
+    if (compareSemver(nextVersion, baseVersion) <= 0) {
+      throw new Error(
+        `Prerelease version must increase by SemVer precedence: base=${baseVersion}, next=${nextVersion}`,
+      );
+    }
+    return true;
+  }
+
+  const coreComparison = next.core.findIndex(
+    (identifier, index) => identifier !== base.core[index],
+  );
+  const coreIncreases = coreComparison !== -1
+    && next.core[coreComparison] > base.core[coreComparison];
+  if (!coreIncreases) {
+    throw new Error(
+      `Skill core version must increase by at least a patch: base=${baseVersion}, next=${nextVersion}`,
+    );
+  }
+  return true;
+}
+
+async function main() {
+  const [baseVersion, nextVersion] = process.argv.slice(2);
+  if (!baseVersion || !nextVersion) {
+    throw new Error("Usage: node scripts/ci/semver_increment.mjs <base-version> <next-version>");
+  }
+  assertSemverIncrement(baseVersion, nextVersion);
+  process.stdout.write(`SemVer increment verified: ${baseVersion} -> ${nextVersion}\n`);
+}
+
+const invokedUrl = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : "";
+if (import.meta.url === invokedUrl) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/ci/simulate_skill_tag_release.mjs
+++ b/scripts/ci/simulate_skill_tag_release.mjs
@@ -13,6 +13,7 @@ import {
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { nextSimulatedReleaseVersion } from "./semver_increment.mjs";
 
 const TRUST_ARTIFACTS = [
   "skill-card.md",
@@ -93,26 +94,6 @@ function runAllowFailure(command, args, options = {}) {
     encoding: "utf8",
     ...options,
   });
-}
-
-function nextSimulatedReleaseVersion(version) {
-  const versionMatch = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z0-9]+))?$/);
-  if (!versionMatch) {
-    throw new Error(`Cannot derive simulated release version from unsupported version: ${version}`);
-  }
-
-  const [, major, minor, patch, prerelease] = versionMatch;
-  if (!prerelease) {
-    return `${major}.${minor}.${Number(patch) + 1}`;
-  }
-
-  const prereleaseMatch = prerelease.match(/^(.*?)(\d+)$/);
-  if (prereleaseMatch) {
-    const [, label, number] = prereleaseMatch;
-    return `${major}.${minor}.${patch}-${label}${Number(number) + 1}`;
-  }
-
-  return `${major}.${minor}.${patch}-${prerelease}1`;
 }
 
 function normalizeReleasePath(rawPath) {

--- a/scripts/ci/simulate_skill_tag_release.mjs
+++ b/scripts/ci/simulate_skill_tag_release.mjs
@@ -248,14 +248,14 @@ async function createSigningKeyPair(tempRoot) {
   return { privateKeyPath, publicKeyPath };
 }
 
-async function signAdvisoryArtifacts(skillDir, tempRoot) {
+async function signAdvisoryArtifacts(skillDir, tempRoot, signingKeys) {
   const advisoryDir = path.join(skillDir, "advisories");
   const feedPath = path.join(advisoryDir, "feed.json");
   if (!existsSync(feedPath)) {
     return;
   }
 
-  const { privateKeyPath, publicKeyPath } = await createSigningKeyPair(tempRoot);
+  const { privateKeyPath, publicKeyPath } = signingKeys;
   const feedSignaturePath = path.join(advisoryDir, "feed.json.sig");
   const checksumsPath = path.join(advisoryDir, "checksums.json");
   const checksumsSignaturePath = path.join(advisoryDir, "checksums.json.sig");
@@ -399,6 +399,7 @@ async function main() {
     const simulatedVersion = nextSimulatedReleaseVersion(originalVersion);
     const tag = `${skillName}-v${simulatedVersion}`;
     const zipName = `${tag}.zip`;
+    const signingKeys = await createSigningKeyPair(tempRoot);
 
     skill.version = simulatedVersion;
     await writeJson(skillJsonPath, skill);
@@ -407,7 +408,7 @@ async function main() {
       replaceSkillMarkdownVersion(await readFile(skillMdPath, "utf8"), simulatedVersion),
     );
     await addSimulatedChangelogEntry(tempSkillDir, simulatedVersion);
-    await signAdvisoryArtifacts(tempSkillDir, tempRoot);
+    await signAdvisoryArtifacts(tempSkillDir, tempRoot, signingKeys);
 
     if (!skill.sbom || !Array.isArray(skill.sbom.files)) {
       throw new Error(`skill.json missing required release field: sbom.files`);
@@ -495,20 +496,19 @@ async function main() {
     }
     await writeJson(path.join(releaseAssetsDir, "checksums.json"), manifest);
 
-    const { privateKeyPath, publicKeyPath } = await createSigningKeyPair(tempRoot);
     await signFileBase64({
-      keyPath: privateKeyPath,
+      keyPath: signingKeys.privateKeyPath,
       inputPath: path.join(releaseAssetsDir, "checksums.json"),
       outputPath: path.join(releaseAssetsDir, "checksums.sig"),
       tempRoot,
     });
     await verifyFileBase64Signature({
-      publicKeyPath,
+      publicKeyPath: signingKeys.publicKeyPath,
       inputPath: path.join(releaseAssetsDir, "checksums.json"),
       signaturePath: path.join(releaseAssetsDir, "checksums.sig"),
       tempRoot,
     });
-    await cp(publicKeyPath, path.join(releaseAssetsDir, "signing-public.pem"));
+    await cp(signingKeys.publicKeyPath, path.join(releaseAssetsDir, "signing-public.pem"));
 
     await writeJson(path.join(outputDir, "simulation-summary.json"), {
       skill: skillName,

--- a/scripts/test-skill-clawhub-trust-extensions.mjs
+++ b/scripts/test-skill-clawhub-trust-extensions.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { cp, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { patchClawhubTrustExtensions } from "./ci/patch_clawhub_trust_extensions.mjs";
+import {
+  collectClawhubPackageFiles,
+  verifyClawhubClientSelection,
+} from "./ci/clawhub_release_package.mjs";
+
+const tempRoot = await mkdtemp(path.join(os.tmpdir(), "clawhub-trust-extensions-"));
+
+try {
+  const schemaDir = path.join(tempRoot, "node_modules", "clawhub", "dist", "schema");
+  const schemaPath = path.join(schemaDir, "textFiles.js");
+  await mkdir(schemaDir, { recursive: true });
+  await writeFile(path.join(tempRoot, "node_modules", "clawhub", "package.json"), '{"type":"module"}\n');
+  await writeFile(
+    schemaPath,
+    [
+      "const RAW_TEXT_FILE_EXTENSIONS = [",
+      "    'md',",
+      "    'json',",
+      "];",
+      "export const TEXT_FILE_EXTENSIONS = RAW_TEXT_FILE_EXTENSIONS;",
+      "export const TEXT_FILE_EXTENSION_SET = new Set(TEXT_FILE_EXTENSIONS);",
+      "",
+    ].join("\n"),
+  );
+
+  const first = await patchClawhubTrustExtensions(tempRoot);
+  assert.equal(first.patched, true);
+  const patchedSource = await readFile(schemaPath, "utf8");
+  assert.match(patchedSource, /'pem',/);
+  assert.match(patchedSource, /'sig',/);
+
+  const second = await patchClawhubTrustExtensions(tempRoot);
+  assert.equal(second.patched, false, "ClawHub extension patch must be idempotent");
+  assert.equal(await readFile(schemaPath, "utf8"), patchedSource);
+
+  const schema = await import(`${pathToFileURL(schemaPath).href}?test=${Date.now()}`);
+  assert.equal(schema.TEXT_FILE_EXTENSION_SET.has("pem"), true);
+  assert.equal(schema.TEXT_FILE_EXTENSION_SET.has("sig"), true);
+
+  const packageDir = path.join(tempRoot, "package");
+  await mkdir(path.join(packageDir, "lib"), { recursive: true });
+  await writeFile(
+    path.join(packageDir, "skill.json"),
+    `${JSON.stringify({
+      name: "fixture",
+      version: "1.0.0",
+      sbom: { files: [{ path: "lib/.gitkeep", required: false }] },
+    })}\n`,
+  );
+  await writeFile(path.join(packageDir, "SKILL.md"), "# Fixture\n");
+  await writeFile(path.join(packageDir, "signature.sig"), "c2lnbmF0dXJl\n");
+  await writeFile(path.join(packageDir, "key.pem"), "public-key\n");
+  await writeFile(path.join(packageDir, "lib", ".gitkeep"), "");
+
+  const publishableFiles = await collectClawhubPackageFiles(packageDir);
+  assert.deepEqual(
+    [...publishableFiles.keys()].sort(),
+    ["SKILL.md", "key.pem", "signature.sig", "skill.json"],
+    "Only an SBOM-declared optional .gitkeep placeholder may be omitted from ClawHub parity",
+  );
+
+  await writeFile(path.join(packageDir, "runtime.bin"), "required binary\n");
+  await assert.rejects(
+    collectClawhubPackageFiles(packageDir),
+    /would omit non-placeholder package file: runtime\.bin/,
+  );
+  await rm(path.join(packageDir, "runtime.bin"));
+
+  const installedClientSource = path.resolve(".github", "clawhub-cli");
+  const installedSkillsModule = path.join(
+    installedClientSource,
+    "node_modules",
+    "clawhub",
+    "dist",
+    "skills.js",
+  );
+  if (existsSync(installedSkillsModule)) {
+    const installedClientCopy = path.join(tempRoot, "installed-clawhub-client");
+    await cp(installedClientSource, installedClientCopy, { recursive: true });
+    await patchClawhubTrustExtensions(installedClientCopy);
+    assert.deepEqual(
+      await verifyClawhubClientSelection({
+        packageDir,
+        cliPrefix: installedClientCopy,
+      }),
+      { files: publishableFiles.size },
+      "The patched pinned ClawHub client must select every expected trust file",
+    );
+  }
+} finally {
+  await rm(tempRoot, { recursive: true, force: true });
+}
+
+console.log("ClawHub trust-extension patch tests passed");

--- a/scripts/test-skill-release-semver.mjs
+++ b/scripts/test-skill-release-semver.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {
   assertSemverIncrement,
   compareSemver,
+  nextSimulatedReleaseVersion,
   parseSemver,
 } from "./ci/semver_increment.mjs";
 
@@ -47,4 +48,13 @@ for (const [baseVersion, nextVersion] of [
 
 for (const invalidVersion of ["1.2", "01.2.3", "1.2.3-beta.01", "v1.2.3", "1.2.3+build"]) {
   assert.throws(() => parseSemver(invalidVersion), /Invalid/);
+}
+
+for (const [version, expected] of [
+  ["0.1.15", "0.1.16"],
+  ["1.2.3-beta5", "1.2.3-beta6"],
+  ["1.2.3-beta.5", "1.2.3-beta.6"],
+  ["1.2.3-preview", "1.2.3-preview1"],
+]) {
+  assert.equal(nextSimulatedReleaseVersion(version), expected);
 }

--- a/scripts/test-skill-release-semver.mjs
+++ b/scripts/test-skill-release-semver.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import {
+  assertSemverIncrement,
+  compareSemver,
+  parseSemver,
+} from "./ci/semver_increment.mjs";
+
+assert.deepEqual(parseSemver("0.1.15"), {
+  raw: "0.1.15",
+  core: [0, 1, 15],
+  prerelease: [],
+});
+
+for (const [baseVersion, nextVersion] of [
+  ["0.1.14", "0.1.15"],
+  ["1.2.3", "1.3.0"],
+  ["1.2.3", "2.0.0"],
+  ["1.2.3-beta.1", "1.2.3-beta.2"],
+  ["1.2.3-beta.2", "1.2.3"],
+  ["1.2.3", "1.2.4-rc.1"],
+]) {
+  assert.equal(assertSemverIncrement(baseVersion, nextVersion), true);
+  assert.equal(compareSemver(nextVersion, baseVersion), 1);
+}
+
+for (const [baseVersion, nextVersion] of [
+  ["0.1.14", "0.1.14"],
+  ["0.1.14", "0.1.13"],
+  ["1.2.3", "1.2.3-rc.1"],
+  ["2.0.0", "1.99.99"],
+]) {
+  assert.throws(
+    () => assertSemverIncrement(baseVersion, nextVersion),
+    /must increase by at least a patch/,
+  );
+}
+
+for (const [baseVersion, nextVersion] of [
+  ["1.2.3-beta.2", "1.2.3-beta.1"],
+  ["1.2.3-beta.2", "1.2.3-beta.2"],
+]) {
+  assert.throws(
+    () => assertSemverIncrement(baseVersion, nextVersion),
+    /Prerelease version must increase by SemVer precedence/,
+  );
+}
+
+for (const invalidVersion of ["1.2", "01.2.3", "1.2.3-beta.01", "v1.2.3", "1.2.3+build"]) {
+  assert.throws(() => parseSemver(invalidVersion), /Invalid/);
+}

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -557,6 +557,12 @@ assert.match(
 
 assert.match(
   workflow,
+  /Legacy unsigned releases cannot be safely republished; create a new patch release/,
+  'Manual ClawHub republish must fail clearly when a legacy release lacks signed verification assets',
+);
+
+assert.match(
+  workflow,
   /simulate-tag-release-build:[\s\S]*clawhub_release_package\.mjs prepare[\s\S]*clawhub_release_package\.mjs verify-client-selection/,
   'PR tag simulation must verify signed release staging through the patched pinned ClawHub client',
 );

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -7,6 +7,7 @@ const clawhubLockPath = new URL('../.github/clawhub-cli/package-lock.json', impo
 const validateSkillInstallDocsPath = new URL('./ci/validate_skill_install_docs.mjs', import.meta.url);
 const installClawhubCliPath = new URL('./ci/install_clawhub_cli.sh', import.meta.url);
 const patchClawhubPayloadPath = new URL('./ci/patch_clawhub_publish_payload.mjs', import.meta.url);
+const patchClawhubTrustExtensionsPath = new URL('./ci/patch_clawhub_trust_extensions.mjs', import.meta.url);
 const guardClawhubSlugOwnerPath = new URL('./ci/guard_clawhub_slug_owner.sh', import.meta.url);
 const releaseSkillScriptPath = new URL('./release-skill.sh', import.meta.url);
 const workflow = await readFile(workflowPath, 'utf8');
@@ -15,6 +16,7 @@ const clawhubLock = JSON.parse(await readFile(clawhubLockPath, 'utf8'));
 const validateSkillInstallDocs = await readFile(validateSkillInstallDocsPath, 'utf8');
 const installClawhubCli = await readFile(installClawhubCliPath, 'utf8');
 const patchClawhubPayload = await readFile(patchClawhubPayloadPath, 'utf8');
+const patchClawhubTrustExtensions = await readFile(patchClawhubTrustExtensionsPath, 'utf8');
 const guardClawhubSlugOwner = await readFile(guardClawhubSlugOwnerPath, 'utf8');
 const releaseSkillScript = await readFile(releaseSkillScriptPath, 'utf8');
 
@@ -91,6 +93,24 @@ assert.match(
 
 assert.match(
   workflow,
+  /sign_advisory_artifacts "\$\{inner_dir\}"/,
+  'PR release dry-runs must sign advisory artifacts inside the staged package',
+);
+
+assert.doesNotMatch(
+  workflow,
+  /Removed test signatures from release staging|rm -f "\$\{inner_dir\}\/advisories\/(?:feed\.json\.sig|checksums\.json|checksums\.json\.sig|feed-signing-public\.pem)"/,
+  'PR release dry-runs must retain the complete signed advisory trust set in the simulated archive',
+);
+
+assert.doesNotMatch(
+  workflow,
+  /rm -f "\$\{skill_dir\}\/advisories\/(?:feed\.json\.sig|checksums\.json|checksums\.json\.sig|feed-signing-public\.pem)"/,
+  'PR release dry-runs must not delete tracked or generated advisory trust files from source directories',
+);
+
+assert.match(
+  workflow,
   /release_tag="\$\{skill_release_name\}-v\$\{head_json_version\}"/,
   'Skill release validation must use the skill package directory name for release tag checks',
 );
@@ -117,6 +137,12 @@ assert.match(
   workflow,
   /::error file=\$\{skill_dir\}::Changed skill package has no version bump and release tag \$\{release_tag\} already exists\./,
   'Skill release validation must still fail unchanged versions after their release tag exists',
+);
+
+assert.match(
+  workflow,
+  /node scripts\/ci\/semver_increment\.mjs "\$\{base_json_version\}" "\$\{head_json_version\}"/,
+  'Changed skill versions must increase by SemVer precedence instead of merely differing from the base version',
 );
 
 assert.match(
@@ -405,8 +431,8 @@ assert.match(
 
 assert.match(
   workflow,
-  /cp scripts\/ci\/resolve_clawhub_slug\.mjs "\$RUNNER_TEMP\/resolve_clawhub_slug\.mjs"[\s\S]*cp scripts\/ci\/skill_platforms\.mjs "\$RUNNER_TEMP\/skill_platforms\.mjs"/,
-  'Manual ClawHub republish must preserve the current slug helper and its local module dependency before checking out an older release tag',
+  /cp scripts\/ci\/resolve_clawhub_slug\.mjs "\$RUNNER_TEMP\/resolve_clawhub_slug\.mjs"[\s\S]*cp scripts\/ci\/skill_platforms\.mjs "\$RUNNER_TEMP\/skill_platforms\.mjs"[\s\S]*cp scripts\/ci\/clawhub_release_package\.mjs "\$RUNNER_TEMP\/clawhub_release_package\.mjs"/,
+  'Manual ClawHub republish must preserve current slug and signed-package helpers before checking out an older release tag',
 );
 
 assert.match(
@@ -429,6 +455,18 @@ assert.match(
 
 assert.match(
   workflow,
+  /id: clawhub-version[\s\S]*already_exists=true[\s\S]*skipping upload and verifying exact registry contents/,
+  'Automatic ClawHub retries must verify an existing version instead of failing before package parity checks',
+);
+
+assert.match(
+  workflow,
+  /Publish to ClawHub[\s\S]*steps\.clawhub-version\.outputs\.already_exists != 'true'/,
+  'Automatic ClawHub retries must skip only the duplicate upload while retaining post-publish verification',
+);
+
+assert.match(
+  workflow,
   /--slug "\$CLAWHUB_SLUG"/,
   'ClawHub publish must use the resolved ClawHub slug',
 );
@@ -440,15 +478,87 @@ assert.match(
 );
 
 assert.equal(
-  workflow.match(/bash scripts\/ci\/install_clawhub_cli\.sh/g)?.length,
+  workflow.match(/gh release download "\$TAG"/g)?.length,
   2,
-  'ClawHub publish and republish jobs must share the same pinned CLI installer',
+  'Automatic and manual ClawHub publication must download the GitHub release payload',
+);
+
+assert.equal(
+  workflow.match(/--pattern "checksums\.sig"/g)?.length,
+  2,
+  'Automatic and manual ClawHub publication must download the signed release manifest companions',
+);
+
+assert.equal(
+  workflow.match(/clawhub_release_package\.mjs"? prepare/g)?.length,
+  3,
+  'PR simulation, automatic publication, and manual publication must prepare a verified package from the signed release archive',
+);
+
+assert.equal(
+  workflow.match(/clawhub_release_package\.mjs"? verify-registry/g)?.length,
+  2,
+  'Automatic and manual ClawHub publication must share registry retry and hash verification',
+);
+
+assert.doesNotMatch(
+  workflow,
+  /for attempt in 1 2 3 4 5 6/,
+  'ClawHub registry retry logic must remain centralized in the release package helper',
+);
+
+assert.equal(
+  workflow.match(/SKILL_PATH="\$\{\{ steps\.clawhub-package\.outputs\.skill_path \}\}"/g)?.length,
+  4,
+  'ClawHub publish, republish, and their verification steps must use the verified release package path',
+);
+
+assert.doesNotMatch(
+  workflow,
+  /publish-clawhub:[\s\S]*?continue-on-error:\s*true/,
+  'ClawHub package verification must be a blocking release gate',
+);
+
+assert.match(
+  workflow,
+  /Require ClawHub token[\s\S]*::error::CLAWHUB_TOKEN secret is not set/,
+  'Publishable tagged skills must fail when the ClawHub token is unavailable',
+);
+
+assert.equal(
+  workflow.match(/grep -Eqi "version \.\*already exists"/g)?.length,
+  2,
+  'Duplicate publish retries must recognize version-specific already-exists responses before post-publish verification',
+);
+
+assert.equal(
+  workflow.match(/bash scripts\/ci\/install_clawhub_cli\.sh/g)?.length,
+  3,
+  'ClawHub simulation, publish, and republish jobs must share the same pinned CLI installer',
 );
 
 assert.equal(
   workflow.match(/node scripts\/ci\/patch_clawhub_publish_payload\.mjs/g)?.length,
   2,
   'ClawHub publish and republish jobs must share the same payload patch helper',
+);
+
+assert.equal(
+  workflow.match(/run: node (?:scripts\/ci\/|"\$RUNNER_TEMP\/)?patch_clawhub_trust_extensions\.mjs"?/g)?.length,
+  3,
+  'ClawHub simulation, automatic publishing, and manual publishing must apply the trust-extension patch',
+);
+
+assert.match(
+  workflow,
+  /cp scripts\/ci\/patch_clawhub_trust_extensions\.mjs "\$RUNNER_TEMP\/patch_clawhub_trust_extensions\.mjs"/,
+  'Manual ClawHub republish must preserve the current trust-extension patch across tag checkout',
+);
+
+assert.match(
+  workflow,
+  /simulate-tag-release-build:[\s\S]*clawhub_release_package\.mjs prepare[\s\S]*clawhub_release_package\.mjs verify-client-selection/,
+  'PR tag simulation must verify signed release staging through the patched pinned ClawHub client',
 );
 
 assert.equal(
@@ -512,6 +622,19 @@ assert.match(
   patchClawhubPayload,
   /Already patched/,
   'ClawHub payload patch helper must stay idempotent when the pinned CLI already includes acceptLicenseTerms',
+);
+
+for (const extension of ['pem', 'sig']) {
+  assert.ok(
+    patchClawhubTrustExtensions.includes(`"${extension}"`),
+    `ClawHub trust-extension patch must preserve .${extension} release artifacts`,
+  );
+}
+
+assert.match(
+  patchClawhubTrustExtensions,
+  /Already patched/,
+  'ClawHub trust-extension patch must be idempotent when the client already accepts trust artifacts',
 );
 
 assert.match(

--- a/scripts/test-skill-tag-release-simulation.mjs
+++ b/scripts/test-skill-tag-release-simulation.mjs
@@ -6,12 +6,24 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
+import {
+  collectClawhubPackageFiles,
+  collectPackageFiles,
+  prepareReleasePackage,
+  verifyRegistryPackage,
+  verifyPublishedPackage,
+} from "./ci/clawhub_release_package.mjs";
 
 const tempRoot = await mkdtemp(path.join(tmpdir(), "clawsec-tag-release-sim-"));
 const fakeSkillspector = path.join(tempRoot, "skillspector");
+const fakeClawhub = path.join(tempRoot, "clawhub");
 
 function sha256(buffer) {
   return createHash("sha256").update(buffer).digest("hex");
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
 }
 
 async function prereleaseFixture(sourceSkillDir, version, fixtureGroup) {
@@ -113,6 +125,53 @@ async function runSimulation({
   const archive = await readFile(archivePath);
   assert.ok(archive.length > 0, "release archive should not be empty");
 
+  if (!verifyEmbeddedAdvisory) {
+    const clawhubOutputDir = path.join(outputDir, "clawhub-package");
+    const prepared = await prepareReleasePackage({
+      releaseDir: releaseAssetsDir,
+      outputDir: clawhubOutputDir,
+      skillName,
+      version: expectedSimulated,
+      canonicalKeyPath: path.join(releaseAssetsDir, "signing-public.pem"),
+    });
+    const publishableFiles = await collectClawhubPackageFiles(prepared.packageDir);
+    const inspectJsonPath = path.join(outputDir, "clawhub-inspect.json");
+    await writeFile(inspectJsonPath, `${JSON.stringify({
+      version: { version: expectedSimulated, files: [...publishableFiles.values()] },
+    }, null, 2)}\n`);
+    assert.deepEqual(
+      await verifyPublishedPackage({
+        packageDir: prepared.packageDir,
+        inspectJsonPath,
+        version: expectedSimulated,
+      }),
+      { version: expectedSimulated, files: publishableFiles.size },
+    );
+
+    const registryAttemptPath = path.join(outputDir, "clawhub-inspect-attempts.txt");
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${tempRoot}:${previousPath}`;
+    process.env.FAKE_CLAWHUB_INSPECT_JSON = inspectJsonPath;
+    process.env.FAKE_CLAWHUB_ATTEMPT_FILE = registryAttemptPath;
+    try {
+      assert.deepEqual(
+        await verifyRegistryPackage({
+          packageDir: prepared.packageDir,
+          slug: "clawsec-suite",
+          version: expectedSimulated,
+          attempts: 2,
+          delayMs: 1,
+        }),
+        { version: expectedSimulated, files: publishableFiles.size },
+      );
+      assert.equal(await readFile(registryAttemptPath, "utf8"), "2");
+    } finally {
+      process.env.PATH = previousPath;
+      delete process.env.FAKE_CLAWHUB_INSPECT_JSON;
+      delete process.env.FAKE_CLAWHUB_ATTEMPT_FILE;
+    }
+  }
+
   if (verifyEmbeddedAdvisory) {
     const readArchiveEntry = (entry) => {
       const extracted = spawnSync("unzip", ["-p", archivePath, entry], {
@@ -181,6 +240,91 @@ async function runSimulation({
     });
     assert.equal(loadedFeed.version, canonicalFeedPayload.version);
     assert.equal(loadedFeed.advisories.length, canonicalFeedPayload.advisories.length);
+
+    const clawhubOutputDir = path.join(outputDir, "clawhub-package");
+    const prepared = await prepareReleasePackage({
+      releaseDir: releaseAssetsDir,
+      outputDir: clawhubOutputDir,
+      skillName,
+      version: expectedSimulated,
+      canonicalKeyPath: path.join(releaseAssetsDir, "signing-public.pem"),
+    });
+    assert.equal(prepared.embeddedAdvisoryTrust.verified, true);
+    assert.equal(prepared.embeddedAdvisoryTrust.files, 5);
+
+    const preparedFiles = await collectPackageFiles(prepared.packageDir);
+    const publishableFiles = await collectClawhubPackageFiles(prepared.packageDir);
+    const extractedFiles = await collectPackageFiles(extractedSkillDir);
+    assert.deepEqual(
+      Object.fromEntries(preparedFiles),
+      Object.fromEntries(extractedFiles),
+      "ClawHub staging must be byte-identical to the verified GitHub release archive",
+    );
+
+    const preparedAdvisoryDir = path.join(prepared.packageDir, "advisories");
+    const preparedFeedPath = path.join(preparedAdvisoryDir, "feed.json");
+    const preparedPublicKeyPath = path.join(preparedAdvisoryDir, "feed-signing-public.pem");
+    const preparedPublicKeyPem = await readFile(preparedPublicKeyPath, "utf8");
+    const preparedFeedModuleUrl = pathToFileURL(
+      path.join(prepared.packageDir, "hooks", "clawsec-advisory-guardian", "lib", "feed.mjs"),
+    );
+    const { loadLocalFeed: loadClawHubFeed } = await import(preparedFeedModuleUrl.href);
+    const clawhubFeed = await loadClawHubFeed(preparedFeedPath, {
+      signaturePath: `${preparedFeedPath}.sig`,
+      checksumsPath: path.join(preparedAdvisoryDir, "checksums.json"),
+      checksumsSignaturePath: path.join(preparedAdvisoryDir, "checksums.json.sig"),
+      publicKeyPem: preparedPublicKeyPem,
+      checksumsPublicKeyPem: preparedPublicKeyPem,
+      verifyChecksumManifest: true,
+      checksumPublicKeyEntry: path.basename(preparedPublicKeyPath),
+    });
+    assert.equal(clawhubFeed.version, canonicalFeedPayload.version);
+    assert.equal(clawhubFeed.advisories.length, canonicalFeedPayload.advisories.length);
+
+    const inspectJsonPath = path.join(outputDir, "clawhub-inspect.json");
+    const inspectPayload = {
+      version: {
+        version: expectedSimulated,
+        files: [...publishableFiles.values()],
+      },
+    };
+    await writeFile(inspectJsonPath, `${JSON.stringify(inspectPayload, null, 2)}\n`);
+    assert.deepEqual(
+      await verifyPublishedPackage({
+        packageDir: prepared.packageDir,
+        inspectJsonPath,
+        version: expectedSimulated,
+      }),
+      { version: expectedSimulated, files: publishableFiles.size },
+    );
+
+    const incompleteInspectPath = path.join(outputDir, "clawhub-inspect-missing-key.json");
+    const incompleteInspect = cloneJson(inspectPayload);
+    incompleteInspect.version.files = incompleteInspect.version.files.filter(
+      (entry) => entry.path !== "advisories/feed-signing-public.pem",
+    );
+    await writeFile(incompleteInspectPath, `${JSON.stringify(incompleteInspect, null, 2)}\n`);
+    await assert.rejects(
+      verifyPublishedPackage({
+        packageDir: prepared.packageDir,
+        inspectJsonPath: incompleteInspectPath,
+        version: expectedSimulated,
+      }),
+      /missing advisories\/feed-signing-public\.pem/,
+    );
+
+    const duplicateInspectPath = path.join(outputDir, "clawhub-inspect-duplicate-path.json");
+    const duplicateInspect = cloneJson(inspectPayload);
+    duplicateInspect.version.files.push(duplicateInspect.version.files[0]);
+    await writeFile(duplicateInspectPath, `${JSON.stringify(duplicateInspect, null, 2)}\n`);
+    await assert.rejects(
+      verifyPublishedPackage({
+        packageDir: prepared.packageDir,
+        inspectJsonPath: duplicateInspectPath,
+        version: expectedSimulated,
+      }),
+      /duplicate file paths/,
+    );
   }
 
   const install = await readFile(path.join(releaseAssetsDir, "install.md"), "utf8");
@@ -239,14 +383,43 @@ writeFileSync(process.argv[outputIndex + 1], "# Fake SkillSpector Report\\n\\nNo
     { mode: 0o700 },
   );
   await chmod(fakeSkillspector, 0o700);
+  await writeFile(
+    fakeClawhub,
+    `#!/usr/bin/env node
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+const attemptFile = process.env.FAKE_CLAWHUB_ATTEMPT_FILE;
+const inspectFile = process.env.FAKE_CLAWHUB_INSPECT_JSON;
+if (process.argv[2] !== "inspect" || !attemptFile || !inspectFile) {
+  process.exit(2);
+}
+const attempt = existsSync(attemptFile) ? Number(readFileSync(attemptFile, "utf8")) + 1 : 1;
+writeFileSync(attemptFile, String(attempt));
+if (attempt === 1) {
+  process.stderr.write("registry result not yet visible\\n");
+  process.exit(1);
+}
+process.stdout.write(readFileSync(inspectFile, "utf8"));
+`,
+    { mode: 0o700 },
+  );
+  await chmod(fakeClawhub, 0o700);
 
   await runSimulation({
     skillDir: "skills/clawsec-suite",
     outputDir: path.join(tempRoot, "stable"),
-    expectedOriginal: "0.1.14",
-    expectedSimulated: "0.1.15",
+    expectedOriginal: "0.1.15",
+    expectedSimulated: "0.1.16",
     expectedAgent: "openclaw",
     verifyEmbeddedAdvisory: true,
+  });
+
+  await runSimulation({
+    skillDir: "skills/clawsec-feed",
+    outputDir: path.join(tempRoot, "feed-only"),
+    expectedOriginal: "0.0.11",
+    expectedSimulated: "0.0.12",
+    expectedAgent: "openclaw",
   });
 
   await runSimulation({

--- a/scripts/test-skill-tag-release-simulation.mjs
+++ b/scripts/test-skill-tag-release-simulation.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { chmod, cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, cp, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -49,6 +49,7 @@ async function runSimulation({
   expectedSimulated,
   expectedAgent,
   verifyEmbeddedAdvisory = false,
+  expectedPreparationError = null,
 }) {
   const result = spawnSync(
     process.execPath,
@@ -127,48 +128,61 @@ async function runSimulation({
 
   if (!verifyEmbeddedAdvisory) {
     const clawhubOutputDir = path.join(outputDir, "clawhub-package");
-    const prepared = await prepareReleasePackage({
+    const prepareOptions = {
       releaseDir: releaseAssetsDir,
       outputDir: clawhubOutputDir,
       skillName,
       version: expectedSimulated,
       canonicalKeyPath: path.join(releaseAssetsDir, "signing-public.pem"),
-    });
-    const publishableFiles = await collectClawhubPackageFiles(prepared.packageDir);
-    const inspectJsonPath = path.join(outputDir, "clawhub-inspect.json");
-    await writeFile(inspectJsonPath, `${JSON.stringify({
-      version: { version: expectedSimulated, files: [...publishableFiles.values()] },
-    }, null, 2)}\n`);
-    assert.deepEqual(
-      await verifyPublishedPackage({
-        packageDir: prepared.packageDir,
-        inspectJsonPath,
-        version: expectedSimulated,
-      }),
-      { version: expectedSimulated, files: publishableFiles.size },
-    );
-
-    const registryAttemptPath = path.join(outputDir, "clawhub-inspect-attempts.txt");
-    const previousPath = process.env.PATH;
-    process.env.PATH = `${tempRoot}:${previousPath}`;
-    process.env.FAKE_CLAWHUB_INSPECT_JSON = inspectJsonPath;
-    process.env.FAKE_CLAWHUB_ATTEMPT_FILE = registryAttemptPath;
-    try {
+    };
+    if (expectedPreparationError) {
+      await assert.rejects(
+        prepareReleasePackage(prepareOptions),
+        expectedPreparationError,
+      );
       assert.deepEqual(
-        await verifyRegistryPackage({
+        await readdir(clawhubOutputDir),
+        [],
+        "failed ClawHub staging must leave the output directory safely retryable",
+      );
+    } else {
+      const prepared = await prepareReleasePackage(prepareOptions);
+      const publishableFiles = await collectClawhubPackageFiles(prepared.packageDir);
+      const inspectJsonPath = path.join(outputDir, "clawhub-inspect.json");
+      await writeFile(inspectJsonPath, `${JSON.stringify({
+        version: { version: expectedSimulated, files: [...publishableFiles.values()] },
+      }, null, 2)}\n`);
+      assert.deepEqual(
+        await verifyPublishedPackage({
           packageDir: prepared.packageDir,
-          slug: "clawsec-suite",
+          inspectJsonPath,
           version: expectedSimulated,
-          attempts: 2,
-          delayMs: 1,
         }),
         { version: expectedSimulated, files: publishableFiles.size },
       );
-      assert.equal(await readFile(registryAttemptPath, "utf8"), "2");
-    } finally {
-      process.env.PATH = previousPath;
-      delete process.env.FAKE_CLAWHUB_INSPECT_JSON;
-      delete process.env.FAKE_CLAWHUB_ATTEMPT_FILE;
+
+      const registryAttemptPath = path.join(outputDir, "clawhub-inspect-attempts.txt");
+      const previousPath = process.env.PATH;
+      process.env.PATH = `${tempRoot}:${previousPath}`;
+      process.env.FAKE_CLAWHUB_INSPECT_JSON = inspectJsonPath;
+      process.env.FAKE_CLAWHUB_ATTEMPT_FILE = registryAttemptPath;
+      try {
+        assert.deepEqual(
+          await verifyRegistryPackage({
+            packageDir: prepared.packageDir,
+            slug: "clawsec-suite",
+            version: expectedSimulated,
+            attempts: 2,
+            delayMs: 1,
+          }),
+          { version: expectedSimulated, files: publishableFiles.size },
+        );
+        assert.equal(await readFile(registryAttemptPath, "utf8"), "2");
+      } finally {
+        process.env.PATH = previousPath;
+        delete process.env.FAKE_CLAWHUB_INSPECT_JSON;
+        delete process.env.FAKE_CLAWHUB_ATTEMPT_FILE;
+      }
     }
   }
 
@@ -455,6 +469,29 @@ process.stdout.write(readFileSync(inspectFile, "utf8"));
     expectedOriginal: "0.0.1-preview",
     expectedSimulated: "0.0.1-preview1",
     expectedAgent: "openclaw",
+  });
+
+  const unsupportedSkillDir = await prereleaseFixture(
+    "skills/picoclaw-self-pen-testing",
+    "0.0.5",
+    "unsupported-client-file-fixture",
+  );
+  await writeFile(path.join(unsupportedSkillDir, "runtime.bin"), "required runtime binary\n");
+  const unsupportedSkillJsonPath = path.join(unsupportedSkillDir, "skill.json");
+  const unsupportedSkill = JSON.parse(await readFile(unsupportedSkillJsonPath, "utf8"));
+  unsupportedSkill.sbom.files.push({
+    path: "runtime.bin",
+    required: true,
+    description: "Unsupported ClawHub runtime fixture",
+  });
+  await writeFile(unsupportedSkillJsonPath, `${JSON.stringify(unsupportedSkill, null, 2)}\n`);
+  await runSimulation({
+    skillDir: unsupportedSkillDir,
+    outputDir: path.join(tempRoot, "unsupported-client-file"),
+    expectedOriginal: "0.0.5",
+    expectedSimulated: "0.0.6",
+    expectedAgent: "openclaw",
+    expectedPreparationError: /would omit non-placeholder package file: runtime\.bin/,
   });
 } finally {
   await rm(tempRoot, { recursive: true, force: true });

--- a/scripts/test-skill-trust-packet.mjs
+++ b/scripts/test-skill-trust-packet.mjs
@@ -25,7 +25,7 @@ function runTrustPacket(skillDir, targetDir, tag) {
 }
 
 try {
-  const result = runTrustPacket("skills/clawsec-suite", outputDir, "clawsec-suite-v0.1.14");
+  const result = runTrustPacket("skills/clawsec-suite", outputDir, "clawsec-suite-v0.1.15");
 
   assert.equal(
     result.status,
@@ -41,10 +41,10 @@ try {
   assert.match(skillCard, /## License\/Terms of Use/);
   assert.match(skillCard, /AGPL-3\.0-or-later/);
   assert.match(skillCard, /skillspector-report\.md/);
-  assert.match(skillCard, /clawsec-suite-v0\.1\.14/);
+  assert.match(skillCard, /clawsec-suite-v0\.1\.15/);
 
   assert.equal(permissions.skill, "clawsec-suite");
-  assert.equal(permissions.version, "0.1.14");
+  assert.equal(permissions.version, "0.1.15");
   assert.equal(permissions.platform, "openclaw");
   assert.deepEqual(
     permissions.required_binaries,

--- a/skills/clawsec-suite/CHANGELOG.md
+++ b/skills/clawsec-suite/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.1.15] - 2026-07-13
+
+### Fixed
+
+- Published ClawHub packages from the verified, signed GitHub release payload instead of the raw source directory.
+- Preserved `.sig` and `.pem` advisory trust files that ClawHub's client extension allowlist otherwise omitted.
+- Made ClawHub publication blocking and verified every published file hash and size before reporting success.
+
+### Changed
+
+- Enforced the complete five-file embedded advisory trust set in release staging and published-package verification.
+- Required changed skill releases to advance the core version by at least a patch so an already released version cannot be reused.
+
 ## [0.1.14] - 2026-07-13
 
 ### Fixed

--- a/skills/clawsec-suite/SKILL.md
+++ b/skills/clawsec-suite/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawsec-suite
-version: 0.1.14
+version: 0.1.15
 description: ClawSec suite manager with embedded advisory-feed monitoring, cryptographic signature verification, approval-gated malicious-skill response, and guided setup for additional security skills.
 homepage: https://clawsec.prompt.security
 clawdis:
@@ -36,7 +36,7 @@ This means `clawsec-suite` can:
 ## Included vs Optional Protections
 
 ### Built into clawsec-suite
-- Embedded consolidated advisory feed seed file: `advisories/feed.json`
+- Embedded signed advisory trust set: `advisories/feed.json`, `feed.json.sig`, `checksums.json`, `checksums.json.sig`, and `feed-signing-public.pem`
 - Portable heartbeat workflow in `HEARTBEAT.md`
 - Advisory polling + state tracking + affected-skill checks
 - OpenClaw advisory guardian hook package: `hooks/clawsec-advisory-guardian/`

--- a/skills/clawsec-suite/skill.json
+++ b/skills/clawsec-suite/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawsec-suite",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "ClawSec suite manager with embedded advisory-feed monitoring, cryptographic signature verification, approval-gated malicious-skill response, and guided setup for additional security skills.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",
@@ -47,18 +47,18 @@
       },
       {
         "path": "advisories/feed.json.sig",
-        "required": false,
-        "description": "Detached Ed25519 signature for advisory feed when bundled with the local suite seed"
+        "required": true,
+        "description": "Detached Ed25519 signature for the bundled advisory feed"
       },
       {
         "path": "advisories/checksums.json",
         "required": false,
-        "description": "SHA-256 checksum manifest for advisory artifacts when bundled with the local suite seed"
+        "description": "Release-generated SHA-256 manifest; required in every published Suite package"
       },
       {
         "path": "advisories/checksums.json.sig",
         "required": false,
-        "description": "Detached Ed25519 signature for checksum manifest when bundled with the local suite seed"
+        "description": "Release-generated Ed25519 checksum signature; required in every published Suite package"
       },
       {
         "path": "advisories/feed-signing-public.pem",

--- a/wiki/modules/automation-release.md
+++ b/wiki/modules/automation-release.md
@@ -24,15 +24,17 @@ When a skill is tagged (for example, `soul-guardian-v1.0.0`), the pipeline:
 5. Generates `checksums.json` for the archive and release assets.
 6. Signs and verifies release checksum artifacts.
 7. Publishes GitHub Release assets.
-8. Supersedes older releases within the same major version (tags remain).
-9. Triggers website catalog refresh.
+8. Publishes the verified release payload to ClawHub when configured, then compares every expected registry file hash and size with the signed package.
+9. Supersedes older releases within the same major version (tags remain).
+10. Triggers website catalog refresh.
 
 ### PR dry-run behavior
 PRs that touch skill packages run the release workflow in validation mode:
 - `validate-pr-version-sync` checks changed skill metadata and documentation parity.
+- Released stable skills must advance by at least one SemVer patch version; equal or lower versions fail validation.
 - `release` builds dry-run release assets for changed release-relevant skill files.
 - `comment-skillspector-report` posts a sanitized SkillSpector summary back to the PR when reports are available.
-- `simulate-tag-release-build` exercises the tag-release builder across skills without publishing.
+- `simulate-tag-release-build` exercises the tag-release builder across skills, verifies signed ClawHub staging through the patched pinned client, and does not publish.
 
 The PR path exists to catch packaging, signing, and release-evidence regressions before a maintainer pushes a real release tag.
 
@@ -61,9 +63,18 @@ Enforced in:
 - `.github/workflows/deploy-pages.yml`
 
 ### Release versioning and superseding
+- Changes to an already released stable skill must increment its version by at least one patch version (for example, `0.1.14` to `0.1.15`).
 - New patch/minor release: previous releases in same major line are removed.
 - New major release: latest release from previous major line is retained for compatibility.
 - Git tags are preserved and can be used to recreate releases when needed.
+
+### ClawHub package parity
+- ClawHub publication uses the package extracted from the signed GitHub release archive, not `skills/<name>/` directly.
+- The pinned ClawHub client is patched to accept `.sig` and `.pem` text trust artifacts before upload.
+- Publication is a blocking release job for configured skills.
+- After publish, `clawhub inspect` must report the exact expected publishable paths, SHA-256 hashes, and sizes. Missing or extra files fail the job.
+- SBOM-declared optional `.gitkeep` placeholders are the only allowed release/archive omission because ClawHub intentionally ignores dotfiles. Any other client-unsupported package file blocks publication.
+- For Suite releases, package preparation verifies the embedded feed signature, checksum signature, signing-key fingerprint, and all required local fallback artifacts before upload.
 
 ### Release artifacts
 Each skill release includes:
@@ -147,6 +158,8 @@ on:
 ## Edge Cases
 - NVD API rate limiting (`403`/`429`) is handled with retry/backoff and can fail workflow on persistent errors.
 - Release pipeline blocks on version mismatch between `skill.json` and `SKILL.md` frontmatter.
+- Release pipeline blocks equal or decreasing versions for changed, previously released skills.
+- ClawHub may silently omit unsupported file extensions; the workflow patches the pinned client and verifies the published registry file list to detect this.
 - Key fingerprint drift between canonical PEM files and docs hard-fails signing-related workflows.
 - Deploy workflow intentionally allows unsigned legacy checksums for backward compatibility in some branches.
 - Manual helper script has safety checks but includes destructive rollback logic in error branches; use carefully.

--- a/wiki/modules/clawsec-suite.md
+++ b/wiki/modules/clawsec-suite.md
@@ -16,6 +16,17 @@
 - `skills/clawsec-suite/scripts/guarded_skill_install.mjs`: advisory-gated installer wrapper.
 - `skills/clawsec-suite/scripts/discover_skill_catalog.mjs`: remote/fallback catalog discovery.
 
+## Packaged Advisory Trust Set
+The standard installed Suite package must contain all five files below:
+
+- `advisories/feed.json`
+- `advisories/feed.json.sig`
+- `advisories/checksums.json`
+- `advisories/checksums.json.sig`
+- `advisories/feed-signing-public.pem`
+
+The local fallback is considered usable only when this complete set verifies. GitHub release and ClawHub packaging must preserve the same signed payload; a registry publish that omits any file is a release failure.
+
 ## Public Interfaces
 | Interface | Consumer | Behavior |
 | --- | --- | --- |
@@ -65,7 +76,7 @@ if (matches.length > 0 && !args.confirmAdvisory) {
 ```
 
 ## Edge Cases
-- Missing/malformed feed signatures force remote rejection and local fallback attempts.
+- Missing/malformed feed signatures force remote rejection and local fallback attempts; an incomplete local trust set cannot be accepted as a verified fallback.
 - Ambiguous checksum manifest basename collisions are treated as errors.
 - Unknown skill versions are treated conservatively in version matching logic.
 - Suppression is disabled unless config includes the pipeline sentinel (`enabledFor`).

--- a/wiki/security-signing-runbook.md
+++ b/wiki/security-signing-runbook.md
@@ -151,6 +151,8 @@ Signing controls:
 Operator review points:
 - verify `checksums.json` includes the release-evidence files documented in `wiki/modules/automation-release.md`
 - verify `checksums.sig` validates against `signing-public.pem`
+- for `clawsec-suite`, verify the GitHub archive and installed ClawHub package both contain `advisories/feed.json`, `feed.json.sig`, `checksums.json`, `checksums.json.sig`, and `feed-signing-public.pem`
+- require the ClawHub post-publish file hash/size comparison to pass before treating a tag release as complete
 - review the release workflow run and PR evidence links before pushing or approving follow-up release tags
 
 ## 8) Rotation policy and runbook

--- a/wiki/workflow.md
+++ b/wiki/workflow.md
@@ -36,7 +36,7 @@
 - Tag pushes matching `<skill>-v<semver>` build the real release payload, sign `checksums.json`, verify the signature, and publish GitHub Release assets.
 - Skill packaging includes SBOM-declared files, release trust packet files, install instructions, security scan evidence, and integrity manifests.
 - `checksums.json` is signed and immediately verified in workflow execution.
-- Optional publish-to-ClawHub job runs after successful GitHub release when configured.
+- Configured ClawHub publication runs as a blocking job after the GitHub release, uploads the verified signed-release payload, and checks exact registry file parity.
 - Older releases within same major line can be superseded/deleted by automation.
 
 ## SkillSpector Release Evidence


### PR DESCRIPTION
# User description
### Summary

- Bump only `clawsec-suite` from 0.1.14 to 0.1.15.
- Publish ClawHub from the verified, signed GitHub release archive instead of the raw source directory.
- Patch the pinned ClawHub client so `.sig` and `.pem` trust artifacts are selected for upload.
- Make configured ClawHub publication blocking and verify exact expected registry paths, hashes, and sizes after publish.
- Require stable skill changes to advance the core version by at least one patch.
- Document the five-file Suite fallback trust set in the skill and wiki.

---

### Root cause

The GitHub release for Suite 0.1.14 contains the complete signed local fallback, but the ClawHub 0.1.14 package contains only `advisories/feed.json`. Two behaviors combined to cause that mismatch:

- The release workflow published `skills/clawsec-suite` directly instead of the already verified release archive, so release-generated `advisories/checksums.json` and `advisories/checksums.json.sig` were unavailable.
- The pinned ClawHub client text-extension allowlist omits `.sig` and `.pem`, so it silently dropped the tracked feed signature and signing key. The current published ClawHub client still omits both extensions, so a version bump alone would not fix this.

The old PR dry-run also removed all four trust companions from its staged archive under a residual test-signature assumption. This PR signs inside staging, retains the full trust set, and no longer rewrites or deletes tracked source trust files.

---

### Verification and CI coverage

- Verify the outer release checksum signature and canonical signing-key fingerprint before ClawHub staging.
- For Suite packages, verify all five internal artifacts, the feed signature, checksum signature, feed/key checksums, and embedded/release key equality.
- Run the packaged Suite fallback through the real runtime loader with checksum verification enabled.
- Install and patch the pinned ClawHub client in PR CI, then verify its actual file selection for every simulated skill release.
- Permit only SBOM-declared optional `.gitkeep` placeholders to be omitted; any unsupported runtime file blocks publication.
- Compare post-publish `clawhub inspect` paths, SHA-256 hashes, and sizes, rejecting missing, extra, duplicate, or changed files.
- Safely verify an already-existing version on workflow retry instead of failing before parity checks.

Local checks passed:

- all `scripts/test-skill-*.mjs` release-tooling tests
- all `skills/clawsec-suite/test/*.test.mjs` tests
- actual pinned ClawHub 0.7.0 client selection test
- `python3 utils/validate_skill.py skills/clawsec-suite`
- tracked-repository ESLint with the unrelated `.worktrees/**` tree excluded
- `npx tsc --noEmit`
- `npm run gen:wiki-llms`
- `npm run build`
- workflow YAML parse and `git diff --check`

The unscoped local ESLint command still traverses an unrelated existing `.worktrees/pr-255/dist` bundle; CI checkouts do not contain that user-owned worktree.

---

### Scope

The five-file internal fallback requirement applies to packages that declare that full trust set, including Suite. `clawsec-feed` retains its separate feed-only package contract while still receiving signed outer-release and registry parity checks. Other public harness packages are exercised by the same ClawHub simulation, including their intentional optional `.gitkeep` placeholders.

Follow-up to #298.

---

### Post-merge release

After merge, create `clawsec-suite-v0.1.15` from the merged `main` commit. Treat the release as complete only after the GitHub release job, blocking ClawHub publish/parity job, and an installed-package fallback load all pass.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enforce patch-version increments and keep staged advisory trust artifacts intact so every Suite dry-run validates the documented fallback payload before metadata or changelog versions land in a release. Drive ClawHub publication from the verified GitHub release archive by preparing and verifying a signed package with the new helper, patching the pinned client, and gating the blocking publish/reg‑istry parity job on those checks.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/299?tool=ast&topic=Release+gating>Release gating</a>
        </td><td>Enforce version-gate and trust-policy guards by validating semver bumps, signing staged advisories, and documenting the five‑file Suite trust set across metadata, changelog, workflow tests, and release runbooks.<details><summary>Modified files (13)</summary><ul><li>.github/workflows/skill-release.yml</li>
<li>scripts/ci/semver_increment.mjs</li>
<li>scripts/ci/simulate_skill_tag_release.mjs</li>
<li>scripts/test-skill-release-semver.mjs</li>
<li>scripts/test-skill-release-workflow.mjs</li>
<li>scripts/test-skill-tag-release-simulation.mjs</li>
<li>skills/clawsec-suite/CHANGELOG.md</li>
<li>skills/clawsec-suite/SKILL.md</li>
<li>skills/clawsec-suite/skill.json</li>
<li>wiki/modules/automation-release.md</li>
<li>wiki/modules/clawsec-suite.md</li>
<li>wiki/security-signing-runbook.md</li>
<li>wiki/workflow.md</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/299?tool=ast&topic=ClawHub+publish>ClawHub publish</a>
        </td><td>Validate and publish ClawHub releases from the signed archive by preparing a verified package, patching the client to allow <code>.sig</code>/<code>.pem</code>, exercising the pipeline through simulations and tests, and blocking both automatic and manual publishes on parity checks.<details><summary>Modified files (6)</summary><ul><li>.github/workflows/skill-release.yml</li>
<li>scripts/ci/clawhub_release_package.mjs</li>
<li>scripts/ci/patch_clawhub_trust_extensions.mjs</li>
<li>scripts/test-skill-clawhub-trust-extensions.mjs</li>
<li>scripts/test-skill-tag-release-simulation.mjs</li>
<li>scripts/test-skill-trust-packet.mjs</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/299?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>