### PR TITLE
fix(release): publish clawsec-suite 0.1.16 safely

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -1987,6 +1987,7 @@ jobs:
           cp scripts/ci/resolve_clawhub_slug.mjs "$RUNNER_TEMP/resolve_clawhub_slug.mjs"
           cp scripts/ci/skill_platforms.mjs "$RUNNER_TEMP/skill_platforms.mjs"
           cp scripts/ci/clawhub_release_package.mjs "$RUNNER_TEMP/clawhub_release_package.mjs"
+          cp scripts/ci/release_path_policy.mjs "$RUNNER_TEMP/release_path_policy.mjs"
           cp scripts/ci/patch_clawhub_trust_extensions.mjs "$RUNNER_TEMP/patch_clawhub_trust_extensions.mjs"
 
       - name: Checkout tag

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { cp, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const workflowPath = new URL('../.github/workflows/skill-release.yml', import.meta.url);
 const ciWorkflowPath = new URL('../.github/workflows/ci.yml', import.meta.url);
@@ -19,6 +22,24 @@ const patchClawhubPayload = await readFile(patchClawhubPayloadPath, 'utf8');
 const patchClawhubTrustExtensions = await readFile(patchClawhubTrustExtensionsPath, 'utf8');
 const guardClawhubSlugOwner = await readFile(guardClawhubSlugOwnerPath, 'utf8');
 const releaseSkillScript = await readFile(releaseSkillScriptPath, 'utf8');
+
+const preservedHelperDir = await mkdtemp(path.join(tmpdir(), 'clawhub-republish-helpers-'));
+try {
+  await Promise.all([
+    cp(new URL('./ci/clawhub_release_package.mjs', import.meta.url), path.join(preservedHelperDir, 'clawhub_release_package.mjs')),
+    cp(new URL('./ci/release_path_policy.mjs', import.meta.url), path.join(preservedHelperDir, 'release_path_policy.mjs')),
+  ]);
+  const preservedHelper = await import(
+    `${pathToFileURL(path.join(preservedHelperDir, 'clawhub_release_package.mjs')).href}?test=${Date.now()}`
+  );
+  assert.equal(
+    typeof preservedHelper.prepareReleasePackage,
+    'function',
+    'Preserved manual republish helpers must remain importable after checkout moves to an older tag',
+  );
+} finally {
+  await rm(preservedHelperDir, { recursive: true, force: true });
+}
 
 assert.match(
   workflow,
@@ -433,6 +454,12 @@ assert.match(
   workflow,
   /cp scripts\/ci\/resolve_clawhub_slug\.mjs "\$RUNNER_TEMP\/resolve_clawhub_slug\.mjs"[\s\S]*cp scripts\/ci\/skill_platforms\.mjs "\$RUNNER_TEMP\/skill_platforms\.mjs"[\s\S]*cp scripts\/ci\/clawhub_release_package\.mjs "\$RUNNER_TEMP\/clawhub_release_package\.mjs"/,
   'Manual ClawHub republish must preserve current slug and signed-package helpers before checking out an older release tag',
+);
+
+assert.match(
+  workflow,
+  /cp scripts\/ci\/clawhub_release_package\.mjs "\$RUNNER_TEMP\/clawhub_release_package\.mjs"[\s\S]*cp scripts\/ci\/release_path_policy\.mjs "\$RUNNER_TEMP\/release_path_policy\.mjs"/,
+  'Manual ClawHub republish must preserve signed-package helper dependencies before checking out an older release tag',
 );
 
 assert.match(

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -23,20 +23,35 @@ const patchClawhubTrustExtensions = await readFile(patchClawhubTrustExtensionsPa
 const guardClawhubSlugOwner = await readFile(guardClawhubSlugOwnerPath, 'utf8');
 const releaseSkillScript = await readFile(releaseSkillScriptPath, 'utf8');
 
+const preservedHelperBlock = workflow.match(
+  /- name: Prepare current ClawHub workflow helpers\s+run: \|\n(?<body>[\s\S]*?)\n\s+- name: Checkout tag/,
+)?.groups?.body;
+assert.ok(preservedHelperBlock, 'Manual ClawHub republish must define a preserved-helper block');
+const preservedHelperCopies = [...preservedHelperBlock.matchAll(
+  /cp (scripts\/ci\/[^\s]+\.mjs) "\$RUNNER_TEMP\/([^"/]+\.mjs)"/g,
+)].map((match) => ({ source: match[1], destination: match[2] }));
+const preservedHelperDestinations = new Set(preservedHelperCopies.map(({ destination }) => destination));
+
+for (const { source, destination } of preservedHelperCopies) {
+  const sourceText = await readFile(new URL(`../${source}`, import.meta.url), 'utf8');
+  for (const match of sourceText.matchAll(/\bfrom\s+["'](\.[^"']+)["']/g)) {
+    const dependency = path.posix.normalize(path.posix.join(path.posix.dirname(destination), match[1]));
+    assert.ok(
+      preservedHelperDestinations.has(dependency),
+      `Manual ClawHub republish must preserve ${dependency}, imported by ${source}`,
+    );
+  }
+}
+
 const preservedHelperDir = await mkdtemp(path.join(tmpdir(), 'clawhub-republish-helpers-'));
 try {
-  await Promise.all([
-    cp(new URL('./ci/clawhub_release_package.mjs', import.meta.url), path.join(preservedHelperDir, 'clawhub_release_package.mjs')),
-    cp(new URL('./ci/release_path_policy.mjs', import.meta.url), path.join(preservedHelperDir, 'release_path_policy.mjs')),
-  ]);
-  const preservedHelper = await import(
-    `${pathToFileURL(path.join(preservedHelperDir, 'clawhub_release_package.mjs')).href}?test=${Date.now()}`
-  );
-  assert.equal(
-    typeof preservedHelper.prepareReleasePackage,
-    'function',
-    'Preserved manual republish helpers must remain importable after checkout moves to an older tag',
-  );
+  await Promise.all(preservedHelperCopies.map(({ source, destination }) => cp(
+    new URL(`../${source}`, import.meta.url),
+    path.join(preservedHelperDir, destination),
+  )));
+  for (const { destination } of preservedHelperCopies) {
+    await import(`${pathToFileURL(path.join(preservedHelperDir, destination)).href}?test=${Date.now()}`);
+  }
 } finally {
   await rm(preservedHelperDir, { recursive: true, force: true });
 }

--- a/scripts/test-skill-tag-release-simulation.mjs
+++ b/scripts/test-skill-tag-release-simulation.mjs
@@ -433,8 +433,8 @@ process.stdout.write(readFileSync(inspectFile, "utf8"));
   await runSimulation({
     skillDir: "skills/clawsec-suite",
     outputDir: path.join(tempRoot, "stable"),
-    expectedOriginal: "0.1.15",
-    expectedSimulated: "0.1.16",
+    expectedOriginal: "0.1.16",
+    expectedSimulated: "0.1.17",
     expectedAgent: "openclaw",
     verifyEmbeddedAdvisory: true,
   });

--- a/scripts/test-skill-trust-packet.mjs
+++ b/scripts/test-skill-trust-packet.mjs
@@ -25,7 +25,7 @@ function runTrustPacket(skillDir, targetDir, tag) {
 }
 
 try {
-  const result = runTrustPacket("skills/clawsec-suite", outputDir, "clawsec-suite-v0.1.15");
+  const result = runTrustPacket("skills/clawsec-suite", outputDir, "clawsec-suite-v0.1.16");
 
   assert.equal(
     result.status,
@@ -41,10 +41,10 @@ try {
   assert.match(skillCard, /## License\/Terms of Use/);
   assert.match(skillCard, /AGPL-3\.0-or-later/);
   assert.match(skillCard, /skillspector-report\.md/);
-  assert.match(skillCard, /clawsec-suite-v0\.1\.15/);
+  assert.match(skillCard, /clawsec-suite-v0\.1\.16/);
 
   assert.equal(permissions.skill, "clawsec-suite");
-  assert.equal(permissions.version, "0.1.15");
+  assert.equal(permissions.version, "0.1.16");
   assert.equal(permissions.platform, "openclaw");
   assert.deepEqual(
     permissions.required_binaries,

--- a/skills/clawsec-suite/CHANGELOG.md
+++ b/skills/clawsec-suite/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.1.16] - 2026-07-14
+
+### Fixed
+
+- Preserved the release-path policy helper required by the manual ClawHub republish flow after it checks out a release tag.
+- Published the corrected signed Suite package under a new immutable version instead of attempting to replace the existing `0.1.15` registry entry.
+
+### Changed
+
+- Added dependency-closure coverage for every current workflow helper carried across the tag-checkout boundary.
+- Kept tests and other excluded development files out of the ClawHub package while retaining the five signed advisory trust artifacts.
+
 ## [0.1.15] - 2026-07-13
 
 ### Fixed

--- a/skills/clawsec-suite/SKILL.md
+++ b/skills/clawsec-suite/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawsec-suite
-version: 0.1.15
+version: 0.1.16
 description: ClawSec suite manager with embedded advisory-feed monitoring, cryptographic signature verification, approval-gated malicious-skill response, and guided setup for additional security skills.
 homepage: https://clawsec.prompt.security
 clawdis:

--- a/skills/clawsec-suite/skill.json
+++ b/skills/clawsec-suite/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "clawsec-suite",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "ClawSec suite manager with embedded advisory-feed monitoring, cryptographic signature verification, approval-gated malicious-skill response, and guided setup for additional security skills.",
   "author": "prompt-security",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
### Summary

- Preserve the complete current ClawHub helper dependency closure before the manual release job checks out a tag.
- Add a regression test that derives every preserved helper from the workflow, validates all relative imports, and imports the copied modules in isolation.
- Advance ClawSec Suite from 0.1.15 to 0.1.16 so the corrected package can be published to the immutable ClawHub registry.
- Keep test and development files excluded while retaining all five signed advisory trust artifacts.

---

### Root cause

PR #301 centralized release-path filtering in release_path_policy.mjs. The manual release boundary copied clawhub_release_package.mjs before checking out the tag, but did not copy its new relative dependency. The job would fail before publication.

The existing clawsec-suite-v0.1.15 release and ClawHub version cannot be replaced. Version 0.1.16 is therefore required for the corrected signed package.

---

### Verification

- all scripts/test-skill-*.mjs
- Suite schema validation and feed-verification tests
- isolated helper dependency-closure import test
- real signed 0.1.15 package replay: 28 runtime files selected, no test files, five advisory trust artifacts verified
- scoped ESLint
- TypeScript type-check
- production build
- version parity and diff checks

After merge, create and push clawsec-suite-v0.1.16 from the merged main commit, monitor the publish workflow, then verify issues #293 and #296 against the deployed endpoints and Hermes remote refresh.