### PR TITLE
fix(release): upload ClawHub trust artifacts as text

### DIFF
--- a/scripts/ci/clawhub_release_package.mjs
+++ b/scripts/ci/clawhub_release_package.mjs
@@ -30,6 +30,15 @@ const ADVISORY_TRUST_ARTIFACTS = [
 ];
 const CLAWHUB_TEXT_TRUST_EXTENSIONS = new Set(["pem", "sig"]);
 
+function isTestReleasePath(filePath) {
+  const normalized = filePath.replaceAll("\\", "/").toLowerCase();
+  const parts = normalized.split("/");
+  const name = parts.at(-1) ?? "";
+  return parts.some((part) => ["__tests__", "test", "tests"].includes(part))
+    || /^(?:test|spec)[_-]/.test(name)
+    || /\.(?:test|spec)\./.test(name);
+}
+
 function usage() {
   return [
     "Usage:",
@@ -161,6 +170,9 @@ export async function collectClawhubPackageFiles(rootDir) {
   const publishedFiles = new Map();
 
   for (const [filePath, metadata] of packageFiles) {
+    if (isTestReleasePath(filePath)) {
+      throw new Error(`ClawHub package must not contain test-only file: ${filePath}`);
+    }
     const parts = filePath.split("/");
     const extension = path.posix.extname(filePath).slice(1).toLowerCase();
     const clientWouldOmit = parts.some((part) => part.startsWith("."))

--- a/scripts/ci/clawhub_release_package.mjs
+++ b/scripts/ci/clawhub_release_package.mjs
@@ -28,6 +28,7 @@ const ADVISORY_TRUST_ARTIFACTS = [
   "advisories/checksums.json.sig",
   "advisories/feed-signing-public.pem",
 ];
+const CLAWHUB_TEXT_TRUST_EXTENSIONS = new Set(["pem", "sig"]);
 
 function usage() {
   return [
@@ -396,6 +397,17 @@ export async function verifyClawhubClientSelection({ packageDir, cliPrefix }) {
   }
 
   const selectedFiles = await skillsModule.listTextFiles(resolvedPackageDir);
+  for (const entry of selectedFiles) {
+    const extension = entry.relPath.split(".").at(-1)?.toLowerCase() ?? "";
+    if (
+      CLAWHUB_TEXT_TRUST_EXTENSIONS.has(extension)
+      && entry.contentType !== "text/plain"
+    ) {
+      throw new Error(
+        `ClawHub client would upload ${entry.relPath} with non-text MIME type: ${entry.contentType ?? "missing"}`,
+      );
+    }
+  }
   const actualFiles = new Map(selectedFiles.map((entry) => [entry.relPath, {
     path: entry.relPath,
     sha256: sha256(Buffer.from(entry.bytes)),

--- a/scripts/ci/clawhub_release_package.mjs
+++ b/scripts/ci/clawhub_release_package.mjs
@@ -14,6 +14,7 @@ import {
 } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { isTestReleasePath } from "./release_path_policy.mjs";
 
 const CLAWHUB_TEXT_EXTENSIONS = new Set([
   "c", "cfg", "cjs", "cpp", "cs", "css", "csv", "env", "go", "h", "hpp",
@@ -29,15 +30,6 @@ const ADVISORY_TRUST_ARTIFACTS = [
   "advisories/feed-signing-public.pem",
 ];
 const CLAWHUB_TEXT_TRUST_EXTENSIONS = new Set(["pem", "sig"]);
-
-function isTestReleasePath(filePath) {
-  const normalized = filePath.replaceAll("\\", "/").toLowerCase();
-  const parts = normalized.split("/");
-  const name = parts.at(-1) ?? "";
-  return parts.some((part) => ["__tests__", "test", "tests"].includes(part))
-    || /^(?:test|spec)[_-]/.test(name)
-    || /\.(?:test|spec)\./.test(name);
-}
 
 function usage() {
   return [

--- a/scripts/ci/patch_clawhub_trust_extensions.mjs
+++ b/scripts/ci/patch_clawhub_trust_extensions.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 const REQUIRED_TRUST_EXTENSIONS = ["pem", "sig"];
+const REQUIRED_TRUST_CONTENT_TYPE = "text/plain";
 
 function resolveTextFilesPath(cliPrefix) {
   return path.join(
@@ -18,17 +19,21 @@ function resolveTextFilesPath(cliPrefix) {
   );
 }
 
+function resolveSkillsPath(cliPrefix) {
+  return path.join(
+    path.resolve(cliPrefix),
+    "node_modules",
+    "clawhub",
+    "dist",
+    "skills.js",
+  );
+}
+
 function extensionPattern(extension) {
   return new RegExp(`["']${extension}["']\\s*,`);
 }
 
-export async function patchClawhubTrustExtensions(cliPrefix) {
-  const textFilesPath = resolveTextFilesPath(cliPrefix);
-  if (!existsSync(textFilesPath)) {
-    throw new Error(`ClawHub text-file schema not found: ${textFilesPath}`);
-  }
-
-  const original = await readFile(textFilesPath, "utf8");
+function patchTextFileExtensions(original, textFilesPath) {
   const listPattern = /(const RAW_TEXT_FILE_EXTENSIONS\s*=\s*\[)([\s\S]*?)(\n\s*\];)/;
   const match = original.match(listPattern);
   if (!match) {
@@ -40,7 +45,7 @@ export async function patchClawhubTrustExtensions(cliPrefix) {
     (extension) => !extensionPattern(extension).test(entries),
   );
   if (missingExtensions.length === 0) {
-    return { patched: false, path: textFilesPath, extensions: REQUIRED_TRUST_EXTENSIONS };
+    return { source: original, patched: false };
   }
 
   const indentation = entries.match(/\n([ \t]+)["']/)?.[1] ?? "    ";
@@ -58,8 +63,62 @@ export async function patchClawhubTrustExtensions(cliPrefix) {
     }
   }
 
-  await writeFile(textFilesPath, patched, "utf8");
-  return { patched: true, path: textFilesPath, extensions: REQUIRED_TRUST_EXTENSIONS };
+  return { source: patched, patched: true };
+}
+
+function patchTrustMimeTypes(original, skillsPath) {
+  const originalAssignment = /const contentType = mime\.getType\(relPath\) \?\? (["'])text\/plain\1;/;
+  const extensions = JSON.stringify(REQUIRED_TRUST_EXTENSIONS);
+  // ClawHub validates upload MIME types separately from its extension allowlist.
+  // The mime package classifies .sig/.pem as non-text even though these files are ASCII here.
+  const patchedAssignment = `const contentType = ${extensions}.includes(ext) ? "${REQUIRED_TRUST_CONTENT_TYPE}" : (mime.getType(relPath) ?? "text/plain");`;
+
+  if (original.includes(patchedAssignment)) {
+    return { source: original, patched: false };
+  }
+  if (!originalAssignment.test(original)) {
+    throw new Error(`Could not find ClawHub MIME assignment in ${skillsPath}`);
+  }
+
+  const patched = original.replace(originalAssignment, patchedAssignment);
+  if (!patched.includes(patchedAssignment)) {
+    throw new Error(`Failed to force trust artifacts to ${REQUIRED_TRUST_CONTENT_TYPE}`);
+  }
+  return { source: patched, patched: true };
+}
+
+export async function patchClawhubTrustExtensions(cliPrefix) {
+  const textFilesPath = resolveTextFilesPath(cliPrefix);
+  const skillsPath = resolveSkillsPath(cliPrefix);
+  if (!existsSync(textFilesPath)) {
+    throw new Error(`ClawHub text-file schema not found: ${textFilesPath}`);
+  }
+  if (!existsSync(skillsPath)) {
+    throw new Error(`ClawHub skill collector not found: ${skillsPath}`);
+  }
+
+  const textFilesPatch = patchTextFileExtensions(
+    await readFile(textFilesPath, "utf8"),
+    textFilesPath,
+  );
+  const skillsPatch = patchTrustMimeTypes(
+    await readFile(skillsPath, "utf8"),
+    skillsPath,
+  );
+  if (textFilesPatch.patched) {
+    await writeFile(textFilesPath, textFilesPatch.source, "utf8");
+  }
+  if (skillsPatch.patched) {
+    await writeFile(skillsPath, skillsPatch.source, "utf8");
+  }
+
+  return {
+    patched: textFilesPatch.patched || skillsPatch.patched,
+    path: textFilesPath,
+    paths: { textFiles: textFilesPath, skills: skillsPath },
+    extensions: REQUIRED_TRUST_EXTENSIONS,
+    contentType: REQUIRED_TRUST_CONTENT_TYPE,
+  };
 }
 
 async function main() {
@@ -72,7 +131,9 @@ async function main() {
     : process.argv[prefixIndex + 1];
   const result = await patchClawhubTrustExtensions(cliPrefix);
   const action = result.patched ? "Patched" : "Already patched";
-  process.stdout.write(`[patch-clawhub-trust] ${action}: ${result.path}\n`);
+  process.stdout.write(
+    `[patch-clawhub-trust] ${action}: ${result.paths.textFiles}, ${result.paths.skills}\n`,
+  );
 }
 
 const invokedUrl = process.argv[1]

--- a/scripts/ci/release_path_policy.mjs
+++ b/scripts/ci/release_path_policy.mjs
@@ -1,0 +1,8 @@
+export function isTestReleasePath(filePath) {
+  const normalized = filePath.replaceAll("\\", "/").toLowerCase();
+  const parts = normalized.split("/");
+  const name = parts.at(-1) ?? "";
+  return parts.some((part) => ["__tests__", "test", "tests"].includes(part))
+    || /^(?:test|spec)[_-]/.test(name)
+    || /\.(?:test|spec)\./.test(name);
+}

--- a/scripts/ci/simulate_skill_tag_release.mjs
+++ b/scripts/ci/simulate_skill_tag_release.mjs
@@ -14,6 +14,7 @@ import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { nextSimulatedReleaseVersion } from "./semver_increment.mjs";
+import { isTestReleasePath } from "./release_path_policy.mjs";
 
 const TRUST_ARTIFACTS = [
   "skill-card.md",
@@ -118,16 +119,6 @@ function normalizeReleasePath(rawPath) {
   }
 
   return releasePath;
-}
-
-function isTestReleasePath(releasePath) {
-  const lower = releasePath.toLowerCase();
-  return lower === "test" ||
-    lower === "tests" ||
-    lower.startsWith("test/") ||
-    lower.startsWith("tests/") ||
-    lower.includes("/test/") ||
-    lower.includes("/tests/");
 }
 
 async function sha256File(filePath) {
@@ -416,7 +407,7 @@ async function main() {
     });
 
     const zipContents = run("unzip", ["-Z1", path.join(releaseAssetsDir, zipName)]);
-    if (zipContents.split("\n").some((entry) => /(^|\/)(test|tests)\//i.test(entry))) {
+    if (zipContents.split("\n").some(isTestReleasePath)) {
       throw new Error(`Simulated release archive contains test-only files: ${zipName}`);
     }
 

--- a/scripts/test-skill-clawhub-trust-extensions.mjs
+++ b/scripts/test-skill-clawhub-trust-extensions.mjs
@@ -15,6 +15,7 @@ const tempRoot = await mkdtemp(path.join(os.tmpdir(), "clawhub-trust-extensions-
 try {
   const schemaDir = path.join(tempRoot, "node_modules", "clawhub", "dist", "schema");
   const schemaPath = path.join(schemaDir, "textFiles.js");
+  const skillsPath = path.join(tempRoot, "node_modules", "clawhub", "dist", "skills.js");
   await mkdir(schemaDir, { recursive: true });
   await writeFile(path.join(tempRoot, "node_modules", "clawhub", "package.json"), '{"type":"module"}\n');
   await writeFile(
@@ -29,16 +30,31 @@ try {
       "",
     ].join("\n"),
   );
+  await writeFile(
+    skillsPath,
+    [
+      "const ext = relPath.split('.').at(-1)?.toLowerCase() ?? '';",
+      "const contentType = mime.getType(relPath) ?? 'text/plain';",
+      "",
+    ].join("\n"),
+  );
 
   const first = await patchClawhubTrustExtensions(tempRoot);
   assert.equal(first.patched, true);
   const patchedSource = await readFile(schemaPath, "utf8");
+  const patchedSkillsSource = await readFile(skillsPath, "utf8");
   assert.match(patchedSource, /'pem',/);
   assert.match(patchedSource, /'sig',/);
+  assert.match(
+    patchedSkillsSource,
+    /\["pem","sig"\]\.includes\(ext\) \? "text\/plain"/,
+    "The patched client must upload trust extensions as text/plain",
+  );
 
   const second = await patchClawhubTrustExtensions(tempRoot);
   assert.equal(second.patched, false, "ClawHub extension patch must be idempotent");
   assert.equal(await readFile(schemaPath, "utf8"), patchedSource);
+  assert.equal(await readFile(skillsPath, "utf8"), patchedSkillsSource);
 
   const schema = await import(`${pathToFileURL(schemaPath).href}?test=${Date.now()}`);
   assert.equal(schema.TEXT_FILE_EXTENSION_SET.has("pem"), true);
@@ -82,9 +98,40 @@ try {
     "skills.js",
   );
   if (existsSync(installedSkillsModule)) {
+    const mimeFailureCopy = path.join(tempRoot, "mime-failure-clawhub-client");
+    await cp(installedClientSource, mimeFailureCopy, { recursive: true });
+    await patchClawhubTrustExtensions(mimeFailureCopy);
+    await cp(
+      installedSkillsModule,
+      path.join(mimeFailureCopy, "node_modules", "clawhub", "dist", "skills.js"),
+    );
+    await assert.rejects(
+      verifyClawhubClientSelection({
+        packageDir,
+        cliPrefix: mimeFailureCopy,
+      }),
+      /non-text MIME type: application\//,
+      "The release simulation must reproduce ClawHub's rejection of non-text trust MIME types",
+    );
+
     const installedClientCopy = path.join(tempRoot, "installed-clawhub-client");
     await cp(installedClientSource, installedClientCopy, { recursive: true });
     await patchClawhubTrustExtensions(installedClientCopy);
+    const installedSkills = await import(
+      `${pathToFileURL(path.join(installedClientCopy, "node_modules", "clawhub", "dist", "skills.js")).href}?mime=${Date.now()}`
+    );
+    const trustFiles = (await installedSkills.listTextFiles(packageDir))
+      .filter((entry) => /\.(?:pem|sig)$/.test(entry.relPath));
+    assert.deepEqual(
+      trustFiles
+        .map((entry) => ({ path: entry.relPath, contentType: entry.contentType }))
+        .sort((left, right) => left.path.localeCompare(right.path)),
+      [
+        { path: "key.pem", contentType: "text/plain" },
+        { path: "signature.sig", contentType: "text/plain" },
+      ],
+      "The patched pinned ClawHub client must send trust files as text/plain",
+    );
     assert.deepEqual(
       await verifyClawhubClientSelection({
         packageDir,

--- a/scripts/test-skill-clawhub-trust-extensions.mjs
+++ b/scripts/test-skill-clawhub-trust-extensions.mjs
@@ -89,6 +89,23 @@ try {
   );
   await rm(path.join(packageDir, "runtime.bin"));
 
+  await writeFile(path.join(packageDir, "test_scanner_fixture.py"), "raise AssertionError\n");
+  await assert.rejects(
+    collectClawhubPackageFiles(packageDir),
+    /must not contain test-only file: test_scanner_fixture\.py/,
+    "ClawHub package preparation must reject test-named files before upload",
+  );
+  await rm(path.join(packageDir, "test_scanner_fixture.py"));
+
+  await mkdir(path.join(packageDir, "tests"));
+  await writeFile(path.join(packageDir, "tests", "scanner-fixture.md"), "# Test fixture\n");
+  await assert.rejects(
+    collectClawhubPackageFiles(packageDir),
+    /must not contain test-only file: tests\/scanner-fixture\.md/,
+    "ClawHub package preparation must reject files in test directories before upload",
+  );
+  await rm(path.join(packageDir, "tests"), { recursive: true });
+
   const installedClientSource = path.resolve(".github", "clawhub-cli");
   const installedSkillsModule = path.join(
     installedClientSource,

--- a/scripts/test-skill-release-path-policy.mjs
+++ b/scripts/test-skill-release-path-policy.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { isTestReleasePath } from "./ci/release_path_policy.mjs";
+
+for (const testOnlyPath of [
+  "test/helper.py",
+  "tests/helper.py",
+  "__tests__/helper.js",
+  "lib/test/helper.py",
+  "lib/tests/helper.py",
+  "lib/__tests__/helper.js",
+  "test_helper.py",
+  "test-helper.py",
+  "spec_helper.py",
+  "spec-helper.py",
+  "helper.test.mjs",
+  "helper.spec.mjs",
+  "TESTS\\helper.py",
+]) {
+  assert.equal(isTestReleasePath(testOnlyPath), true, `expected test-only path: ${testOnlyPath}`);
+}
+
+for (const releasePath of [
+  "SKILL.md",
+  "attestation/verify.mjs",
+  "contest/data.md",
+  "latest/feed.json",
+  "testing/guide.md",
+]) {
+  assert.equal(isTestReleasePath(releasePath), false, `expected release path: ${releasePath}`);
+}
+
+console.log("Release test-path policy tests passed");

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -639,6 +639,12 @@ for (const extension of ['pem', 'sig']) {
 
 assert.match(
   patchClawhubTrustExtensions,
+  /REQUIRED_TRUST_CONTENT_TYPE = "text\/plain"/,
+  'ClawHub trust-extension patch must send ASCII trust artifacts with a server-accepted text MIME type',
+);
+
+assert.match(
+  patchClawhubTrustExtensions,
   /Already patched/,
   'ClawHub trust-extension patch must be idempotent when the client already accepts trust artifacts',
 );

--- a/scripts/test-skill-tag-release-simulation.mjs
+++ b/scripts/test-skill-tag-release-simulation.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { chmod, cp, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { chmod, cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -50,6 +50,7 @@ async function runSimulation({
   expectedAgent,
   verifyEmbeddedAdvisory = false,
   expectedPreparationError = null,
+  expectedExcludedPaths = [],
 }) {
   const result = spawnSync(
     process.execPath,
@@ -125,6 +126,16 @@ async function runSimulation({
   const archivePath = path.join(releaseAssetsDir, `${expectedTag}.zip`);
   const archive = await readFile(archivePath);
   assert.ok(archive.length > 0, "release archive should not be empty");
+  const archiveListing = spawnSync("unzip", ["-Z1", archivePath], { encoding: "utf8" });
+  assert.equal(archiveListing.status, 0, `failed to list simulated release archive: ${archiveListing.stderr}`);
+  const archiveEntries = new Set(archiveListing.stdout.split(/\r?\n/).filter(Boolean));
+  for (const excludedPath of expectedExcludedPaths) {
+    assert.equal(
+      archiveEntries.has(`${skillName}/${excludedPath}`),
+      false,
+      `simulated release archive must exclude test-only path: ${excludedPath}`,
+    );
+  }
 
   if (!verifyEmbeddedAdvisory) {
     const clawhubOutputDir = path.join(outputDir, "clawhub-package");
@@ -469,6 +480,41 @@ process.stdout.write(readFileSync(inspectFile, "utf8"));
     expectedOriginal: "0.0.1-preview",
     expectedSimulated: "0.0.1-preview1",
     expectedAgent: "openclaw",
+  });
+
+  const testFilterSkillDir = await prereleaseFixture(
+    "skills/picoclaw-self-pen-testing",
+    "0.0.5",
+    "test-filter-fixture",
+  );
+  const testOnlyPaths = [
+    "tests/scanner-fixture.md",
+    "__tests__/scanner-fixture.js",
+    "test_scanner_fixture.py",
+    "scanner-fixture.spec.mjs",
+  ];
+  await mkdir(path.join(testFilterSkillDir, "tests"));
+  await mkdir(path.join(testFilterSkillDir, "__tests__"));
+  for (const testOnlyPath of testOnlyPaths) {
+    await writeFile(path.join(testFilterSkillDir, testOnlyPath), "test fixture\n");
+  }
+  const testFilterSkillJsonPath = path.join(testFilterSkillDir, "skill.json");
+  const testFilterSkill = JSON.parse(await readFile(testFilterSkillJsonPath, "utf8"));
+  for (const testOnlyPath of testOnlyPaths) {
+    testFilterSkill.sbom.files.push({
+      path: testOnlyPath,
+      required: true,
+      description: "Test-only release filtering fixture",
+    });
+  }
+  await writeFile(testFilterSkillJsonPath, `${JSON.stringify(testFilterSkill, null, 2)}\n`);
+  await runSimulation({
+    skillDir: testFilterSkillDir,
+    outputDir: path.join(tempRoot, "test-filter"),
+    expectedOriginal: "0.0.5",
+    expectedSimulated: "0.0.6",
+    expectedAgent: "openclaw",
+    expectedExcludedPaths: testOnlyPaths,
   });
 
   const unsupportedSkillDir = await prereleaseFixture(


### PR DESCRIPTION
# User description
### Summary

- Force the patched ClawHub 0.7.0 client to upload ASCII `.sig` and `.pem` trust artifacts as `text/plain`.
- Keep the existing extension-selection patch so those files remain present in the upload.
- Make the release simulation fail when a trust artifact would use a non-text MIME type.
- Reproduce the production failure in regression coverage before proving the repaired client behavior.

---

### Root cause

The `clawsec-suite-v0.1.15` release prepared and cryptographically verified the complete signed package, but the blocking ClawHub publish job failed with `Only text-based files are allowed`.

The earlier patch added `.sig` and `.pem` to the pinned client's text-file extension allowlist. However, the client's `mime` dependency still classified those ASCII files as `application/pgp-signature` and `application/x-x509-ca-cert`. ClawHub validates upload MIME types independently of file selection and rejected the package.

Failed production run: https://github.com/prompt-security/clawsec/actions/runs/29319909067

---

### Verification

- `node scripts/test-skill-clawhub-trust-extensions.mjs`
- `node scripts/test-skill-release-workflow.mjs`
- `node scripts/test-skill-tag-release-simulation.mjs`
- all `scripts/test-skill-*.mjs`
- scoped ESLint for all changed files
- `npx tsc --noEmit`
- `git diff --check`
- replayed the actual signed Suite 0.1.15 release package through a patched copy of the pinned ClawHub 0.7.0 client: all 28 expected files were selected and all three `.sig`/`.pem` artifacts used `text/plain`

---

### Release scope

No packaged Suite byte changes in this PR. The existing signed `clawsec-suite-v0.1.15` GitHub release remains canonical. After merge, run the manual `Skill Release` workflow for that tag, then verify exact ClawHub path/hash/size parity and an installed fallback load.

Follow-up to #299.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enforce ClawHub trust artifacts to upload as ASCII text by patching the trust-extension schema and skills collection logic while reproducing the MIME rejection in the release simulation. Enforce the release package builder to reject test-only paths so only legit production files are sent to ClawHub.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/301?tool=ast&topic=Trust+Artifact+Upload>Trust Artifact Upload</a>
        </td><td>Ensure ClawHub trust artifacts are forced to <code>text/plain</code> by patching <code>patchClawhubTrustExtensions</code> logic and verifying through patched <code>skills.js</code> selection plus the release simulation tests that initially reproduced the MIME rejection.<details><summary>Modified files (4)</summary><ul><li>scripts/ci/patch_clawhub_trust_extensions.mjs</li>
<li>scripts/test-skill-clawhub-trust-extensions.mjs</li>
<li>scripts/test-skill-release-workflow.mjs</li>
<li>scripts/test-skill-tag-release-simulation.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(release): reject C...</td><td>July 14, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(clawsec-suite): pu...</td><td>July 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/301?tool=ast&topic=Release+Path+Policy>Release Path Policy</a>
        </td><td>Enforce rejection of test-only files in release builds by sharing the <code>isTestReleasePath</code> policy across packaging, simulation, and dedicated path-policy tests so ClawHub packages stay production-only.<details><summary>Modified files (5)</summary><ul><li>scripts/ci/clawhub_release_package.mjs</li>
<li>scripts/ci/release_path_policy.mjs</li>
<li>scripts/ci/simulate_skill_tag_release.mjs</li>
<li>scripts/test-skill-release-path-policy.mjs</li>
<li>scripts/test-skill-tag-release-simulation.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(release): share te...</td><td>July 14, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(clawsec-suite): pu...</td><td>July 14, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/301?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>