### PR TITLE
fix(release): preserve historical skill releases

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -1727,43 +1727,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Delete superseded releases
-        run: |
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          CURRENT_VERSION="${{ steps.parse.outputs.version }}"
-
-          # Extract major version from current release
-          CURRENT_MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
-
-          echo "Current release: $SKILL_NAME v$CURRENT_VERSION (major: $CURRENT_MAJOR)"
-
-          # List all releases for this skill
-          gh release list --limit 100 | grep "^${SKILL_NAME} " | while read -r line; do
-            # Extract tag from release list (3rd tab-delimited column)
-            TAG=$(echo "$line" | awk -F'\t' '{print $3}')
-            VERSION="${TAG#${SKILL_NAME}-v}"
-
-            # Skip current version
-            if [ "$VERSION" = "$CURRENT_VERSION" ]; then
-              continue
-            fi
-
-            # Extract major version
-            RELEASE_MAJOR=$(echo "$VERSION" | cut -d. -f1)
-
-            # Only delete if same major version (preserve old majors for backwards compat)
-            if [ "$RELEASE_MAJOR" = "$CURRENT_MAJOR" ]; then
-              echo "Deleting $TAG (superseded by v$CURRENT_VERSION)"
-              gh release delete "$TAG" --yes || echo "Warning: Could not delete $TAG"
-            else
-              echo "Keeping $TAG as latest for major version $RELEASE_MAJOR"
-            fi
-          done
-
-          echo "Superseded release cleanup complete"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   publish-clawhub:
     # Separate blocking job for ClawHub publishing - runs after GitHub release.
     # It publishes the verified GitHub release payload, never the raw source directory.

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -237,6 +237,18 @@ assert.match(
 
 assert.doesNotMatch(
   workflow,
+  /\bgh\s+release\s+delete\b/,
+  'Skill release workflow must retain every published GitHub release, including superseded same-major versions',
+);
+
+assert.doesNotMatch(
+  workflow,
+  /- name: Delete superseded releases\b/,
+  'Skill release workflow must not run superseded-release cleanup',
+);
+
+assert.doesNotMatch(
+  workflow,
   /SKILLSPECTOR_REPORT_EOF|\$\{\{ steps\.skillspector_report\.outputs\.body \}\}|cat release-assets\/skillspector-report\.md[\s\S]*>> "\$GITHUB_OUTPUT"/,
   'SkillSpector report content must not be sent through GitHub Actions step outputs',
 );


### PR DESCRIPTION
# User description
## What changed

- Remove the `Delete superseded releases` step from the skill release workflow.
- Add structural regression assertions that forbid both `gh release delete` and the superseded-release cleanup step.

## Why

The workflow deleted every older same-major GitHub Release immediately after publishing a newer version. That destroys historical release assets needed for pinned installs, rollback, provenance review, and the immutable-release migration defined by the multi-harness lifecycle design.

## Impact

- Future skill releases retain prior tags, releases, and assets across patch/minor updates.
- Release creation, release assets, ClawHub publication, tags, signing, and skill runtime behavior are unchanged.
- This PR does not restore previously deleted releases and performs no live GitHub release operation.

## Validation

- Copied the workflow test bundle with `scp` into a fresh quarantine directory on the operator-approved remote Linux host before committing or pushing.
- Local and remote SHA-256 hashes matched for both changed files.
- Remote: `node scripts/test-skill-release-workflow.mjs` passed.
- Remote focused evidence: `release_creation_steps=1`, `release_delete_commands=0`, `superseded_cleanup_steps=0`.
- Local supplemental run of the same Node test passed after the remote proof.
- `git diff --check` passed.

## Scope boundary

This is only the `release-retention-v1` pipeline unit related to draft architecture PR #306. Public prerelease blocking, immutable-release preflight, verified draft publication, Pages authority/selection, and ClawHub allowlisting each remain separate future PRs.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Preserve historical skill releases by removing the superseded-release cleanup from the <code>skill-release</code> workflow, so <code>gh release</code> publication keeps prior tags and assets for rollback and pinned installs. Add regression checks in <code>test-skill-release-workflow</code> to forbid <code>gh release delete</code> and the superseded-release cleanup step.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/307?tool=ast&topic=Workflow+tests>Workflow tests</a>
        </td><td>Add assertions that block <code>gh release delete</code> and the superseded-release cleanup step to prevent the workflow from regressing.<details><summary>Modified files (1)</summary><ul><li>scripts/test-skill-release-workflow.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(release): preserve...</td><td>July 22, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(release): publish ...</td><td>July 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/307?tool=ast&topic=Release+retention>Release retention</a>
        </td><td>Remove the step that deletes superseded same-major GitHub Releases so skill release history, tags, and assets remain available.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/skill-release.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(release): preserve...</td><td>July 22, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(release): publish ...</td><td>July 14, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/307?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>