### PR TITLE
fix(release): verify install paths and deny non-installable publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
       - run: npm ci
       - name: GHSA Without CVE Feed Tests
         run: node scripts/test-ghsa-without-cve-feed.mjs

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -758,6 +758,13 @@ jobs:
               continue
             fi
 
+            if ! add_release_asset_checksum "${out_assets}" "verify_skill_release_bundle.py"; then
+              failures=$((failures + 1))
+              rm -rf "${staging_dir}"
+              echo "::endgroup::"
+              continue
+            fi
+
             if ! add_release_asset_checksum "${out_assets}" "skillspector-report.md"; then
               failures=$((failures + 1))
               rm -rf "${staging_dir}"
@@ -1479,11 +1486,13 @@ jobs:
           test -s release-assets/skill-card.md
           test -s release-assets/permissions.json
           test -s release-assets/install.md
+          test -s release-assets/verify_skill_release_bundle.py
           test -s release-assets/skillspector-report.md
 
           add_release_asset_checksum "skill-card.md"
           add_release_asset_checksum "permissions.json"
           add_release_asset_checksum "install.md"
+          add_release_asset_checksum "verify_skill_release_bundle.py"
           add_release_asset_checksum "skillspector-report.md"
 
           if ! jq -e . "release-assets/checksums.json" >/dev/null 2>&1; then

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -1061,16 +1061,31 @@ jobs:
               "dist/tag-release-simulation/${skill_name}" \
               --repository "${{ github.repository }}" \
               --source-ref "${{ github.event.pull_request.head.sha }}"
+            summary_path="dist/tag-release-simulation/${skill_name}/simulation-summary.json"
             jq -e '.simulated_version | test("^[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9]+)?$")' \
-              "dist/tag-release-simulation/${skill_name}/simulation-summary.json" >/dev/null
+              "$summary_path" >/dev/null
+            jq -e '(.installable | type) == "boolean"' "$summary_path" >/dev/null
             test -s "dist/tag-release-simulation/${skill_name}/release-assets/checksums.json"
             test -s "dist/tag-release-simulation/${skill_name}/release-assets/checksums.sig"
             test -s "dist/tag-release-simulation/${skill_name}/release-assets/signing-public.pem"
             test -s "dist/tag-release-simulation/${skill_name}/release-assets/skillspector-report.md"
 
-            simulated_version="$(jq -r '.simulated_version' "dist/tag-release-simulation/${skill_name}/simulation-summary.json")"
+            simulated_version="$(jq -r '.simulated_version' "$summary_path")"
+            installable="$(jq -r '.installable' "$summary_path")"
             release_dir="dist/tag-release-simulation/${skill_name}/release-assets"
             clawhub_output="dist/tag-release-simulation/${skill_name}/clawhub-package"
+            jq -e --argjson expected_installable "$installable" \
+              '.installable == $expected_installable' \
+              "$release_dir/permissions.json" >/dev/null
+
+            if [ "$installable" = "false" ]; then
+              echo "Non-installable package: signed denial evidence generated; skipping ClawHub package preparation."
+              test ! -e "$clawhub_output"
+              echo "::endgroup::"
+              continue
+            fi
+            test "$installable" = "true"
+
             node scripts/ci/clawhub_release_package.mjs prepare \
               --release-dir "$release_dir" \
               --output-dir "$clawhub_output" \
@@ -1092,6 +1107,7 @@ jobs:
       skill_name: ${{ steps.parse.outputs.skill_name }}
       version: ${{ steps.parse.outputs.version }}
       skill_path: ${{ steps.parse.outputs.skill_path }}
+      installable: ${{ steps.installability.outputs.installable }}
       publishable: ${{ steps.publishable.outputs.publishable }}
       openclaw_skill: ${{ steps.publishable.outputs.openclaw_skill }}
       publish_clawhub: ${{ steps.publishable.outputs.publish_clawhub }}
@@ -1171,10 +1187,20 @@ jobs:
             exit 1
           fi
 
+      - name: Reject non-installable public release
+        id: installability
+        run: |
+          set -euo pipefail
+          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          INSTALLABLE="$(node scripts/ci/skill_installability.mjs "$SKILL_PATH" --require-publication)"
+          test "$INSTALLABLE" = "true"
+          echo "installable=${INSTALLABLE}" >> "$GITHUB_OUTPUT"
+
       - name: Detect publishability and install defaults
         id: publishable
         run: |
           SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          INSTALLABLE="${{ steps.installability.outputs.installable }}"
           INTERNAL=$(jq -r 'if (.openclaw | type) == "object" then (.openclaw.internal // false) else false end' "$SKILL_PATH/skill.json")
 
           OPENCLAW_SKILL=false
@@ -1183,7 +1209,10 @@ jobs:
           fi
 
           PUBLISHABLE=true
-          if [ "$INTERNAL" = "true" ]; then
+          if [ "$INSTALLABLE" != "true" ]; then
+            PUBLISHABLE=false
+            echo "Skill is non-installable; public publication is disabled."
+          elif [ "$INTERNAL" = "true" ]; then
             PUBLISHABLE=false
             echo "Skill marked internal=true; will skip ClawHub publishing."
           fi
@@ -1995,6 +2024,7 @@ jobs:
         run: |
           cp scripts/ci/resolve_clawhub_slug.mjs "$RUNNER_TEMP/resolve_clawhub_slug.mjs"
           cp scripts/ci/skill_platforms.mjs "$RUNNER_TEMP/skill_platforms.mjs"
+          cp scripts/ci/skill_installability.mjs "$RUNNER_TEMP/skill_installability.mjs"
           cp scripts/ci/clawhub_release_package.mjs "$RUNNER_TEMP/clawhub_release_package.mjs"
           cp scripts/ci/release_path_policy.mjs "$RUNNER_TEMP/release_path_policy.mjs"
           cp scripts/ci/patch_clawhub_trust_extensions.mjs "$RUNNER_TEMP/patch_clawhub_trust_extensions.mjs"
@@ -2016,6 +2046,13 @@ jobs:
             exit 1
           fi
           echo "Skill validated: $SKILL_PATH"
+
+      - name: Reject non-installable public republish
+        run: |
+          set -euo pipefail
+          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          INSTALLABLE="$(node "$RUNNER_TEMP/skill_installability.mjs" "$SKILL_PATH" --require-publication)"
+          test "$INSTALLABLE" = "true"
 
       - name: Check if publishable
         id: publishable

--- a/scripts/ci/clawhub_release_package.mjs
+++ b/scripts/ci/clawhub_release_package.mjs
@@ -15,6 +15,7 @@ import {
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { isTestReleasePath } from "./release_path_policy.mjs";
+import { requireSkillPublication } from "./skill_installability.mjs";
 
 const CLAWHUB_TEXT_EXTENSIONS = new Set([
   "c", "cfg", "cjs", "cpp", "cs", "css", "csv", "env", "go", "h", "hpp",
@@ -354,10 +355,12 @@ export async function prepareReleasePackage({
       }
     }
 
-    const skill = JSON.parse(await readFile(path.join(packageDir, "skill.json"), "utf8"));
+    const packagedSkillJsonPath = path.join(packageDir, "skill.json");
+    const skill = JSON.parse(await readFile(packagedSkillJsonPath, "utf8"));
     if (skill.version !== version) {
       throw new Error(`Packaged skill.json version mismatch: expected ${version}, got ${skill.version}`);
     }
+    requireSkillPublication(skill, packagedSkillJsonPath);
 
     const declaredPackageFiles = new Set(
       (skill.sbom?.files ?? []).map((entry) => entry.path.replaceAll("\\", "/").replace(/^\.\//, "")),

--- a/scripts/ci/generate_skill_release_trust_packet.mjs
+++ b/scripts/ci/generate_skill_release_trust_packet.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { resolveSkillInstallability } from "./skill_installability.mjs";
 import { PLATFORM_KEYS, resolveDirectSkillsCliTargets } from "./skill_platforms.mjs";
 
 const KNOWN_AGENT_TYPES = new Set(["codex", "hermes-agent", "openclaw", "universal"]);
@@ -161,11 +162,42 @@ function requireField(skill, fieldName) {
   return skill[fieldName].trim();
 }
 
+function validateReleaseIdentity(skill, tag) {
+  if (!tag) {
+    return;
+  }
+
+  const expectedTag = `${skill.name}-v${skill.version}`;
+  if (tag !== expectedTag) {
+    throw new Error(`Release tag ${tag} does not match skill identity ${expectedTag}`);
+  }
+}
+
 function codeBlock(command) {
   return ["```bash", command, "```"].join("\n");
 }
 
-function buildPermissions({ skill, metadata, platform, generatedAt }) {
+function buildPermissions({ skill, metadata, platform, generatedAt, installable }) {
+  if (!installable) {
+    return {
+      schema_version: "1",
+      generated_at: generatedAt,
+      skill: skill.name,
+      version: skill.version,
+      platform: "not-applicable",
+      installable: false,
+      required_binaries: [],
+      optional_binaries: [],
+      required_env: [],
+      optional_env: [],
+      network_egress: "Not applicable: package is non-installable.",
+      persistence: "Not applicable: package is non-installable.",
+      automatic_execution: "Not applicable: package is non-installable.",
+      capabilities: [],
+      operator_review: ["Limit use to read-only historical review or migration planning."],
+    };
+  }
+
   const execution = metadata.execution && typeof metadata.execution === "object" ? metadata.execution : {};
   const permissions = {
     schema_version: "1",
@@ -173,6 +205,7 @@ function buildPermissions({ skill, metadata, platform, generatedAt }) {
     skill: skill.name,
     version: skill.version,
     platform,
+    installable: true,
     required_binaries: collectRequiredBinaries(metadata),
     optional_binaries: collectOptionalBinaries(metadata),
     required_env: collectRequiredEnv(metadata),
@@ -191,18 +224,44 @@ function buildSkillCard({ skill, frontmatter, permissions, repository, tag, sour
   const homepage = skill.homepage || frontmatter.homepage || `https://github.com/${repository}`;
   const supportRef = `${repository}@${tag || sourceRef}`;
   const licenseRef = `https://github.com/${repository}/blob/${tag || sourceRef}/LICENSE`;
-  const outputTypes = ["Markdown instructions", "release artifact files"];
-  if (permissions.capabilities.length > 0) {
+  const isInstallable = skill.installable !== false;
+  const outputTypes = isInstallable
+    ? ["Markdown instructions", "release artifact files"]
+    : ["Historical and migration documentation", "signed denial evidence"];
+  if (isInstallable && permissions.capabilities.length > 0) {
     outputTypes.push("local security findings or status reports");
   }
+
+  const description = isInstallable
+    ? `The \`${skill.name}\` skill provides this capability: ${skill.description}
+
+This skill is intended for operator-reviewed security workflows, not unattended production mutation without the review steps declared in the skill instructions.`
+    : `The \`${skill.name}\` package declares \`installable: false\`: ${skill.description}
+
+It is retained only as immutable historical, migration, or test-vector evidence. It has no supported execution or activation path.`;
+  const useCase = isInstallable
+    ? `Use this skill for ${permissions.platform} workflows where an agent or operator needs the capability described in \`${skill.name}\`.`
+    : `Use this package only for read-only historical review or migration planning. Do not install, activate, execute, or substitute another harness target.`;
+  const risks = isInstallable
+    ? `Risk: The skill may run commands, inspect local files, install hooks, or fetch remote security metadata depending on the workflow.
+
+Mitigation: Review \`permissions.json\`, \`SKILL.md\`, and the signed \`checksums.json\` before enabling the skill. Keep high-impact actions approval-gated.
+
+Risk: Security findings and remediation guidance can be incomplete or wrong.
+
+Mitigation: Treat output as operator guidance. Review proposed removals, installs, configuration changes, and reports before acting.`
+    : `Risk: Historical material may be mistaken for a supported integration.
+
+Mitigation: Enforce \`installable: false\`, emit no installation commands, and do not execute preserved source. \`SKILL.md\` may provide migration context, but it is not installation authority.`;
+  const outputFormat = isInstallable
+    ? "Markdown, JSON, shell commands, or local files as documented by the skill."
+    : "Read-only Markdown and JSON evidence; no runtime output is authorized.";
 
   return `# Skill Card
 
 ## Description
 
-The \`${skill.name}\` skill provides this capability: ${skill.description}
-
-This skill is intended for operator-reviewed security workflows, not unattended production mutation without the review steps declared in the skill instructions.
+${description}
 
 ## Owner
 
@@ -218,7 +277,7 @@ Project homepage: ${homepage}
 
 ## Use Case
 
-Use this skill for ${permissions.platform} workflows where an agent or operator needs the capability described in \`${skill.name}\`.
+${useCase}
 
 ## Deployment Geography for Use
 
@@ -226,13 +285,7 @@ Global, subject to the operator's local compliance, network, and data-handling r
 
 ## Known Risks and Mitigations
 
-Risk: The skill may run commands, inspect local files, install hooks, or fetch remote security metadata depending on the workflow.
-
-Mitigation: Review \`permissions.json\`, \`SKILL.md\`, and the signed \`checksums.json\` before enabling the skill. Keep high-impact actions approval-gated.
-
-Risk: Security findings and remediation guidance can be incomplete or wrong.
-
-Mitigation: Treat output as operator guidance. Review proposed removals, installs, configuration changes, and reports before acting.
+${risks}
 
 ## References
 
@@ -246,7 +299,7 @@ Mitigation: Treat output as operator guidance. Review proposed removals, install
 
 Output type(s): ${outputTypes.join(", ")}
 
-Output format: Markdown, JSON, shell commands, or local files as documented by the skill.
+Output format: ${outputFormat}
 
 Output parameters: See \`SKILL.md\`, \`permissions.json\`, and release checksums for exact files and side effects.
 
@@ -258,14 +311,28 @@ ${skill.version}${tag ? ` (${tag})` : ""}
 
 ## Ethical Considerations
 
-Use this skill only on systems, agents, repositories, and workspaces where you have authorization. Review generated security reports before sharing them because they may contain operational details.
+${isInstallable
+    ? "Use this skill only on systems, agents, repositories, and workspaces where you have authorization. Review generated security reports before sharing them because they may contain operational details."
+    : "Preserve operator data and history. Keep assessment read-only unless a separate reviewed migration plan explicitly authorizes a change."}
 `;
 }
 
 function buildInstallDoc({ skill, repository, tag, sourceRef }) {
+  const releaseUrl = tag ? `https://github.com/${repository}/releases/tag/${tag}` : `https://github.com/${repository}`;
+
+  if (skill.installable === false) {
+    return `# Installation Unavailable for ${skill.name}
+
+This package declares \`installable: false\` in signed package metadata. It may be retained as immutable historical, migration, or test-vector evidence, but it has no supported installation or activation path.
+
+Do not install, extract into a harness skill directory, activate, execute, or substitute another harness target. \`SKILL.md\` may provide status and migration context, but it cannot override this denial.
+
+Reference identifier only: ${releaseUrl}.
+`;
+  }
+
   const refSuffix = sourceRef && sourceRef !== "main" ? `#${sourceRef}` : "";
   const source = `${repository}${refSuffix}`;
-  const releaseUrl = tag ? `https://github.com/${repository}/releases/tag/${tag}` : `https://github.com/${repository}`;
   const archiveName = `${skill.name}-v${skill.version}.zip`;
   const releaseAssetBase = tag ? `https://github.com/${repository}/releases/download/${tag}` : "";
   const resolution = resolveDirectSkillsCliTargets(skill, KNOWN_AGENT_TYPES);
@@ -377,11 +444,13 @@ async function main() {
   skill.version = requireField(skill, "version");
   skill.description = requireField(skill, "description");
   skill.license = requireField(skill, "license");
+  const { installable } = resolveSkillInstallability(skill);
+  validateReleaseIdentity(skill, args.tag);
 
-  const platform = detectPlatform(skill);
-  const metadata = platformMetadata(skill, platform);
+  const platform = installable ? detectPlatform(skill) : "not-applicable";
+  const metadata = installable ? platformMetadata(skill, platform) : {};
   const generatedAt = new Date().toISOString();
-  const permissions = buildPermissions({ skill, metadata, platform, generatedAt });
+  const permissions = buildPermissions({ skill, metadata, platform, generatedAt, installable });
 
   await mkdir(outputDir, { recursive: true });
   await Promise.all([

--- a/scripts/ci/generate_skill_release_trust_packet.mjs
+++ b/scripts/ci/generate_skill_release_trust_packet.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { installAgentForSkill, PLATFORM_KEYS } from "./skill_platforms.mjs";
+import { PLATFORM_KEYS, resolveDirectSkillsCliTargets } from "./skill_platforms.mjs";
 
 const KNOWN_AGENT_TYPES = new Set(["codex", "hermes-agent", "openclaw", "universal"]);
+const RELEASE_SIGNING_KEY_SHA256 = "711424e4535f84093fefb024cd1ca4ec87439e53907b305b79a631d5befba9c8";
+const RELEASE_VERIFIER_URL = new URL("./verify_skill_release_bundle.py", import.meta.url);
 
 function usage() {
   return [
@@ -264,37 +266,95 @@ function buildInstallDoc({ skill, repository, tag, sourceRef }) {
   const refSuffix = sourceRef && sourceRef !== "main" ? `#${sourceRef}` : "";
   const source = `${repository}${refSuffix}`;
   const releaseUrl = tag ? `https://github.com/${repository}/releases/tag/${tag}` : `https://github.com/${repository}`;
-  const agent = installAgentForSkill(skill, KNOWN_AGENT_TYPES);
+  const archiveName = `${skill.name}-v${skill.version}.zip`;
+  const releaseAssetBase = tag ? `https://github.com/${repository}/releases/download/${tag}` : "";
+  const resolution = resolveDirectSkillsCliTargets(skill, KNOWN_AGENT_TYPES);
+  if (resolution.status === "error") {
+    throw new Error(`Cannot generate install instructions for ${skill.name}: ${resolution.errors.join(" ")}`);
+  }
 
-  return `# Install and Update ${skill.name}
+  const secureInstallSection = tag
+    ? `## Secure Path: Verify the Canonical Release Before Installation
 
-## Install With Agent Skills CLI
+The signed release archive is the only installation artifact this packet binds cryptographically. Confirm the pinned signing-key fingerprint through an independent trusted channel before first use; this packet cannot bootstrap trust in its own key.
 
-Harness-aware global install:
+${codeBlock(`set -euo pipefail
+VERIFY_DIR="$(mktemp -d)"
+cd "$VERIFY_DIR"
+SKILL="${skill.name}"
+VERSION="${skill.version}"
+TAG="${tag}"
+ARCHIVE="${archiveName}"
+BASE_URL="${releaseAssetBase}"
+EXPECTED_KEY_SHA256="${RELEASE_SIGNING_KEY_SHA256}"
 
-${codeBlock(`npx skills add ${source} --skill ${skill.name} --agent ${agent} --global --yes`)}
+curl -fSLO "$BASE_URL/$ARCHIVE"
+curl -fSLO "$BASE_URL/checksums.json"
+curl -fSLO "$BASE_URL/checksums.sig"
+curl -fSLO "$BASE_URL/signing-public.pem"
+curl -fSLO "$BASE_URL/verify_skill_release_bundle.py"
 
-Project-local install for compatible agents:
+ACTUAL_KEY_SHA256="$(openssl pkey -pubin -in signing-public.pem -outform DER | openssl dgst -sha256 | awk '{print $NF}')"
+test "$EXPECTED_KEY_SHA256" = "$ACTUAL_KEY_SHA256"
+openssl base64 -d -A -in checksums.sig -out checksums.sig.bin
+openssl pkeyutl -verify -rawin -pubin -inkey signing-public.pem -sigfile checksums.sig.bin -in checksums.json
 
-${codeBlock(`npx skills add ${source} --skill ${skill.name} --yes`)}
+EXPECTED_VERIFIER_SHA="$(jq -r '.files["verify_skill_release_bundle.py"].sha256 // empty' checksums.json)"
+ACTUAL_VERIFIER_SHA="$(openssl dgst -sha256 verify_skill_release_bundle.py | awk '{print $NF}')"
+EXPECTED_VERIFIER_SIZE="$(jq -r '.files["verify_skill_release_bundle.py"].size // empty' checksums.json)"
+ACTUAL_VERIFIER_SIZE="$(wc -c < verify_skill_release_bundle.py | tr -d ' ')"
+test -n "$EXPECTED_VERIFIER_SHA"
+test "$EXPECTED_VERIFIER_SHA" = "$ACTUAL_VERIFIER_SHA"
+test "$EXPECTED_VERIFIER_SIZE" = "$ACTUAL_VERIFIER_SIZE"
 
-## Update
+python3 verify_skill_release_bundle.py \
+  --release-dir "$VERIFY_DIR" \
+  --output-dir "$VERIFY_DIR/verified" \
+  --skill "$SKILL" \
+  --version "$VERSION" \
+  --tag "$TAG" \
+  --spki-sha256 "$EXPECTED_KEY_SHA256" \
+  --openssl openssl`)}
 
-Update this skill when installed through the Skills CLI:
+Integrate only the verified extracted \`${skill.name}/\` directory. Follow its harness-native installation instructions before enabling hooks, persistence, or automatic execution. Release page: ${releaseUrl}.`
+    : `## Secure Path: Exact Release Tag Required
 
-${codeBlock(`npx skills update ${skill.name}`)}
+This packet has no exact release tag, so it cannot render an executable secure-install procedure. Generate it with \`--tag\`, then verify the signed canonical archive before installation. Repository: ${releaseUrl}.`;
 
-List installed skills:
+  let skillsCliSection;
+  if (resolution.status === "not_applicable") {
+    const unsupportedSubject = resolution.unsupportedPlatforms.join(" and ");
+    const unsupportedVerb = resolution.unsupportedPlatforms.length === 1 ? "has" : "have";
+    skillsCliSection = `## Harness-Native Integration
 
-${codeBlock("npx skills list")}
+Not applicable. ${unsupportedSubject} ${unsupportedVerb} no reviewed direct Vercel Agent Skills target. Do not substitute an OpenClaw or other unrelated agent target.
 
-## Verify Release Artifact
+Follow \`SKILL.md\` and a harness-native installation document from the verified extracted archive above.`;
+  } else {
+    const commands = resolution.agents
+      .map((agent) => codeBlock(`npx skills add ${source} --skill ${skill.name} --agent ${agent} --yes`))
+      .join("\n\n");
+    let unsupportedNotice = "";
+    if (resolution.unsupportedPlatforms.length > 0) {
+      const unsupportedSubject = resolution.unsupportedPlatforms.join(" and ");
+      const unsupportedVerb = resolution.unsupportedPlatforms.length === 1 ? "has" : "have";
+      unsupportedNotice = `\n\nThese commands cover only the direct targets above. ${unsupportedSubject} ${unsupportedVerb} no reviewed direct Agent Skills target.`;
+    }
 
-When installing from a GitHub release instead of the Skills CLI, download the archive, \`checksums.json\`, \`checksums.sig\`, and \`signing-public.pem\` from:
+    skillsCliSection = `## Optional Compatibility-Only Agent Skills CLI Check
 
-${releaseUrl}
+These commands test reviewed direct-target compatibility in a disposable project. They resolve repository source; their installed tree is not byte-bound to the signed release archive or its manifest.
 
-Verify \`checksums.json\` before trusting the archive or standalone files.
+${commands}${unsupportedNotice}
+
+Do not treat the resolver output as a verified installation, do not promote it from staging, and do not run the CLI's mutable update operation on a verified install. This packet emits no installed-tree parity procedure; use the verified canonical release archive above for a trusted installation. Direct-target compatibility also does not grant catalog authorization.`;
+  }
+
+  return `# Verify and Install ${skill.name}
+
+${secureInstallSection}
+
+${skillsCliSection}
 `;
 }
 
@@ -305,9 +365,10 @@ async function main() {
 
   const skillJsonPath = path.join(skillDir, "skill.json");
   const skillMdPath = path.join(skillDir, "SKILL.md");
-  const [skillJsonRaw, skillMdRaw] = await Promise.all([
+  const [skillJsonRaw, skillMdRaw, releaseVerifier] = await Promise.all([
     readFile(skillJsonPath, "utf8"),
     readFile(skillMdPath, "utf8"),
+    readFile(RELEASE_VERIFIER_URL, "utf8"),
   ]);
 
   const skill = JSON.parse(skillJsonRaw);
@@ -347,6 +408,10 @@ async function main() {
         tag: args.tag,
         sourceRef: args.sourceRef,
       }),
+    ),
+    writeFile(
+      path.join(outputDir, "verify_skill_release_bundle.py"),
+      releaseVerifier,
     ),
   ]);
 

--- a/scripts/ci/simulate_skill_tag_release.mjs
+++ b/scripts/ci/simulate_skill_tag_release.mjs
@@ -15,6 +15,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { nextSimulatedReleaseVersion } from "./semver_increment.mjs";
 import { isTestReleasePath } from "./release_path_policy.mjs";
+import { resolveSkillInstallability } from "./skill_installability.mjs";
 
 const TRUST_ARTIFACTS = [
   "skill-card.md",
@@ -368,6 +369,7 @@ async function main() {
     const skillJsonPath = path.join(tempSkillDir, "skill.json");
     const skillMdPath = path.join(tempSkillDir, "SKILL.md");
     const skill = JSON.parse(await readFile(skillJsonPath, "utf8"));
+    const { installable } = resolveSkillInstallability(skill);
     const originalVersion = skill.version;
     const simulatedVersion = nextSimulatedReleaseVersion(originalVersion);
     const tag = `${skillName}-v${simulatedVersion}`;
@@ -487,6 +489,7 @@ async function main() {
       skill: skillName,
       original_version: originalVersion,
       simulated_version: simulatedVersion,
+      installable,
       tag,
       release_assets: path.relative(outputDir, releaseAssetsDir),
       archive: `release-assets/${zipName}`,

--- a/scripts/ci/simulate_skill_tag_release.mjs
+++ b/scripts/ci/simulate_skill_tag_release.mjs
@@ -20,6 +20,7 @@ const TRUST_ARTIFACTS = [
   "skill-card.md",
   "permissions.json",
   "install.md",
+  "verify_skill_release_bundle.py",
   "skillspector-report.md",
 ];
 

--- a/scripts/ci/skill_installability.mjs
+++ b/scripts/ci/skill_installability.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+function usage() {
+  return [
+    "Usage: node scripts/ci/skill_installability.mjs <skill-dir> [--require-publication]",
+    "",
+    "Without --require-publication, prints the resolved installable value.",
+    "With --require-publication, fails when the skill is non-installable.",
+  ].join("\n");
+}
+
+function validateSkillObject(skill, source) {
+  if (!skill || typeof skill !== "object" || Array.isArray(skill)) {
+    throw new Error(`Invalid skill metadata in ${source}: expected a JSON object`);
+  }
+}
+
+export function resolveSkillInstallability(skill, source = "skill.json") {
+  validateSkillObject(skill, source);
+
+  const explicitlyDeclared = Object.hasOwn(skill, "installable");
+  if (explicitlyDeclared && typeof skill.installable !== "boolean") {
+    throw new Error(
+      `Invalid skill metadata in ${source}: "installable" must be a boolean when present`,
+    );
+  }
+
+  return {
+    installable: explicitlyDeclared ? skill.installable : true,
+    explicitlyDeclared,
+  };
+}
+
+export function requireSkillPublication(skill, source = "skill.json") {
+  const resolution = resolveSkillInstallability(skill, source);
+  if (!resolution.installable) {
+    throw new Error(
+      `Publication denied for ${source}: skill.json declares "installable": false`,
+    );
+  }
+  return resolution;
+}
+
+export async function loadSkillInstallability(skillDir) {
+  if (typeof skillDir !== "string" || !skillDir.trim()) {
+    throw new Error("Skill directory must be a non-empty path");
+  }
+
+  const resolvedSkillDir = path.resolve(skillDir);
+  const skillJsonPath = path.join(resolvedSkillDir, "skill.json");
+  let source;
+  try {
+    source = await readFile(skillJsonPath, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw new Error(`Skill metadata not found: ${skillJsonPath}`);
+    }
+    throw new Error(`Unable to read skill metadata: ${skillJsonPath}`);
+  }
+
+  let skill;
+  try {
+    skill = JSON.parse(source);
+  } catch {
+    throw new Error(`Invalid JSON in skill metadata: ${skillJsonPath}`);
+  }
+
+  return {
+    skillDir: resolvedSkillDir,
+    skillJsonPath,
+    skill,
+    ...resolveSkillInstallability(skill, skillJsonPath),
+  };
+}
+
+function parseArgs(argv) {
+  const positional = [];
+  let requirePublication = false;
+
+  for (const argument of argv) {
+    if (argument === "--require-publication") {
+      requirePublication = true;
+    } else if (argument === "--help" || argument === "-h") {
+      return { help: true, requirePublication, skillDir: "" };
+    } else if (argument.startsWith("--")) {
+      throw new Error(`Unknown option: ${argument}\n${usage()}`);
+    } else {
+      positional.push(argument);
+    }
+  }
+
+  if (positional.length !== 1) {
+    throw new Error(usage());
+  }
+
+  return {
+    help: false,
+    requirePublication,
+    skillDir: positional[0],
+  };
+}
+
+export async function runSkillInstallabilityCli(argv) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    return { output: `${usage()}\n` };
+  }
+
+  const resolution = await loadSkillInstallability(options.skillDir);
+  if (options.requirePublication) {
+    requireSkillPublication(resolution.skill, resolution.skillJsonPath);
+  }
+
+  return {
+    output: `${resolution.installable}\n`,
+    resolution,
+  };
+}
+
+async function main() {
+  const result = await runSkillInstallabilityCli(process.argv.slice(2));
+  process.stdout.write(result.output);
+}
+
+const invokedUrl = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : "";
+if (import.meta.url === invokedUrl) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/ci/skill_platforms.mjs
+++ b/scripts/ci/skill_platforms.mjs
@@ -1,6 +1,15 @@
 export const PLATFORM_KEYS = Object.freeze(["openclaw", "nanoclaw", "hermes", "picoclaw"]);
 
-const PLATFORM_AGENT_ALIASES = new Map([["hermes", "hermes-agent"]]);
+// This reviewed map answers only whether the Vercel Skills CLI has a direct
+// target for a declared platform. It does not grant release-channel eligibility.
+// A null value is an explicit, fail-closed "no direct target" decision.
+const PLATFORM_AGENT_TARGETS = new Map([
+  ["codex", "codex"],
+  ["openclaw", "openclaw"],
+  ["hermes", "hermes-agent"],
+  ["nanoclaw", null],
+  ["picoclaw", null],
+]);
 
 function asStringArray(value) {
   if (Array.isArray(value)) {
@@ -27,26 +36,63 @@ export function collectDeclaredPlatforms(skill) {
   return [...platforms];
 }
 
-export function installAgentForSkill(skill, agentTypes, fallback = "openclaw") {
+export function resolveDirectSkillsCliTargets(skill, agentTypes) {
   const platforms = collectDeclaredPlatforms(skill);
   if (platforms.length === 0) {
-    return fallback;
+    return {
+      status: "error",
+      agents: [],
+      unsupportedPlatforms: [],
+      errors: ["Skill metadata does not declare a platform."],
+    };
   }
 
   const matchedAgents = new Set();
-  let allPlatformsMatched = true;
+  const unsupportedPlatforms = new Set();
+  const errors = [];
+
   for (const platform of platforms) {
-    const candidate = PLATFORM_AGENT_ALIASES.get(platform) || platform;
-    if (agentTypes.has(candidate)) {
-      matchedAgents.add(candidate);
-    } else {
-      allPlatformsMatched = false;
+    if (PLATFORM_AGENT_TARGETS.has(platform)) {
+      const target = PLATFORM_AGENT_TARGETS.get(platform);
+      if (target === null) {
+        unsupportedPlatforms.add(platform);
+      } else if (agentTypes.has(target)) {
+        matchedAgents.add(target);
+      } else {
+        errors.push(`Configured npx skills target ${target} for ${platform} is unavailable.`);
+      }
+      continue;
     }
+
+    errors.push(`Unknown platform without a reviewed npx skills target: ${platform}.`);
   }
 
-  if (allPlatformsMatched && matchedAgents.size === 1) {
-    return [...matchedAgents][0];
+  const agents = [...matchedAgents].sort();
+  const unsupported = [...unsupportedPlatforms].sort();
+  if (errors.length > 0) {
+    return {
+      status: "error",
+      agents,
+      unsupportedPlatforms: unsupported,
+      errors,
+    };
   }
 
-  return fallback;
+  return {
+    status: agents.length > 0 ? "required" : "not_applicable",
+    agents,
+    unsupportedPlatforms: unsupported,
+    errors: [],
+  };
+}
+
+export function installAgentForSkill(skill, agentTypes) {
+  const resolution = resolveDirectSkillsCliTargets(skill, agentTypes);
+  if (resolution.status === "error") {
+    throw new Error(resolution.errors.join(" "));
+  }
+  if (resolution.agents.length !== 1 || resolution.unsupportedPlatforms.length > 0) {
+    throw new Error("Skill does not resolve to exactly one reviewed npx skills target.");
+  }
+  return resolution.agents[0];
 }

--- a/scripts/ci/test_verify_skill_release_bundle.py
+++ b/scripts/ci/test_verify_skill_release_bundle.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Security regression tests for verify_skill_release_bundle.py."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+import warnings
+import zipfile
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("verify_skill_release_bundle.py")
+SKILL = "demo-skill"
+VERSION = "1.2.3"
+TAG = f"{SKILL}-v{VERSION}"
+ARCHIVE_NAME = f"{TAG}.zip"
+
+
+def _select_openssl_3() -> str:
+    candidates = [os.environ.get("OPENSSL_BIN"), shutil.which("openssl"), "/opt/homebrew/bin/openssl"]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            result = subprocess.run(
+                [candidate, "version"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            continue
+        if re.match(r"^OpenSSL\s+3(?:\.|\s)", result.stdout.strip()):
+            return candidate
+    raise unittest.SkipTest("OpenSSL 3 is required for release-verifier tests")
+
+
+def _run_checked(command: list[str]) -> bytes:
+    return subprocess.run(command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).stdout
+
+
+class ReleaseBundleVerifierTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.openssl = _select_openssl_3()
+        cls.key_temp = tempfile.TemporaryDirectory(prefix="clawsec-verifier-key-")
+        cls.private_key = Path(cls.key_temp.name) / "private.pem"
+        cls.public_key = Path(cls.key_temp.name) / "public.pem"
+        _run_checked([cls.openssl, "genpkey", "-algorithm", "ED25519", "-out", os.fspath(cls.private_key)])
+        _run_checked(
+            [
+                cls.openssl,
+                "pkey",
+                "-in",
+                os.fspath(cls.private_key),
+                "-pubout",
+                "-out",
+                os.fspath(cls.public_key),
+            ]
+        )
+        der = _run_checked(
+            [
+                cls.openssl,
+                "pkey",
+                "-pubin",
+                "-in",
+                os.fspath(cls.public_key),
+                "-outform",
+                "DER",
+            ]
+        )
+        cls.fingerprint = hashlib.sha256(der).hexdigest()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.key_temp.cleanup()
+
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory(prefix="clawsec-verifier-test-")
+        self.root = Path(self.temp.name)
+        self.release_dir = self.root / "release"
+        self.release_dir.mkdir()
+        self.output_dir = self.root / "verified-output"
+        shutil.copyfile(self.public_key, self.release_dir / "signing-public.pem")
+        self.entries = self._valid_entries()
+        self._write_archive(self.entries)
+        self._refresh_manifest_and_signature()
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    @staticmethod
+    def _valid_entries() -> list[tuple[str, bytes, int, int]]:
+        markdown = f"---\nname: {SKILL}\nversion: {VERSION}\ndescription: test fixture\n---\n\n# Test\n".encode()
+        skill_json = json.dumps({"name": SKILL, "version": VERSION, "sbom": {"files": []}}).encode()
+        return [
+            (f"{SKILL}/", b"", stat.S_IFDIR | 0o755, zipfile.ZIP_STORED),
+            (f"{SKILL}/SKILL.md", markdown, stat.S_IFREG | 0o644, zipfile.ZIP_DEFLATED),
+            (f"{SKILL}/skill.json", skill_json, stat.S_IFREG | 0o600, zipfile.ZIP_DEFLATED),
+            (f"{SKILL}/lib/main.txt", b"safe\n", stat.S_IFREG | 0o644, zipfile.ZIP_DEFLATED),
+        ]
+
+    def _write_archive(self, entries: list[tuple[str, bytes, int, int]]) -> None:
+        archive_path = self.release_dir / ARCHIVE_NAME
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                for name, content, mode, compression in entries:
+                    info = zipfile.ZipInfo(name)
+                    info.create_system = 3
+                    info.external_attr = mode << 16
+                    info.compress_type = compression
+                    archive.writestr(info, content)
+
+    def _refresh_manifest_and_signature(self) -> None:
+        archive = self.release_dir / ARCHIVE_NAME
+        manifest = {
+            "skill": SKILL,
+            "version": VERSION,
+            "tag": TAG,
+            "archive": {
+                "filename": ARCHIVE_NAME,
+                "sha256": hashlib.sha256(archive.read_bytes()).hexdigest(),
+                "size": archive.stat().st_size,
+            },
+            "files": {},
+        }
+        manifest_path = self.release_dir / "checksums.json"
+        manifest_path.write_text(json.dumps(manifest, sort_keys=True, separators=(",", ":")) + "\n")
+        self._sign_current_manifest()
+
+    def _sign_current_manifest(self) -> None:
+        manifest_path = self.release_dir / "checksums.json"
+        signature = _run_checked(
+            [
+                self.openssl,
+                "pkeyutl",
+                "-sign",
+                "-rawin",
+                "-inkey",
+                os.fspath(self.private_key),
+                "-in",
+                os.fspath(manifest_path),
+            ]
+        )
+        (self.release_dir / "checksums.sig").write_bytes(base64.b64encode(signature) + b"\n")
+
+    def _run(
+        self,
+        *extra: str,
+        include_canonical: bool = False,
+        fingerprint: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        command = [
+            sys.executable,
+            os.fspath(SCRIPT),
+            "--release-dir",
+            os.fspath(self.release_dir),
+            "--output-dir",
+            os.fspath(self.output_dir),
+            "--skill",
+            SKILL,
+            "--version",
+            VERSION,
+            "--tag",
+            TAG,
+            "--spki-sha256",
+            fingerprint if fingerprint is not None else self.fingerprint,
+            "--openssl",
+            self.openssl,
+        ]
+        if include_canonical:
+            command.extend(["--canonical-key", os.fspath(self.public_key)])
+        command.extend(extra)
+        return subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    def _assert_rejected(self, result: subprocess.CompletedProcess[str], message: str = "") -> None:
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertFalse(self.output_dir.exists(), message or result.stdout + result.stderr)
+
+    def test_success_verifies_and_extracts_to_absent_output(self) -> None:
+        result = self._run(include_canonical=True)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        extracted = self.output_dir / SKILL
+        self.assertEqual(json.loads((extracted / "skill.json").read_text())["version"], VERSION)
+        self.assertTrue((extracted / "SKILL.md").is_file())
+        self.assertFalse(any(self.root.glob(f".{self.output_dir.name}.staging-*")))
+
+    def test_extraction_normalizes_authenticated_modes(self) -> None:
+        executable_mode = stat.S_IFREG | stat.S_ISUID | stat.S_ISGID | stat.S_ISVTX | 0o010
+        non_executable_mode = stat.S_IFREG | stat.S_ISUID | stat.S_ISGID | stat.S_ISVTX | 0o666
+        directory_mode = stat.S_IFDIR | stat.S_ISUID | stat.S_ISGID | stat.S_ISVTX | 0o777
+        self._write_archive(
+            self.entries
+            + [
+                (f"{SKILL}/bin/", b"", directory_mode, zipfile.ZIP_STORED),
+                (f"{SKILL}/bin/run.sh", b"#!/bin/sh\n", executable_mode, zipfile.ZIP_STORED),
+                (f"{SKILL}/notes.txt", b"not executable\n", non_executable_mode, zipfile.ZIP_STORED),
+            ]
+        )
+        self._refresh_manifest_and_signature()
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        extracted = self.output_dir / SKILL
+        self.assertEqual(stat.S_IMODE(self.output_dir.stat().st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE(extracted.stat().st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE((extracted / "bin").stat().st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE((extracted / "bin" / "run.sh").stat().st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE((extracted / "notes.txt").stat().st_mode), 0o600)
+        self.assertEqual(stat.S_IMODE((extracted / "SKILL.md").stat().st_mode), 0o600)
+
+    def test_wrong_key_fingerprint_is_rejected(self) -> None:
+        replacement = "0" if self.fingerprint[0] != "0" else "1"
+        result = self._run(fingerprint=replacement + self.fingerprint[1:])
+
+        self._assert_rejected(result)
+        self.assertIn("release signing key fingerprint mismatch", result.stderr)
+
+    def test_archive_tamper_is_rejected(self) -> None:
+        with (self.release_dir / ARCHIVE_NAME).open("ab") as archive:
+            archive.write(b"tamper")
+        result = self._run()
+        self._assert_rejected(result)
+        self.assertIn("archive size mismatch", result.stderr)
+
+    def test_equal_size_archive_sha_tamper_is_rejected(self) -> None:
+        archive_path = self.release_dir / ARCHIVE_NAME
+        original_size = archive_path.stat().st_size
+        archive = bytearray(archive_path.read_bytes())
+        archive[len(archive) // 2] ^= 0x01
+        archive_path.write_bytes(archive)
+        self.assertEqual(archive_path.stat().st_size, original_size)
+
+        result = self._run()
+
+        self._assert_rejected(result)
+        self.assertIn("archive SHA-256 mismatch", result.stderr)
+
+    def test_manifest_tamper_fails_signature(self) -> None:
+        manifest_path = self.release_dir / "checksums.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["tag"] = "attacker-v9.9.9"
+        manifest_path.write_text(json.dumps(manifest))
+        result = self._run()
+        self._assert_rejected(result)
+        self.assertIn("signature", result.stderr.lower())
+
+    def test_validly_signed_manifest_must_match_explicit_tag(self) -> None:
+        manifest_path = self.release_dir / "checksums.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["tag"] = "demo-skill-v1.2.3-wrong"
+        manifest_path.write_text(json.dumps(manifest))
+        self._sign_current_manifest()
+        result = self._run()
+        self._assert_rejected(result)
+        self.assertIn("tag mismatch", result.stderr)
+
+    def test_traversal_entry_is_rejected(self) -> None:
+        self._write_archive(self.entries + [(f"{SKILL}/../escape", b"bad", stat.S_IFREG | 0o644, zipfile.ZIP_STORED)])
+        self._refresh_manifest_and_signature()
+        result = self._run()
+        self._assert_rejected(result)
+        self.assertIn("relative path component", result.stderr)
+
+    def test_absolute_and_backslash_entries_are_rejected(self) -> None:
+        malicious_names = ["/absolute", f"{SKILL}\\escape"]
+        for index, malicious_name in enumerate(malicious_names):
+            with self.subTest(name=malicious_name):
+                self.output_dir = self.root / f"output-{index}"
+                self._write_archive(
+                    self.entries + [(malicious_name, b"bad", stat.S_IFREG | 0o644, zipfile.ZIP_STORED)]
+                )
+                self._refresh_manifest_and_signature()
+                self._assert_rejected(self._run())
+
+    def test_symlink_entry_is_rejected(self) -> None:
+        self._write_archive(
+            self.entries + [(f"{SKILL}/link", b"../../escape", stat.S_IFLNK | 0o777, zipfile.ZIP_STORED)]
+        )
+        self._refresh_manifest_and_signature()
+        result = self._run()
+        self._assert_rejected(result)
+        self.assertIn("symlink or special file", result.stderr)
+
+    def test_special_file_entry_is_rejected(self) -> None:
+        self._write_archive(
+            self.entries + [(f"{SKILL}/pipe", b"", stat.S_IFIFO | 0o600, zipfile.ZIP_STORED)]
+        )
+        self._refresh_manifest_and_signature()
+        result = self._run()
+        self._assert_rejected(result)
+        self.assertIn("symlink or special file", result.stderr)
+
+    def test_encrypted_entry_flag_is_rejected_before_extraction(self) -> None:
+        archive_path = self.release_dir / ARCHIVE_NAME
+        archive = bytearray(archive_path.read_bytes())
+        central_header = archive.find(b"PK\x01\x02")
+        self.assertGreaterEqual(central_header, 0)
+        flag_offset = central_header + 8
+        flags = int.from_bytes(archive[flag_offset : flag_offset + 2], "little") | 0x1
+        archive[flag_offset : flag_offset + 2] = flags.to_bytes(2, "little")
+        archive_path.write_bytes(archive)
+        self._refresh_manifest_and_signature()
+        result = self._run()
+        self._assert_rejected(result)
+        self.assertIn("encrypted entry", result.stderr)
+
+    def test_duplicate_and_case_colliding_entries_are_rejected(self) -> None:
+        variants = [
+            [(f"{SKILL}/lib/main.txt", b"duplicate", stat.S_IFREG | 0o644, zipfile.ZIP_STORED)],
+            [
+                (f"{SKILL}/Case.txt", b"one", stat.S_IFREG | 0o644, zipfile.ZIP_STORED),
+                (f"{SKILL}/case.txt", b"two", stat.S_IFREG | 0o644, zipfile.ZIP_STORED),
+            ],
+        ]
+        for index, extra_entries in enumerate(variants):
+            with self.subTest(index=index):
+                self.output_dir = self.root / f"collision-output-{index}"
+                self._write_archive(self.entries + extra_entries)
+                self._refresh_manifest_and_signature()
+                result = self._run()
+                self._assert_rejected(result)
+                self.assertIn("collid", result.stderr.lower())
+
+    def test_unicode_collision_is_rejected(self) -> None:
+        self._write_archive(
+            self.entries
+            + [
+                (f"{SKILL}/caf\u00e9.txt", b"one", stat.S_IFREG | 0o644, zipfile.ZIP_STORED),
+                (f"{SKILL}/cafe\u0301.txt", b"two", stat.S_IFREG | 0o644, zipfile.ZIP_STORED),
+            ]
+        )
+        self._refresh_manifest_and_signature()
+        result = self._run()
+        self._assert_rejected(result)
+        self.assertIn("collid", result.stderr.lower())
+
+    def test_file_directory_prefix_collision_is_rejected(self) -> None:
+        self._write_archive(
+            self.entries
+            + [
+                (f"{SKILL}/blocked", b"file", stat.S_IFREG | 0o644, zipfile.ZIP_STORED),
+                (f"{SKILL}/blocked/child", b"child", stat.S_IFREG | 0o644, zipfile.ZIP_STORED),
+            ]
+        )
+        self._refresh_manifest_and_signature()
+        result = self._run()
+        self._assert_rejected(result)
+        self.assertIn("prefix collision", result.stderr)
+
+    def test_output_directory_must_not_preexist(self) -> None:
+        self.output_dir.mkdir()
+        marker = self.output_dir / "do-not-touch"
+        marker.write_text("preserved")
+        result = self._run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(marker.read_text(), "preserved")
+        self.assertIn("must not already exist", result.stderr)
+
+    def test_windows_unsafe_component_is_rejected(self) -> None:
+        self._write_archive(
+            self.entries + [(f"{SKILL}/CON.txt", b"bad", stat.S_IFREG | 0o644, zipfile.ZIP_STORED)]
+        )
+        self._refresh_manifest_and_signature()
+        result = self._run()
+        self._assert_rejected(result)
+        self.assertIn("reserved Windows", result.stderr)
+
+    def test_excessive_entry_count_and_compression_ratio_are_rejected(self) -> None:
+        result = self._run("--max-entries", "3")
+        self._assert_rejected(result)
+        self.assertIn("limit is 3", result.stderr)
+
+        self.output_dir = self.root / "ratio-output"
+        self._write_archive(
+            self.entries
+            + [(f"{SKILL}/compressed.txt", b"0" * 1_000_000, stat.S_IFREG | 0o644, zipfile.ZIP_DEFLATED)]
+        )
+        self._refresh_manifest_and_signature()
+        result = self._run("--max-compression-ratio", "10")
+        self._assert_rejected(result)
+        self.assertIn("compression ratio", result.stderr)
+
+    def test_extracted_identity_mismatch_is_rejected(self) -> None:
+        wrong_json = json.dumps({"name": SKILL, "version": "9.9.9"}).encode()
+        entries = [entry for entry in self.entries if entry[0] != f"{SKILL}/skill.json"]
+        entries.append((f"{SKILL}/skill.json", wrong_json, stat.S_IFREG | 0o600, zipfile.ZIP_STORED))
+        self._write_archive(entries)
+        self._refresh_manifest_and_signature()
+        result = self._run()
+        self._assert_rejected(result)
+        self.assertIn("identity mismatch", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/ci/validate_skill_install_docs.mjs
+++ b/scripts/ci/validate_skill_install_docs.mjs
@@ -1,14 +1,16 @@
 #!/usr/bin/env node
 import { readFile, readdir } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { existsSync, lstatSync, realpathSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import https from "node:https";
 import path from "node:path";
-import { installAgentForSkill } from "./skill_platforms.mjs";
+import { isTestReleasePath } from "./release_path_policy.mjs";
+import { resolveDirectSkillsCliTargets } from "./skill_platforms.mjs";
 
 const DEFAULT_REPOSITORY = "prompt-security/clawsec";
 const DEFAULT_AGENT_TYPES_URL = "https://raw.githubusercontent.com/vercel-labs/skills/main/src/types.ts";
 const DOC_FILENAMES = ["README.md", "SKILL.md"];
+const NO_DIRECT_TARGET_PATTERN = /no\s+(?:reviewed\s+)?direct[\s\S]{0,80}(?:Agent Skills|Skills CLI)[\s\S]{0,40}target/i;
 
 function usage() {
   return [
@@ -173,28 +175,283 @@ async function readJson(filePath) {
   return JSON.parse(await readFile(filePath, "utf8"));
 }
 
-function hasRequiredCommand(markdown, { repository, skillName, agent }) {
-  return markdown
-    .split("\n")
-    .map((line) => line.replace(/\s+/g, " ").trim())
-    .filter((line) => line.includes("npx skills add"))
-    .some((line) => {
-      return (
-        line.includes(`npx skills add ${repository}`) &&
-        line.includes(`--skill ${skillName}`) &&
-        (line.includes(`-a ${agent}`) || line.includes(`--agent ${agent}`)) &&
-        (line.includes(" -y") || line.includes(" --yes"))
-      );
+function logicalShellLines(markdown) {
+  const lines = [];
+  let current = "";
+  let awaitingContinuation = false;
+
+  for (const rawLine of markdown.split("\n")) {
+    const line = rawLine.trim();
+    current = current ? `${current} ${line}` : line.replace(/^\$\s+/, "");
+    if (current.endsWith("\\")) {
+      current = current.slice(0, -1).trimEnd();
+      awaitingContinuation = true;
+      continue;
+    }
+    if (current) {
+      lines.push({ text: current, malformedContinuation: false });
+    }
+    current = "";
+    awaitingContinuation = false;
+  }
+
+  if (current) {
+    lines.push({ text: current, malformedContinuation: awaitingContinuation });
+  }
+  return lines;
+}
+
+function stripHtmlComments(markdown) {
+  return markdown.replace(/<!--[\s\S]*?(?:-->|$)/g, "");
+}
+
+function tokenizeShellLine(line) {
+  const tokens = [];
+  let current = "";
+  let quote = "";
+  let escaped = false;
+  let hasUnsafeShellSyntax = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = "";
+      } else {
+        if (quote === '"' && (char === "`" || (char === "$" && line[index + 1] === "("))) {
+          hasUnsafeShellSyntax = true;
+        }
+        current += char;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === "#" && current === "") {
+      break;
+    }
+    if (
+      char === ";" ||
+      char === "|" ||
+      char === "&" ||
+      char === "<" ||
+      char === ">" ||
+      char === "`" ||
+      (char === "$" && line[index + 1] === "(")
+    ) {
+      hasUnsafeShellSyntax = true;
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (current) {
+    tokens.push(current);
+  }
+  return {
+    tokens,
+    hasUnsafeShellSyntax,
+    malformed: Boolean(escaped || quote),
+  };
+}
+
+function parseCommandOptions(tokens, start) {
+  const skillValues = [];
+  const agentValues = [];
+  const unexpectedTokens = [];
+  let yesCount = 0;
+  let globalCount = 0;
+
+  for (let index = start + 4; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === "--skill") {
+      skillValues.push(tokens[index + 1] || "");
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("--skill=")) {
+      skillValues.push(token.slice("--skill=".length));
+      continue;
+    }
+    if (token === "-a" || token === "--agent") {
+      agentValues.push(tokens[index + 1] || "");
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-a=") || token.startsWith("--agent=")) {
+      agentValues.push(token.slice(token.indexOf("=") + 1));
+      continue;
+    }
+    if (token === "-y" || token === "--yes") {
+      yesCount += 1;
+      continue;
+    }
+    if (token === "-g" || token === "--global") {
+      globalCount += 1;
+      continue;
+    }
+    unexpectedTokens.push(token);
+  }
+
+  return { skillValues, agentValues, yesCount, globalCount, unexpectedTokens };
+}
+
+function parseSkillsAddCommands(markdown) {
+  const commands = [];
+  for (const { text: line, malformedContinuation } of logicalShellLines(markdown)) {
+    const { tokens, hasUnsafeShellSyntax, malformed } = tokenizeShellLine(line);
+    const start = 0;
+    if (tokens[start] !== "npx" || tokens[start + 1] !== "skills" || tokens[start + 2] !== "add") {
+      if (/\bnpx\s+skills\s+add(?:\s|$)/.test(line)) {
+        commands.push({
+          source: "",
+          skill: "",
+          skillValues: [],
+          agent: "",
+          agentValues: [],
+          yes: false,
+          malformed: true,
+          valid: false,
+        });
+      }
+      continue;
+    }
+
+    const { skillValues, agentValues, yesCount, globalCount, unexpectedTokens } = parseCommandOptions(tokens, start);
+    const malformedCommand = malformed || malformedContinuation;
+    commands.push({
+      source: tokens[start + 3] || "",
+      skill: skillValues[0] || "",
+      skillValues,
+      agent: agentValues[0] || "",
+      agentValues,
+      yes: yesCount === 1,
+      malformed: malformedCommand,
+      valid: (
+        !malformedCommand &&
+        !hasUnsafeShellSyntax &&
+        skillValues.length === 1 &&
+        agentValues.length === 1 &&
+        yesCount === 1 &&
+        globalCount <= 1 &&
+        unexpectedTokens.length === 0
+      ),
     });
+  }
+  return commands;
+}
+
+function hasRequiredCommand(commands, { repository, skillName, agent }) {
+  return commands.some((command) => (
+    command.valid &&
+    command.source === repository &&
+    command.skill === skillName &&
+    command.agent === agent &&
+    command.yes
+  ));
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function hasPlatformNoDirectTargetStatement(markdown, platform) {
+  const platformPattern = escapeRegExp(platform);
+  const noTargetPattern = NO_DIRECT_TARGET_PATTERN.source;
+  const subjectStatement = new RegExp(
+    `(?:^|[^A-Za-z0-9])${platformPattern}` +
+    `(?:(?:\\s+and\\s+[A-Za-z0-9._+-]+)+|\\s*,\\s*which)?` +
+    `\\s+(?:has|have)\\s+${noTargetPattern}`,
+    "i",
+  );
+  const reverseStatement = new RegExp(
+    `${noTargetPattern}\\s+(?:exists?\\s+)?(?:for|in)\\s+` +
+    `(?:the\\s+)?${platformPattern}(?:$|[^A-Za-z0-9])`,
+    "i",
+  );
+  return markdown
+    .split(/\n+|(?<=[.!?;])\s+/)
+    .map((statement) => statement.replace(/\s+/g, " ").trim())
+    .some((statement) => subjectStatement.test(statement) || reverseStatement.test(statement));
+}
+
+function packagedSkillFiles(skill) {
+  const files = new Set();
+  for (const entry of skill.sbom?.files || []) {
+    const candidate = typeof entry === "string" ? entry : entry?.path;
+    if (typeof candidate !== "string" || !candidate.trim()) {
+      continue;
+    }
+    const normalized = candidate.replaceAll("\\", "/").replace(/^\.\//, "");
+    if (!isTestReleasePath(normalized)) {
+      files.add(normalized);
+    }
+  }
+  return files;
+}
+
+function localInstallReferences(markdown, { docPath, skillRoot }) {
+  const references = [];
+  for (const match of markdown.matchAll(/\[([^\]]+)\]\(([^)]+)\)/g)) {
+    const label = match[1];
+    const href = match[2].trim().replace(/^<|>$/g, "");
+    if (!/(?:install|setup|integration)/i.test(`${label} ${href}`) || /^[a-z]+:/i.test(href)) {
+      continue;
+    }
+
+    const relativeTarget = href.split(/[?#]/, 1)[0];
+    const target = path.resolve(path.dirname(docPath), relativeTarget);
+    const skillPrefix = `${skillRoot}${path.sep}`;
+    if (target === docPath || !target.startsWith(skillPrefix) || !/\.md$/i.test(target)) {
+      continue;
+    }
+
+    try {
+      const targetStat = lstatSync(target);
+      const realSkillRoot = realpathSync(skillRoot);
+      const realTarget = realpathSync(target);
+      if (
+        targetStat.isFile() &&
+        realTarget.startsWith(`${realSkillRoot}${path.sep}`)
+      ) {
+        references.push(path.relative(realSkillRoot, realTarget).split(path.sep).join("/"));
+      }
+    } catch {
+      // Broken links and unreadable targets do not prove a native install path.
+    }
+  }
+  return [...new Set(references)];
 }
 
 async function validateSkill({ root, skillDir, repository, agentTypes }) {
   const skillJsonPath = path.join(root, skillDir, "skill.json");
   const skill = await readJson(skillJsonPath);
   const skillName = skill.name || path.basename(skillDir);
-  const agent = installAgentForSkill(skill, agentTypes);
-  const command = `npx skills add ${repository} --skill ${skillName} -a ${agent} -y`;
+  const resolution = resolveDirectSkillsCliTargets(skill, agentTypes);
   const failures = [];
+  const skillRoot = path.join(root, skillDir);
+  const packagedFiles = packagedSkillFiles(skill);
+
+  for (const error of resolution.errors) {
+    failures.push(`Invalid npx skills target policy for ${skillDir}: ${error}`);
+  }
 
   for (const filename of DOC_FILENAMES) {
     const docPath = path.join(root, skillDir, filename);
@@ -203,16 +460,85 @@ async function validateSkill({ root, skillDir, repository, agentTypes }) {
       continue;
     }
 
-    const markdown = await readFile(docPath, "utf8");
-    if (!hasRequiredCommand(markdown, { repository, skillName, agent })) {
-      failures.push(`Missing required npx skills install command in ${path.join(skillDir, filename)}: ${command}`);
+    const markdown = stripHtmlComments(await readFile(docPath, "utf8"));
+    const commands = parseSkillsAddCommands(markdown);
+    const commandsForSkill = commands.filter((command) => command.skillValues.includes(skillName));
+    const malformedCommands = commands.filter(
+      (command) => command.malformed &&
+        (command.skillValues.length === 0 || command.skillValues.includes(skillName)),
+    );
+
+    if (malformedCommands.length > 0) {
+      failures.push(
+        `Invalid npx skills install command in ${path.join(skillDir, filename)}: ` +
+        "the command must be standalone, use the exact reviewed grammar, and have no wrapper, " +
+        "environment assignment, malformed quoting, or trailing line continuation.",
+      );
+    }
+
+    const missingNoTargetPlatforms = resolution.unsupportedPlatforms.filter(
+      (platform) => !hasPlatformNoDirectTargetStatement(markdown, platform),
+    );
+    if (missingNoTargetPlatforms.length > 0) {
+      failures.push(
+        `Missing explicit no-direct-target statement in ${path.join(skillDir, filename)} for ` +
+        `${missingNoTargetPlatforms.join(", ")}.`,
+      );
+    }
+
+    if (resolution.status === "not_applicable" && commandsForSkill.length > 0) {
+      failures.push(
+        `Unsupported npx skills install command in ${path.join(skillDir, filename)}: ` +
+        `${resolution.unsupportedPlatforms.join(", ")} has no reviewed direct AgentType target.`,
+      );
+    }
+
+    if (resolution.unsupportedPlatforms.length > 0) {
+      const nativeReferences = localInstallReferences(markdown, { docPath, skillRoot });
+      if (nativeReferences.length === 0) {
+        failures.push(
+          `Missing local harness-native installation reference in ${path.join(skillDir, filename)}.`,
+        );
+      } else if (!nativeReferences.some((reference) => packagedFiles.has(reference))) {
+        failures.push(
+          `Harness-native installation reference is omitted from skill.json sbom.files in ` +
+          `${path.join(skillDir, filename)}: ${nativeReferences.join(", ")}.`,
+        );
+      }
+    }
+
+    if (resolution.status !== "required") {
+      continue;
+    }
+
+    if (commandsForSkill.some((command) => !command.valid && !command.malformed)) {
+      failures.push(
+        `Invalid npx skills install command in ${path.join(skillDir, filename)}: ` +
+        "use only the reviewed command grammar with exactly one --skill, one --agent/-a, one --yes/-y, " +
+        "at most one --global/-g, and no executable shell syntax or extra tokens.",
+      );
+    }
+
+    for (const command of commandsForSkill.filter((candidate) => candidate.valid)) {
+      if (!resolution.agents.includes(command.agent)) {
+        failures.push(
+          `Unreviewed npx skills target in ${path.join(skillDir, filename)}: ${command.agent || "(missing)"}.`,
+        );
+      }
+    }
+
+    for (const agent of resolution.agents) {
+      if (!hasRequiredCommand(commands, { repository, skillName, agent })) {
+        const command = `npx skills add ${repository} --skill ${skillName} -a ${agent} -y`;
+        failures.push(`Missing required npx skills install command in ${path.join(skillDir, filename)}: ${command}`);
+      }
     }
   }
 
   return {
     skillDir,
     skillName,
-    agent,
+    resolution,
     failures,
   };
 }
@@ -260,7 +586,19 @@ async function main() {
   }
 
   for (const result of results) {
-    console.log(`npx skills install docs OK for ${result.skillName}: -a ${result.agent}`);
+    if (result.resolution.status === "not_applicable") {
+      console.log(
+        `npx skills install docs not applicable for ${result.skillName}: ` +
+        `no reviewed direct AgentType for ${result.resolution.unsupportedPlatforms.join(", ")}`,
+      );
+      continue;
+    }
+
+    const targets = result.resolution.agents.map((agent) => `-a ${agent}`).join(", ");
+    const unsupported = result.resolution.unsupportedPlatforms.length > 0
+      ? `; no direct target for ${result.resolution.unsupportedPlatforms.join(", ")}`
+      : "";
+    console.log(`npx skills install docs OK for ${result.skillName}: ${targets}${unsupported}`);
   }
 }
 

--- a/scripts/ci/verify_skill_release_bundle.py
+++ b/scripts/ci/verify_skill_release_bundle.py
@@ -1,0 +1,796 @@
+#!/usr/bin/env python3
+"""Verify and safely extract a signed ClawSec skill release bundle.
+
+The verifier deliberately treats every downloaded release asset as untrusted.
+It authenticates ``checksums.json`` with a pinned Ed25519 public key, binds the
+manifest to the caller's expected release identity, validates the complete ZIP
+namespace, and only then extracts into a private staging directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unicodedata
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO, NoReturn
+
+
+DEFAULT_MAX_ENTRIES = 4096
+DEFAULT_MAX_FILE_SIZE = 128 * 1024 * 1024
+DEFAULT_MAX_TOTAL_SIZE = 512 * 1024 * 1024
+DEFAULT_MAX_COMPRESSION_RATIO = 200.0
+MAX_MANIFEST_SIZE = 4 * 1024 * 1024
+MAX_SIGNATURE_SIZE = 16 * 1024
+MAX_PUBLIC_KEY_SIZE = 64 * 1024
+MAX_PATH_LENGTH = 4096
+MAX_COMPONENT_LENGTH = 255
+COPY_CHUNK_SIZE = 1024 * 1024
+
+_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+_SAFE_RELEASE_COMPONENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$")
+_OPENSSL_3_RE = re.compile(r"^OpenSSL\s+3(?:\.|\s)")
+_WINDOWS_RESERVED = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{number}" for number in range(1, 10)),
+    *(f"LPT{number}" for number in range(1, 10)),
+}
+_WINDOWS_FORBIDDEN_CHARS = set('<>:"|?*')
+_ALLOWED_COMPRESSION = {
+    zipfile.ZIP_STORED,
+    zipfile.ZIP_DEFLATED,
+    zipfile.ZIP_BZIP2,
+    zipfile.ZIP_LZMA,
+}
+
+
+class VerificationError(Exception):
+    """Raised when a release bundle fails a verification boundary."""
+
+
+@dataclass(frozen=True)
+class Limits:
+    max_entries: int
+    max_file_size: int
+    max_total_size: int
+    max_compression_ratio: float
+
+
+@dataclass(frozen=True)
+class ValidatedEntry:
+    info: zipfile.ZipInfo
+    parts: tuple[str, ...]
+    is_dir: bool
+    extracted_mode: int
+
+
+def fail(message: str) -> NoReturn:
+    raise VerificationError(message)
+
+
+def _json_object_without_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            fail(f"JSON contains duplicate key: {key!r}")
+        result[key] = value
+    return result
+
+
+def load_json_bytes(data: bytes, label: str) -> object:
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        fail(f"{label} is not valid UTF-8: {exc}")
+    try:
+        return json.loads(text, object_pairs_hook=_json_object_without_duplicates)
+    except json.JSONDecodeError as exc:
+        fail(f"{label} is not valid JSON: {exc}")
+
+
+def _require_regular_file(path: Path, label: str, max_size: int | None = None) -> os.stat_result:
+    try:
+        file_stat = path.lstat()
+    except FileNotFoundError:
+        fail(f"missing {label}: {path}")
+    if not stat.S_ISREG(file_stat.st_mode):
+        fail(f"{label} must be a regular file, not a symlink or special file: {path}")
+    if max_size is not None and file_stat.st_size > max_size:
+        fail(f"{label} exceeds the {max_size}-byte safety limit: {path}")
+    return file_stat
+
+
+def _read_limited(path: Path, label: str, max_size: int) -> bytes:
+    expected = _require_regular_file(path, label, max_size).st_size
+    try:
+        with path.open("rb") as handle:
+            data = handle.read(max_size + 1)
+    except OSError as exc:
+        fail(f"could not read {label} {path}: {exc}")
+    if len(data) > max_size:
+        fail(f"{label} exceeds the {max_size}-byte safety limit: {path}")
+    if len(data) != expected:
+        fail(f"{label} changed while it was being read: {path}")
+    return data
+
+
+def _run_openssl(openssl: str, arguments: list[str], label: str) -> subprocess.CompletedProcess[bytes]:
+    command = [openssl, *arguments]
+    try:
+        return subprocess.run(
+            command,
+            check=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        fail(f"OpenSSL executable not found: {openssl}")
+    except subprocess.TimeoutExpired:
+        fail(f"OpenSSL timed out while attempting to {label}")
+    except subprocess.CalledProcessError as exc:
+        detail = exc.stderr.decode("utf-8", "replace").strip()
+        suffix = f": {detail}" if detail else ""
+        fail(f"OpenSSL failed to {label}{suffix}")
+
+
+def require_openssl_3(openssl: str) -> str:
+    result = _run_openssl(openssl, ["version"], "report its version")
+    version = result.stdout.decode("utf-8", "replace").strip()
+    if not _OPENSSL_3_RE.match(version):
+        fail(f"OpenSSL 3 is required; selected executable reported: {version or '<empty>'}")
+    return version
+
+
+def spki_sha256(openssl: str, public_key: Path, label: str) -> str:
+    _require_regular_file(public_key, label, MAX_PUBLIC_KEY_SIZE)
+    details = _run_openssl(
+        openssl,
+        ["pkey", "-pubin", "-in", os.fspath(public_key), "-text_pub", "-noout"],
+        f"inspect {label}",
+    )
+    key_description = (details.stdout + details.stderr).decode("utf-8", "replace").upper()
+    if "ED25519" not in key_description:
+        fail(f"{label} is not an Ed25519 public key")
+    der = _run_openssl(
+        openssl,
+        ["pkey", "-pubin", "-in", os.fspath(public_key), "-outform", "DER"],
+        f"encode {label} as SPKI DER",
+    ).stdout
+    if not der:
+        fail(f"OpenSSL produced an empty SPKI DER encoding for {label}")
+    return hashlib.sha256(der).hexdigest()
+
+
+def _normalize_fingerprint(value: str, label: str) -> str:
+    if not _SHA256_RE.fullmatch(value):
+        fail(f"{label} must be exactly 64 hexadecimal characters")
+    return value.lower()
+
+
+def verify_key_pin(
+    openssl: str,
+    release_key: Path,
+    expected_spki_sha256: str | None,
+    canonical_key: Path | None,
+) -> str:
+    if expected_spki_sha256 is None and canonical_key is None:
+        fail("one of --spki-sha256 or --canonical-key is required")
+
+    expected = (
+        _normalize_fingerprint(expected_spki_sha256, "--spki-sha256")
+        if expected_spki_sha256 is not None
+        else None
+    )
+    if canonical_key is not None:
+        canonical_fingerprint = spki_sha256(openssl, canonical_key, "canonical signing key")
+        if expected is not None and canonical_fingerprint != expected:
+            fail(
+                "canonical signing key fingerprint does not match --spki-sha256: "
+                f"expected {expected}, got {canonical_fingerprint}"
+            )
+        expected = canonical_fingerprint
+
+    assert expected is not None
+    actual = spki_sha256(openssl, release_key, "release signing key")
+    if actual != expected:
+        fail(f"release signing key fingerprint mismatch: expected {expected}, got {actual}")
+    return actual
+
+
+def decode_signature(signature_path: Path, destination: Path) -> None:
+    encoded = _read_limited(signature_path, "checksums signature", MAX_SIGNATURE_SIZE)
+    try:
+        compact = b"".join(encoded.split())
+        signature = base64.b64decode(compact, validate=True)
+    except (ValueError, binascii.Error):
+        fail("checksums.sig is not valid strict base64")
+    if len(signature) != 64:
+        fail(f"checksums.sig must decode to a 64-byte Ed25519 signature, got {len(signature)} bytes")
+    try:
+        descriptor = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(signature)
+    except OSError as exc:
+        fail(f"could not stage the decoded signature: {exc}")
+
+
+def verify_manifest_signature(
+    openssl: str,
+    public_key: Path,
+    signature_path: Path,
+    manifest_path: Path,
+) -> None:
+    _require_regular_file(manifest_path, "checksums manifest", MAX_MANIFEST_SIZE)
+    with tempfile.TemporaryDirectory(prefix="clawsec-release-signature-") as temporary:
+        decoded_signature = Path(temporary) / "checksums.sig.bin"
+        decode_signature(signature_path, decoded_signature)
+        _run_openssl(
+            openssl,
+            [
+                "pkeyutl",
+                "-verify",
+                "-rawin",
+                "-pubin",
+                "-inkey",
+                os.fspath(public_key),
+                "-sigfile",
+                os.fspath(decoded_signature),
+                "-in",
+                os.fspath(manifest_path),
+            ],
+            "verify the checksums.json Ed25519 signature",
+        )
+
+
+def _require_safe_release_component(value: str, label: str) -> None:
+    if not _SAFE_RELEASE_COMPONENT_RE.fullmatch(value):
+        fail(f"{label} is not a safe release identifier: {value!r}")
+    _validate_windows_component(value, label)
+
+
+def validate_expected_identity(skill: str, version: str, tag: str) -> str:
+    _require_safe_release_component(skill, "skill")
+    _require_safe_release_component(version, "version")
+    _require_safe_release_component(tag, "tag")
+    conventional_tag = f"{skill}-v{version}"
+    if tag != conventional_tag:
+        fail(f"tag must match the ClawSec release convention {conventional_tag!r}, got {tag!r}")
+    return f"{tag}.zip"
+
+
+def _require_string(mapping: dict[str, object], key: str, label: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str):
+        fail(f"{label}.{key} must be a string")
+    return value
+
+
+def _require_nonnegative_integer(mapping: dict[str, object], key: str, label: str) -> int:
+    value = mapping.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        fail(f"{label}.{key} must be a non-negative integer")
+    return value
+
+
+def validate_manifest(
+    manifest_path: Path,
+    skill: str,
+    version: str,
+    tag: str,
+    expected_archive_name: str,
+) -> tuple[dict[str, object], str, int]:
+    manifest_data = _read_limited(manifest_path, "checksums manifest", MAX_MANIFEST_SIZE)
+    manifest = load_json_bytes(manifest_data, "checksums.json")
+    if not isinstance(manifest, dict):
+        fail("checksums.json root must be an object")
+
+    expected_fields = {"skill": skill, "version": version, "tag": tag}
+    for field, expected in expected_fields.items():
+        actual = _require_string(manifest, field, "checksums.json")
+        if actual != expected:
+            fail(f"checksums.json {field} mismatch: expected {expected!r}, got {actual!r}")
+
+    archive = manifest.get("archive")
+    if not isinstance(archive, dict):
+        fail("checksums.json.archive must be an object")
+    filename = _require_string(archive, "filename", "checksums.json.archive")
+    if filename != expected_archive_name:
+        fail(
+            "checksums.json archive filename mismatch: "
+            f"expected {expected_archive_name!r}, got {filename!r}"
+        )
+    digest = _require_string(archive, "sha256", "checksums.json.archive")
+    digest = _normalize_fingerprint(digest, "checksums.json.archive.sha256")
+    size = _require_nonnegative_integer(archive, "size", "checksums.json.archive")
+    return manifest, digest, size
+
+
+def _sha256_stream(handle: BinaryIO) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    for block in iter(lambda: handle.read(COPY_CHUNK_SIZE), b""):
+        digest.update(block)
+        size += len(block)
+    return digest.hexdigest(), size
+
+
+def verify_archive_digest(handle: BinaryIO, expected_digest: str, expected_size: int) -> None:
+    handle.seek(0)
+    actual_digest, actual_size = _sha256_stream(handle)
+    if actual_size != expected_size:
+        fail(f"release archive size mismatch: expected {expected_size}, got {actual_size}")
+    if actual_digest != expected_digest:
+        fail(f"release archive SHA-256 mismatch: expected {expected_digest}, got {actual_digest}")
+    handle.seek(0)
+
+
+def _validate_windows_component(component: str, label: str) -> None:
+    if not component or component in {".", ".."}:
+        fail(f"{label} contains an empty or relative path component")
+    if len(component) > MAX_COMPONENT_LENGTH:
+        fail(f"{label} contains a component longer than {MAX_COMPONENT_LENGTH} characters")
+    if component[-1] in {" ", "."}:
+        fail(f"{label} contains a Windows-unsafe trailing space or dot: {component!r}")
+    if any(ord(character) < 32 or ord(character) == 127 for character in component):
+        fail(f"{label} contains a control character")
+    if any(character in _WINDOWS_FORBIDDEN_CHARS for character in component):
+        fail(f"{label} contains a Windows-unsafe character: {component!r}")
+    normalized = unicodedata.normalize("NFKC", component)
+    if "/" in normalized or "\\" in normalized or normalized in {".", ".."}:
+        fail(f"{label} changes into a path separator or relative component under Unicode normalization")
+    device_name = normalized.split(".", 1)[0].upper()
+    if device_name in _WINDOWS_RESERVED:
+        fail(f"{label} contains a reserved Windows device name: {component!r}")
+
+
+def _zip_entry_type(info: zipfile.ZipInfo) -> tuple[bool, int]:
+    is_dir = info.is_dir()
+    unix_mode = info.external_attr >> 16
+    file_type = stat.S_IFMT(unix_mode)
+    if is_dir:
+        if file_type not in {0, stat.S_IFDIR}:
+            fail(f"ZIP directory entry has a special-file mode: {info.filename!r}")
+    else:
+        if file_type == stat.S_IFDIR:
+            fail(f"ZIP directory mode lacks a trailing slash: {info.filename!r}")
+        if file_type not in {0, stat.S_IFREG}:
+            fail(f"ZIP contains a symlink or special file: {info.filename!r}")
+    return is_dir, file_type
+
+
+def _canonical_path_key(parts: tuple[str, ...]) -> str:
+    return unicodedata.normalize("NFKC", "/".join(parts)).casefold()
+
+
+def _validated_entry_path(info: zipfile.ZipInfo, skill: str) -> tuple[tuple[str, ...], bool]:
+    name = info.filename
+    if not name:
+        fail("ZIP contains an empty entry name")
+    if len(name) > MAX_PATH_LENGTH:
+        fail(f"ZIP entry path exceeds {MAX_PATH_LENGTH} characters")
+    if "\\" in name:
+        fail(f"ZIP entry uses a backslash path separator: {name!r}")
+    if name.startswith("/") or name.startswith("//") or re.match(r"^[A-Za-z]:", name):
+        fail(f"ZIP entry uses an absolute path: {name!r}")
+
+    is_dir, _ = _zip_entry_type(info)
+    logical_name = name[:-1] if is_dir else name
+    if not logical_name or "//" in logical_name:
+        fail(f"ZIP entry contains an empty path component: {name!r}")
+    parts = tuple(logical_name.split("/"))
+    for component in parts:
+        _validate_windows_component(component, f"ZIP entry {name!r}")
+    if parts[0] != skill:
+        fail(f"ZIP entry is outside the exact {skill!r} skill root: {name!r}")
+    if len(parts) == 1 and not is_dir:
+        fail(f"ZIP skill root must be a directory, not a file: {name!r}")
+    return parts, is_dir
+
+
+def validate_zip_structure(
+    archive: zipfile.ZipFile,
+    skill: str,
+    limits: Limits,
+) -> list[ValidatedEntry]:
+    infos = archive.infolist()
+    if not infos:
+        fail("release archive is empty")
+    if len(infos) > limits.max_entries:
+        fail(f"release archive has {len(infos)} entries; limit is {limits.max_entries}")
+
+    entries: list[ValidatedEntry] = []
+    explicit_paths: dict[str, str] = {}
+    namespace: dict[str, tuple[str, str]] = {}
+    total_uncompressed = 0
+
+    for info in infos:
+        if info.flag_bits & 0x1:
+            fail(f"ZIP contains an encrypted entry: {info.filename!r}")
+        if info.compress_type not in _ALLOWED_COMPRESSION:
+            fail(f"ZIP entry uses unsupported compression method {info.compress_type}: {info.filename!r}")
+
+        parts, is_dir = _validated_entry_path(info, skill)
+        raw_path = "/".join(parts)
+        canonical = _canonical_path_key(parts)
+        prior_explicit = explicit_paths.get(canonical)
+        if prior_explicit is not None:
+            fail(
+                "ZIP contains duplicate, case-colliding, or Unicode-colliding entries: "
+                f"{prior_explicit!r} and {raw_path!r}"
+            )
+
+        for length in range(1, len(parts)):
+            prefix_parts = parts[:length]
+            prefix = "/".join(prefix_parts)
+            prefix_key = _canonical_path_key(prefix_parts)
+            existing = namespace.get(prefix_key)
+            if existing is None:
+                namespace[prefix_key] = ("dir", prefix)
+            elif existing[0] != "dir":
+                fail(f"ZIP file/directory prefix collision: {existing[1]!r} blocks {raw_path!r}")
+            elif existing[1] != prefix:
+                fail(f"ZIP case or Unicode directory collision: {existing[1]!r} and {prefix!r}")
+
+        desired_type = "dir" if is_dir else "file"
+        existing = namespace.get(canonical)
+        if existing is None:
+            namespace[canonical] = (desired_type, raw_path)
+        elif existing[0] != desired_type:
+            fail(f"ZIP file/directory prefix collision at {raw_path!r}")
+        elif existing[1] != raw_path:
+            fail(f"ZIP case or Unicode path collision: {existing[1]!r} and {raw_path!r}")
+        elif not is_dir:
+            fail(f"ZIP contains duplicate file entry: {raw_path!r}")
+
+        explicit_paths[canonical] = raw_path
+
+        if is_dir:
+            if info.file_size != 0 or info.compress_size != 0:
+                fail(f"ZIP directory entry carries data: {info.filename!r}")
+        else:
+            if info.file_size > limits.max_file_size:
+                fail(
+                    f"ZIP entry {info.filename!r} expands to {info.file_size} bytes; "
+                    f"per-file limit is {limits.max_file_size}"
+                )
+            total_uncompressed += info.file_size
+            if total_uncompressed > limits.max_total_size:
+                fail(
+                    f"ZIP expands to more than the {limits.max_total_size}-byte total safety limit"
+                )
+            if info.file_size:
+                if info.compress_size == 0:
+                    fail(f"ZIP entry has data but zero compressed size: {info.filename!r}")
+                ratio = info.file_size / info.compress_size
+                if ratio > limits.max_compression_ratio:
+                    fail(
+                        f"ZIP entry {info.filename!r} compression ratio {ratio:.2f} exceeds "
+                        f"limit {limits.max_compression_ratio:.2f}"
+                    )
+
+        archived_mode = info.external_attr >> 16
+        extracted_mode = 0o700 if is_dir or archived_mode & 0o111 else 0o600
+        entries.append(
+            ValidatedEntry(
+                info=info,
+                parts=parts,
+                is_dir=is_dir,
+                extracted_mode=extracted_mode,
+            )
+        )
+
+    required = {
+        _canonical_path_key((skill, "SKILL.md")): f"{skill}/SKILL.md",
+        _canonical_path_key((skill, "skill.json")): f"{skill}/skill.json",
+    }
+    for key, path in required.items():
+        node = namespace.get(key)
+        if node is None or node[0] != "file" or node[1] != path:
+            fail(f"release archive is missing required regular file: {path}")
+    return entries
+
+
+def _safe_open_destination(path: Path) -> BinaryIO:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except OSError as exc:
+        fail(f"could not create staged release file {path}: {exc}")
+    return os.fdopen(descriptor, "wb")
+
+
+def _ensure_private_directories(staging: Path, parts: tuple[str, ...]) -> Path:
+    current = staging
+    for component in parts:
+        current /= component
+        try:
+            current.mkdir(mode=0o700, exist_ok=True)
+            current.chmod(0o700)
+        except OSError as exc:
+            fail(f"could not create private staged release directory {current}: {exc}")
+    return current
+
+
+def extract_manually(
+    archive: zipfile.ZipFile,
+    entries: list[ValidatedEntry],
+    staging: Path,
+    limits: Limits,
+) -> None:
+    total_written = 0
+    for entry in entries:
+        target = staging.joinpath(*entry.parts)
+        if entry.is_dir:
+            _ensure_private_directories(staging, entry.parts)
+            continue
+
+        try:
+            _ensure_private_directories(staging, entry.parts[:-1])
+            source = archive.open(entry.info, "r")
+        except (OSError, RuntimeError, zipfile.BadZipFile, NotImplementedError) as exc:
+            fail(f"could not open ZIP entry {entry.info.filename!r}: {exc}")
+
+        written = 0
+        try:
+            with source, _safe_open_destination(target) as destination:
+                while True:
+                    block = source.read(COPY_CHUNK_SIZE)
+                    if not block:
+                        break
+                    written += len(block)
+                    total_written += len(block)
+                    if written > entry.info.file_size or written > limits.max_file_size:
+                        fail(f"ZIP entry expanded beyond its declared or permitted size: {entry.info.filename!r}")
+                    if total_written > limits.max_total_size:
+                        fail("ZIP expanded beyond the permitted total size during extraction")
+                    destination.write(block)
+                os.fchmod(destination.fileno(), entry.extracted_mode)
+        except (OSError, RuntimeError, zipfile.BadZipFile, NotImplementedError) as exc:
+            fail(f"failed while extracting ZIP entry {entry.info.filename!r}: {exc}")
+        if written != entry.info.file_size:
+            fail(
+                f"ZIP entry size changed during extraction for {entry.info.filename!r}: "
+                f"expected {entry.info.file_size}, got {written}"
+            )
+
+
+def _frontmatter_scalar(markdown: str, key: str) -> str:
+    lines = markdown.splitlines()
+    if not lines or lines[0].strip() != "---":
+        fail("SKILL.md must begin with YAML frontmatter")
+    values: list[str] = []
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        if line.startswith((" ", "\t")) or ":" not in line:
+            continue
+        candidate_key, candidate_value = line.split(":", 1)
+        if candidate_key.strip() == key:
+            values.append(candidate_value.strip())
+    else:
+        fail("SKILL.md frontmatter is not terminated")
+    if len(values) != 1:
+        fail(f"SKILL.md frontmatter must contain exactly one {key!r} field")
+    value = values[0]
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        if value[0] == '"':
+            try:
+                decoded = json.loads(value)
+            except json.JSONDecodeError:
+                fail(f"SKILL.md frontmatter {key!r} has invalid quoting")
+            if not isinstance(decoded, str):
+                fail(f"SKILL.md frontmatter {key!r} must be a string")
+            value = decoded
+        else:
+            value = value[1:-1].replace("''", "'")
+    if not value:
+        fail(f"SKILL.md frontmatter {key!r} must not be empty")
+    return value
+
+
+def validate_extracted_identity(staging: Path, skill: str, version: str) -> None:
+    skill_root = staging / skill
+    skill_json_path = skill_root / "skill.json"
+    skill_md_path = skill_root / "SKILL.md"
+    _require_regular_file(skill_json_path, "extracted skill.json", DEFAULT_MAX_FILE_SIZE)
+    _require_regular_file(skill_md_path, "extracted SKILL.md", DEFAULT_MAX_FILE_SIZE)
+
+    skill_json = load_json_bytes(
+        _read_limited(skill_json_path, "extracted skill.json", DEFAULT_MAX_FILE_SIZE),
+        "extracted skill.json",
+    )
+    if not isinstance(skill_json, dict):
+        fail("extracted skill.json root must be an object")
+    json_name = _require_string(skill_json, "name", "extracted skill.json")
+    json_version = _require_string(skill_json, "version", "extracted skill.json")
+    if json_name != skill or json_version != version:
+        fail(
+            "extracted skill.json identity mismatch: "
+            f"expected {skill}@{version}, got {json_name}@{json_version}"
+        )
+
+    try:
+        markdown = _read_limited(skill_md_path, "extracted SKILL.md", DEFAULT_MAX_FILE_SIZE).decode("utf-8")
+    except UnicodeDecodeError as exc:
+        fail(f"extracted SKILL.md is not valid UTF-8: {exc}")
+    md_name = _frontmatter_scalar(markdown, "name")
+    md_version = _frontmatter_scalar(markdown, "version")
+    if md_name != skill or md_version != version:
+        fail(
+            "extracted SKILL.md identity mismatch: "
+            f"expected {skill}@{version}, got {md_name}@{md_version}"
+        )
+
+
+def _validate_limits(arguments: argparse.Namespace) -> Limits:
+    integer_limits = {
+        "--max-entries": arguments.max_entries,
+        "--max-file-size": arguments.max_file_size,
+        "--max-total-size": arguments.max_total_size,
+    }
+    for name, value in integer_limits.items():
+        if value <= 0:
+            fail(f"{name} must be greater than zero")
+    ratio = arguments.max_compression_ratio
+    if not math.isfinite(ratio) or ratio < 1.0:
+        fail("--max-compression-ratio must be a finite number of at least 1")
+    return Limits(
+        max_entries=arguments.max_entries,
+        max_file_size=arguments.max_file_size,
+        max_total_size=arguments.max_total_size,
+        max_compression_ratio=ratio,
+    )
+
+
+def verify_and_extract(arguments: argparse.Namespace) -> Path:
+    limits = _validate_limits(arguments)
+    expected_archive_name = validate_expected_identity(arguments.skill, arguments.version, arguments.tag)
+
+    release_dir = Path(arguments.release_dir).absolute()
+    try:
+        release_stat = release_dir.lstat()
+    except FileNotFoundError:
+        fail(f"release directory does not exist: {release_dir}")
+    if not stat.S_ISDIR(release_stat.st_mode):
+        fail(f"release directory must be a real directory, not a symlink: {release_dir}")
+
+    output_dir = Path(arguments.output_dir).absolute()
+    if output_dir.exists() or output_dir.is_symlink():
+        fail(f"output directory must not already exist: {output_dir}")
+    output_parent = output_dir.parent
+    try:
+        parent_stat = output_parent.lstat()
+    except FileNotFoundError:
+        fail(f"output directory parent does not exist: {output_parent}")
+    if not stat.S_ISDIR(parent_stat.st_mode):
+        fail(f"output directory parent must be a real directory, not a symlink: {output_parent}")
+
+    manifest_path = release_dir / "checksums.json"
+    signature_path = release_dir / "checksums.sig"
+    release_key = release_dir / "signing-public.pem"
+    archive_path = release_dir / expected_archive_name
+    _require_regular_file(archive_path, "release archive")
+
+    openssl = arguments.openssl
+    require_openssl_3(openssl)
+    canonical_key = Path(arguments.canonical_key).absolute() if arguments.canonical_key else None
+    verify_key_pin(openssl, release_key, arguments.spki_sha256, canonical_key)
+    verify_manifest_signature(openssl, release_key, signature_path, manifest_path)
+    _, archive_digest, archive_size = validate_manifest(
+        manifest_path,
+        arguments.skill,
+        arguments.version,
+        arguments.tag,
+        expected_archive_name,
+    )
+
+    staging: Path | None = None
+    try:
+        staging = Path(tempfile.mkdtemp(prefix=f".{output_dir.name}.staging-", dir=output_parent))
+        os.chmod(staging, 0o700)
+        try:
+            archive_handle = archive_path.open("rb")
+        except OSError as exc:
+            fail(f"could not open release archive {archive_path}: {exc}")
+        with archive_handle:
+            opened_stat = os.fstat(archive_handle.fileno())
+            if not stat.S_ISREG(opened_stat.st_mode):
+                fail("release archive changed into a non-regular file")
+            verify_archive_digest(archive_handle, archive_digest, archive_size)
+            try:
+                with zipfile.ZipFile(archive_handle, "r") as archive:
+                    entries = validate_zip_structure(archive, arguments.skill, limits)
+                    extract_manually(archive, entries, staging, limits)
+            except zipfile.BadZipFile as exc:
+                fail(f"release archive is not a valid ZIP file: {exc}")
+
+            final_stat = os.fstat(archive_handle.fileno())
+            if (
+                final_stat.st_dev != opened_stat.st_dev
+                or final_stat.st_ino != opened_stat.st_ino
+                or final_stat.st_size != opened_stat.st_size
+                or final_stat.st_mtime_ns != opened_stat.st_mtime_ns
+            ):
+                fail("release archive changed while it was being verified or extracted")
+            verify_archive_digest(archive_handle, archive_digest, archive_size)
+
+        validate_extracted_identity(staging, arguments.skill, arguments.version)
+        if output_dir.exists() or output_dir.is_symlink():
+            fail(f"output directory appeared before final rename: {output_dir}")
+        try:
+            os.rename(staging, output_dir)
+        except OSError as exc:
+            fail(f"could not atomically publish verified output directory {output_dir}: {exc}")
+        staging = None
+        return output_dir / arguments.skill
+    finally:
+        if staging is not None:
+            shutil.rmtree(staging, ignore_errors=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify and safely extract a signed ClawSec skill release bundle.",
+    )
+    parser.add_argument("--release-dir", required=True, help="Directory containing the four downloaded release assets")
+    parser.add_argument("--output-dir", required=True, help="Absent directory to receive the verified archive contents")
+    parser.add_argument("--skill", required=True, help="Expected skill package name")
+    parser.add_argument("--version", required=True, help="Expected skill package version")
+    parser.add_argument("--tag", required=True, help="Exact expected release tag")
+    parser.add_argument(
+        "--spki-sha256",
+        help="Pinned SHA-256 fingerprint of the trusted Ed25519 public key's SPKI DER encoding",
+    )
+    parser.add_argument(
+        "--canonical-key",
+        help="Trusted canonical Ed25519 public key whose SPKI fingerprint pins the downloaded release key",
+    )
+    parser.add_argument(
+        "--openssl",
+        default=os.environ.get("OPENSSL_BIN", "openssl"),
+        help="OpenSSL 3 executable (default: OPENSSL_BIN or openssl)",
+    )
+    parser.add_argument("--max-entries", type=int, default=DEFAULT_MAX_ENTRIES)
+    parser.add_argument("--max-file-size", type=int, default=DEFAULT_MAX_FILE_SIZE)
+    parser.add_argument("--max-total-size", type=int, default=DEFAULT_MAX_TOTAL_SIZE)
+    parser.add_argument("--max-compression-ratio", type=float, default=DEFAULT_MAX_COMPRESSION_RATIO)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    arguments = parser.parse_args(argv)
+    try:
+        extracted_skill = verify_and_extract(arguments)
+    except VerificationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(f"ERROR: operating-system failure: {exc}", file=sys.stderr)
+        return 1
+    print(f"Verified and extracted {arguments.skill}@{arguments.version} to {extracted_skill}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release-skill.sh
+++ b/scripts/release-skill.sh
@@ -70,6 +70,17 @@ if [ ! -f "$SKILL_PATH/skill.json" ]; then
   exit 1
 fi
 
+if ! command -v node >/dev/null 2>&1; then
+  echo "Error: Node.js is required to evaluate skill publication eligibility" >&2
+  exit 1
+fi
+
+if [[ "$IS_RELEASE_BRANCH" == "true" || "$FORCE_TAG" == "true" ]]; then
+  INSTALLABLE="$(node scripts/ci/skill_installability.mjs "$SKILL_PATH" --require-publication)"
+else
+  INSTALLABLE="$(node scripts/ci/skill_installability.mjs "$SKILL_PATH")"
+fi
+
 # Validate semver format (supports prerelease like 1.0.0-beta1)
 if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
   echo "Error: Invalid version format. Use semver (e.g., 1.0.0, 1.1.0-beta1)"
@@ -338,6 +349,17 @@ if [[ "$IS_RELEASE_BRANCH" == "true" || "$FORCE_TAG" == "true" ]]; then
   fi
 else
   # Feature branch: skip tagging, instruct user on next steps
+  if [[ "$INSTALLABLE" == "false" ]]; then
+    echo ""
+    echo "Done! Non-installable package version updated and committed for review."
+    echo ""
+    echo "Next step: push this branch so CI can build signed denial evidence."
+    echo "  git push origin $CURRENT_BRANCH"
+    echo ""
+    echo "Do not create or push a public tag, GitHub Release, or skill-store publication for this package."
+    exit 0
+  fi
+
   echo ""
   echo "Done! Version updated and committed (tag deferred)."
   echo ""

--- a/scripts/test-skill-install-docs.mjs
+++ b/scripts/test-skill-install-docs.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -19,8 +19,16 @@ function runValidator(args) {
   );
 }
 
-async function writeSkill({ name, metadata, readme, skillMd }) {
+async function writeSkill({ name, metadata, readme, skillMd, installMd }) {
   const skillDir = path.join(tempRoot, "skills", name);
+  const releaseMetadata = installMd !== undefined && metadata.sbom === undefined
+    ? {
+        ...metadata,
+        sbom: {
+          files: [{ path: "INSTALL.md", required: true, description: "Native installation guide" }],
+        },
+      }
+    : metadata;
   await mkdir(skillDir, { recursive: true });
   await writeFile(
     path.join(skillDir, "skill.json"),
@@ -30,7 +38,7 @@ async function writeSkill({ name, metadata, readme, skillMd }) {
         version: "1.0.0",
         description: `${name} test skill`,
         license: "AGPL-3.0-or-later",
-        ...metadata,
+        ...releaseMetadata,
       },
       null,
       2,
@@ -38,6 +46,9 @@ async function writeSkill({ name, metadata, readme, skillMd }) {
   );
   await writeFile(path.join(skillDir, "README.md"), readme);
   await writeFile(path.join(skillDir, "SKILL.md"), skillMd);
+  if (installMd !== undefined) {
+    await writeFile(path.join(skillDir, "INSTALL.md"), installMd);
+  }
 }
 
 try {
@@ -78,6 +89,118 @@ try {
   );
 
   await writeSkill({
+    name: "hermes-env-prefix",
+    metadata: { hermes: { category: "security" } },
+    readme:
+      "# Hermes Environment Prefix\n\n```bash\nNODE_OPTIONS=--require=./evil.js npx skills add prompt-security/clawsec --skill hermes-env-prefix -a hermes-agent -y\n```\n",
+    skillMd:
+      "---\nname: hermes-env-prefix\nversion: 1.0.0\n---\n\n```bash\nNODE_OPTIONS=--require=./evil.js npx skills add prompt-security/clawsec --skill hermes-env-prefix -a hermes-agent -y\n```\n",
+  });
+  const environmentPrefix = runValidator(["--skills", "skills/hermes-env-prefix"]);
+  assert.equal(environmentPrefix.status, 1, "environment assignments must not prefix an approved command");
+  assert.match(environmentPrefix.stderr, /no wrapper, environment assignment/);
+
+  for (const [label, wrappedCommand] of [
+    ["sudo", "sudo npx skills add prompt-security/clawsec --skill hermes-wrapped-sudo -a hermes-agent -y"],
+    ["env", "env npx skills add prompt-security/clawsec --skill hermes-wrapped-env -a hermes-agent -y"],
+    ["command", "command npx skills add prompt-security/clawsec --skill hermes-wrapped-command -a hermes-agent -y"],
+    [
+      "shell",
+      "bash -c 'npx skills add prompt-security/clawsec --skill hermes-wrapped-shell -a hermes-agent -y'",
+    ],
+  ]) {
+    const name = `hermes-wrapped-${label}`;
+    const canonical = `npx skills add prompt-security/clawsec --skill ${name} -a hermes-agent -y`;
+    await writeSkill({
+      name,
+      metadata: { hermes: { category: "security" } },
+      readme: `# Wrapped Hermes Command\n\n\`\`\`bash\n${canonical}\n${wrappedCommand}\n\`\`\`\n`,
+      skillMd: `---\nname: ${name}\nversion: 1.0.0\n---\n\n\`\`\`bash\n${canonical}\n${wrappedCommand}\n\`\`\`\n`,
+    });
+    const wrapped = runValidator(["--skills", `skills/${name}`]);
+    assert.equal(wrapped.status, 1, `${label} wrapped commands must fail even beside a canonical command`);
+    assert.match(wrapped.stderr, /no wrapper, environment assignment/);
+  }
+
+  await writeSkill({
+    name: "hermes-example",
+    metadata: { hermes: { category: "security" } },
+    readme:
+      "# Hermes Example\n\n```bash\nnpx skills add prompt-security/clawsec-evil --skill hermes-example-evil -a hermes-agent-evil --yes-please\n# npx skills add prompt-security/clawsec --skill hermes-example -a hermes-agent -y\n```\n",
+    skillMd:
+      "---\nname: hermes-example\nversion: 1.0.0\n---\n\n```bash\nnpx skills add prompt-security/clawsec-evil --skill hermes-example-evil -a hermes-agent-evil --yes-please\n# npx skills add prompt-security/clawsec --skill hermes-example -a hermes-agent -y\n```\n",
+  });
+  const suffixAndCommentBypass = runValidator(["--skills", "skills/hermes-example"]);
+  assert.equal(suffixAndCommentBypass.status, 1, "suffixes and commented commands must not satisfy validation");
+  assert.match(suffixAndCommentBypass.stderr, /hermes-example -a hermes-agent -y/);
+
+  await writeSkill({
+    name: "hermes-example",
+    metadata: { hermes: { category: "security" } },
+    readme:
+      "# Hermes Example\n\n```bash\nnpx skills add prompt-security/clawsec \\\n  --skill hermes-example \\\n  --agent hermes-agent \\\n  --yes\n```\n",
+    skillMd:
+      "---\nname: hermes-example\nversion: 1.0.0\n---\n\n```bash\nnpx skills add prompt-security/clawsec \\\n  --skill hermes-example \\\n  --agent hermes-agent \\\n  --yes\n```\n",
+  });
+  const multilineHermes = runValidator(["--skills", "skills/hermes-example"]);
+  assert.equal(multilineHermes.status, 0, `canonical multiline commands should pass\n${multilineHermes.stderr}`);
+
+  await writeSkill({
+    name: "hermes-example",
+    metadata: { hermes: { category: "security" } },
+    readme:
+      "# Hermes Example\n\n```bash\nnpx skills add prompt-security/clawsec --skill hermes-example --agent hermes-agent --agent openclaw -y\n```\n",
+    skillMd:
+      "---\nname: hermes-example\nversion: 1.0.0\n---\n\n```bash\nnpx skills add prompt-security/clawsec --skill hermes-example --agent hermes-agent --agent openclaw -y\n```\n",
+  });
+  const duplicateAgent = runValidator(["--skills", "skills/hermes-example"]);
+  assert.equal(duplicateAgent.status, 1, "duplicate agent options must fail closed");
+  assert.match(duplicateAgent.stderr, /reviewed command grammar with exactly one --skill/);
+
+  await writeSkill({
+    name: "hermes-example",
+    metadata: { hermes: { category: "security" } },
+    readme:
+      "# Hermes Example\n\n```bash\nnpx skills add prompt-security/clawsec --skill hermes-example -a hermes-agent -y ; echo unsafe\n```\n",
+    skillMd:
+      "---\nname: hermes-example\nversion: 1.0.0\n---\n\n```bash\nnpx skills add prompt-security/clawsec --skill hermes-example -a hermes-agent -y ; echo unsafe\n```\n",
+  });
+  const shellControlOperator = runValidator(["--skills", "skills/hermes-example"]);
+  assert.equal(shellControlOperator.status, 1, "shell control operators must fail closed");
+  assert.match(shellControlOperator.stderr, /no executable shell syntax or extra tokens/);
+
+  for (const [label, suffix] of [
+    ["command-substitution", '"$(printf unsafe)"'],
+    ["backticks", '"`printf unsafe`"'],
+    ["redirection", ">proof.txt"],
+    ["extra-positional", "unexpected"],
+  ]) {
+    const name = `hermes-unsafe-${label}`;
+    const command = `npx skills add prompt-security/clawsec --skill ${name} -a hermes-agent -y ${suffix}`;
+    await writeSkill({
+      name,
+      metadata: { hermes: { category: "security" } },
+      readme: `# Unsafe Hermes Example\n\n\`\`\`bash\n${command}\n\`\`\`\n`,
+      skillMd: `---\nname: ${name}\nversion: 1.0.0\n---\n\n\`\`\`bash\n${command}\n\`\`\`\n`,
+    });
+    const unsafeCommand = runValidator(["--skills", `skills/${name}`]);
+    assert.equal(unsafeCommand.status, 1, `${label} syntax must fail closed`);
+    assert.match(unsafeCommand.stderr, /no executable shell syntax or extra tokens/);
+  }
+
+  await writeSkill({
+    name: "hermes-comment-example",
+    metadata: { hermes: { category: "security" } },
+    readme:
+      "# Hermes Comment Example\n\n<!-- npx skills add prompt-security/clawsec --skill hermes-comment-example -a hermes-agent -y -->\n",
+    skillMd:
+      "---\nname: hermes-comment-example\nversion: 1.0.0\n---\n\n<!-- npx skills add prompt-security/clawsec --skill hermes-comment-example -a hermes-agent -y -->\n",
+  });
+  const hiddenHermesCommand = runValidator(["--skills", "skills/hermes-comment-example"]);
+  assert.equal(hiddenHermesCommand.status, 1, "HTML-comment-only commands must not satisfy validation");
+  assert.match(hiddenHermesCommand.stderr, /hermes-comment-example -a hermes-agent -y/);
+
+  await writeSkill({
     name: "codex-example",
     metadata: { platform: "codex" },
     readme:
@@ -98,34 +221,283 @@ try {
     name: "nanoclaw-example",
     metadata: { platform: "nanoclaw", nanoclaw: { category: "security" } },
     readme:
-      "# NanoClaw Example\n\n## Vercel Skills Installation\n\n```bash\nnpx skills add prompt-security/clawsec --skill nanoclaw-example -a hermes-agent -y\n```\n",
+      "# NanoClaw Example\n\n## Vercel Skills Installation\n\n```bash\nnpx skills add https://github.com/evil/fork --skill nanoclaw-example -a openclaw -y\n```\n",
     skillMd:
-      "---\nname: nanoclaw-example\nversion: 1.0.0\n---\n\n## Vercel Skills Installation\n\n```bash\nnpx skills add prompt-security/clawsec --skill nanoclaw-example -a hermes-agent -y\n```\n",
+      "---\nname: nanoclaw-example\nversion: 1.0.0\n---\n\n## Vercel Skills Installation\n\n```bash\nnpx skills add https://github.com/evil/fork --skill nanoclaw-example -a openclaw -y\n```\n",
   });
 
   const wrongNanoTarget = runValidator(["--skills", "skills/nanoclaw-example"]);
-  assert.equal(wrongNanoTarget.status, 1, "NanoClaw docs must fail when they use the Hermes target");
+  assert.equal(wrongNanoTarget.status, 1, "NanoClaw docs must fail when they claim any unrelated agent target");
   assert.match(
     wrongNanoTarget.stderr,
-    /npx skills add prompt-security\/clawsec --skill nanoclaw-example -a openclaw -y/,
-    "NanoClaw skills must install through the openclaw target",
+    /Unsupported npx skills install command[\s\S]*nanoclaw has no reviewed direct AgentType target/,
+    "NanoClaw must not silently fall back to an OpenClaw or Hermes target",
   );
+
+  await writeSkill({
+    name: "nanoclaw-unterminated-quote",
+    metadata: { platform: "nanoclaw" },
+    readme:
+      "# NanoClaw Unterminated Quote\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n\nnpx skills add prompt-security/clawsec --skill nanoclaw-unterminated-quote --agent \"openclaw --yes",
+    skillMd:
+      "---\nname: nanoclaw-unterminated-quote\nversion: 1.0.0\n---\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n\nnpx skills add prompt-security/clawsec --skill nanoclaw-unterminated-quote --agent \"openclaw --yes",
+    installMd: "# Native installation\n",
+  });
+  const unterminatedQuote = runValidator(["--skills", "skills/nanoclaw-unterminated-quote"]);
+  assert.equal(unterminatedQuote.status, 1, "an unterminated quoted install candidate must fail closed");
+  assert.match(unterminatedQuote.stderr, /Invalid npx skills install command/);
+
+  await writeSkill({
+    name: "nanoclaw-trailing-continuation",
+    metadata: { platform: "nanoclaw" },
+    readme:
+      "# NanoClaw Trailing Continuation\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n\nnpx skills add prompt-security/clawsec --skill nanoclaw-trailing-continuation --agent openclaw --yes \\",
+    skillMd:
+      "---\nname: nanoclaw-trailing-continuation\nversion: 1.0.0\n---\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n\nnpx skills add prompt-security/clawsec --skill nanoclaw-trailing-continuation --agent openclaw --yes \\",
+    installMd: "# Native installation\n",
+  });
+  const trailingContinuation = runValidator(["--skills", "skills/nanoclaw-trailing-continuation"]);
+  assert.equal(trailingContinuation.status, 1, "a trailing continuation install candidate must fail closed");
+  assert.match(trailingContinuation.stderr, /Invalid npx skills install command/);
 
   await writeSkill({
     name: "nanoclaw-example",
     metadata: { platform: "nanoclaw", nanoclaw: { category: "security" } },
     readme:
-      "# NanoClaw Example\n\n## Vercel Skills Installation\n\n```bash\nnpx skills add prompt-security/clawsec --skill nanoclaw-example -a openclaw -y\n```\n",
+      "# NanoClaw Example\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n",
     skillMd:
-      "---\nname: nanoclaw-example\nversion: 1.0.0\n---\n\n## Vercel Skills Installation\n\n```bash\nnpx skills add prompt-security/clawsec --skill nanoclaw-example -a openclaw -y\n```\n",
+      "---\nname: nanoclaw-example\nversion: 1.0.0\n---\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n",
+    installMd: "# Native installation\n",
   });
 
-  const validNano = runValidator(["--skills", "skills/nanoclaw-example"]);
+  const nativeNano = runValidator(["--skills", "skills/nanoclaw-example"]);
   assert.equal(
-    validNano.status,
+    nativeNano.status,
     0,
-    `valid NanoClaw install docs should pass\nstdout:\n${validNano.stdout}\nstderr:\n${validNano.stderr}`,
+    `NanoClaw docs without a fabricated direct target should pass\nstdout:\n${nativeNano.stdout}\nstderr:\n${nativeNano.stderr}`,
   );
+  assert.match(nativeNano.stdout, /not applicable[\s\S]*nanoclaw/);
+
+  await writeSkill({
+    name: "nanoclaw-wrapped-command",
+    metadata: { platform: "nanoclaw" },
+    readme:
+      "# Unsupported Wrapped Command\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n\n```bash\nsudo npx skills add prompt-security/clawsec --skill nanoclaw-wrapped-command -a openclaw -y\n```\n",
+    skillMd:
+      "---\nname: nanoclaw-wrapped-command\nversion: 1.0.0\n---\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n\n```bash\nsudo npx skills add prompt-security/clawsec --skill nanoclaw-wrapped-command -a openclaw -y\n```\n",
+    installMd: "# Native installation\n",
+  });
+  const unsupportedWrappedCommand = runValidator(["--skills", "skills/nanoclaw-wrapped-command"]);
+  assert.equal(unsupportedWrappedCommand.status, 1, "unsupported harness docs must reject wrapped commands");
+  assert.match(unsupportedWrappedCommand.stderr, /no wrapper, environment assignment/);
+
+  await writeSkill({
+    name: "native-wrong-harness-statement",
+    metadata: { platform: "nanoclaw" },
+    readme:
+      "# Wrong Harness Statement\n\nPicoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n",
+    skillMd:
+      "---\nname: native-wrong-harness-statement\nversion: 1.0.0\n---\n\nPicoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n",
+    installMd: "# Native installation\n",
+  });
+  const wrongHarnessStatement = runValidator(["--skills", "skills/native-wrong-harness-statement"]);
+  assert.equal(wrongHarnessStatement.status, 1, "a no-target statement must name the unsupported harness");
+  assert.match(wrongHarnessStatement.stderr, /Missing explicit no-direct-target statement[\s\S]*nanoclaw/);
+
+  await writeSkill({
+    name: "mixed-harness-claim",
+    metadata: { platform: "nanoclaw" },
+    readme:
+      "# Mixed Harness Claim\n\nNanoClaw supports a direct target. PicoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n",
+    skillMd:
+      "---\nname: mixed-harness-claim\nversion: 1.0.0\n---\n\nNanoClaw supports a direct target. PicoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n",
+    installMd: "# Native installation\n",
+  });
+  const mixedHarnessClaim = runValidator(["--skills", "skills/mixed-harness-claim"]);
+  assert.equal(mixedHarnessClaim.status, 1, "a nearby statement about another harness must not cross-bind");
+  assert.match(mixedHarnessClaim.stderr, /Missing explicit no-direct-target statement[\s\S]*nanoclaw/);
+
+  await writeSkill({
+    name: "nanoclaw-unpackaged-guide",
+    metadata: { platform: "nanoclaw", sbom: { files: [] } },
+    readme:
+      "# Unpackaged Native Guide\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n",
+    skillMd:
+      "---\nname: nanoclaw-unpackaged-guide\nversion: 1.0.0\n---\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n",
+    installMd: "# Native installation\n",
+  });
+  const unpackagedNativeGuide = runValidator(["--skills", "skills/nanoclaw-unpackaged-guide"]);
+  assert.equal(unpackagedNativeGuide.status, 1, "native install guides must be included in release SBOM files");
+  assert.match(unpackagedNativeGuide.stderr, /omitted from skill\.json sbom\.files[\s\S]*INSTALL\.md/);
+
+  await writeSkill({
+    name: "nanoclaw-filtered-guide",
+    metadata: {
+      platform: "nanoclaw",
+      sbom: {
+        files: [{ path: "tests/INSTALL.md", required: true, description: "Filtered test guide" }],
+      },
+    },
+    readme:
+      "# Filtered Native Guide\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./tests/INSTALL.md).\n",
+    skillMd:
+      "---\nname: nanoclaw-filtered-guide\nversion: 1.0.0\n---\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./tests/INSTALL.md).\n",
+  });
+  const filteredGuideRoot = path.join(tempRoot, "skills", "nanoclaw-filtered-guide", "tests");
+  await mkdir(filteredGuideRoot);
+  await writeFile(path.join(filteredGuideRoot, "INSTALL.md"), "# Filtered native installation\n");
+  const filteredNativeGuide = runValidator(["--skills", "skills/nanoclaw-filtered-guide"]);
+  assert.equal(filteredNativeGuide.status, 1, "release-filtered test paths must not count as packaged guides");
+  assert.match(filteredNativeGuide.stderr, /omitted from skill\.json sbom\.files[\s\S]*tests\/INSTALL\.md/);
+
+  await writeSkill({
+    name: "nanoclaw-comment-example",
+    metadata: { platform: "nanoclaw", nanoclaw: { category: "security" } },
+    readme:
+      "# NanoClaw Comment Example\n\n<!-- NanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md). -->\n",
+    skillMd:
+      "---\nname: nanoclaw-comment-example\nversion: 1.0.0\n---\n\n<!-- NanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md). -->\n",
+    installMd: "# Native installation\n",
+  });
+  const hiddenNanoRequirements = runValidator(["--skills", "skills/nanoclaw-comment-example"]);
+  assert.equal(hiddenNanoRequirements.status, 1, "HTML-comment-only native guidance must not satisfy validation");
+  assert.match(hiddenNanoRequirements.stderr, /Missing explicit no-direct-target statement/);
+  assert.match(hiddenNanoRequirements.stderr, /Missing local harness-native installation reference/);
+
+  await writeSkill({
+    name: "nanoclaw-directory-reference",
+    metadata: { platform: "nanoclaw" },
+    readme:
+      "# NanoClaw Directory Reference\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n",
+    skillMd:
+      "---\nname: nanoclaw-directory-reference\nversion: 1.0.0\n---\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n",
+  });
+  await mkdir(path.join(tempRoot, "skills", "nanoclaw-directory-reference", "INSTALL.md"));
+  const directoryReference = runValidator(["--skills", "skills/nanoclaw-directory-reference"]);
+  assert.equal(directoryReference.status, 1, "a directory must not count as a native install document");
+  assert.match(directoryReference.stderr, /Missing local harness-native installation reference/);
+
+  const outsideInstallPath = path.join(tempRoot, "outside-native-install.md");
+  await writeFile(outsideInstallPath, "# Outside native installation\n");
+  await writeSkill({
+    name: "nanoclaw-symlink-reference",
+    metadata: { platform: "nanoclaw" },
+    readme:
+      "# NanoClaw Symlink Reference\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n",
+    skillMd:
+      "---\nname: nanoclaw-symlink-reference\nversion: 1.0.0\n---\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n",
+  });
+  await symlink(
+    outsideInstallPath,
+    path.join(tempRoot, "skills", "nanoclaw-symlink-reference", "INSTALL.md"),
+  );
+  const symlinkReference = runValidator(["--skills", "skills/nanoclaw-symlink-reference"]);
+  assert.equal(symlinkReference.status, 1, "an escaping symlink must not count as a native install document");
+  assert.match(symlinkReference.stderr, /Missing local harness-native installation reference/);
+
+  await writeSkill({
+    name: "picoclaw-example",
+    metadata: { platform: "picoclaw", picoclaw: { category: "security" } },
+    readme:
+      "# PicoClaw Example\n\n```bash\nnpx skills add prompt-security/clawsec --skill picoclaw-example -a openclaw -y\n```\n",
+    skillMd:
+      "---\nname: picoclaw-example\nversion: 1.0.0\n---\n\n```bash\nnpx skills add prompt-security/clawsec --skill picoclaw-example -a openclaw -y\n```\n",
+  });
+  const wrongPicoTarget = runValidator(["--skills", "skills/picoclaw-example"]);
+  assert.equal(wrongPicoTarget.status, 1, "PicoClaw must not inherit an OpenClaw installer target");
+  assert.match(wrongPicoTarget.stderr, /picoclaw has no reviewed direct AgentType target/);
+
+  await writeSkill({
+    name: "multi-example",
+    metadata: { platforms: ["openclaw", "nanoclaw", "hermes", "picoclaw"] },
+    readme:
+      "# Multi Example\n\nNanoClaw and PicoClaw have no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n\n```bash\nnpx skills add prompt-security/clawsec --skill multi-example -a openclaw -y\n```\n",
+    skillMd:
+      "---\nname: multi-example\nversion: 1.0.0\n---\n\nNanoClaw and PicoClaw have no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n\n```bash\nnpx skills add prompt-security/clawsec --skill multi-example -a openclaw -y\n```\n",
+    installMd: "# Native installation\n",
+  });
+  const missingMultiTarget = runValidator(["--skills", "skills/multi-example"]);
+  assert.equal(missingMultiTarget.status, 1, "multi-platform docs must cover every reviewed direct target");
+  assert.match(missingMultiTarget.stderr, /multi-example -a hermes-agent -y/);
+
+  await writeSkill({
+    name: "multi-no-native-example",
+    metadata: { platforms: ["openclaw", "nanoclaw", "hermes"] },
+    readme:
+      "# Multi No Native Example\n\nNanoClaw has no reviewed direct Agent Skills target.\n\n```bash\nnpx skills add prompt-security/clawsec --skill multi-no-native-example -a openclaw -y\nnpx skills add prompt-security/clawsec --skill multi-no-native-example -a hermes-agent -y\n```\n",
+    skillMd:
+      "---\nname: multi-no-native-example\nversion: 1.0.0\n---\n\nNanoClaw has no reviewed direct Agent Skills target.\n\n```bash\nnpx skills add prompt-security/clawsec --skill multi-no-native-example -a openclaw -y\nnpx skills add prompt-security/clawsec --skill multi-no-native-example -a hermes-agent -y\n```\n",
+  });
+  const mixedMissingNativeReference = runValidator(["--skills", "skills/multi-no-native-example"]);
+  assert.equal(mixedMissingNativeReference.status, 1, "mixed-platform docs must link a native install guide");
+  assert.match(mixedMissingNativeReference.stderr, /Missing local harness-native installation reference/);
+
+  await writeSkill({
+    name: "multi-example",
+    metadata: { platforms: ["openclaw", "nanoclaw", "hermes", "picoclaw"] },
+    readme:
+      "# Multi Example\n\nNanoClaw and PicoClaw have no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n\n```bash\nnpx skills add prompt-security/clawsec --skill multi-example -a openclaw -y\nnpx skills add prompt-security/clawsec --skill multi-example -a hermes-agent -y\n```\n",
+    skillMd:
+      "---\nname: multi-example\nversion: 1.0.0\n---\n\nNanoClaw and PicoClaw have no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n\n```bash\nnpx skills add prompt-security/clawsec --skill multi-example -a openclaw -y\nnpx skills add prompt-security/clawsec --skill multi-example -a hermes-agent -y\n```\n",
+    installMd: "# Native installation\n",
+  });
+  const validMulti = runValidator(["--skills", "skills/multi-example"]);
+  assert.equal(validMulti.status, 0, `valid multi-target docs should pass\n${validMulti.stderr}`);
+  assert.match(validMulti.stdout, /-a hermes-agent, -a openclaw; no direct target for nanoclaw, picoclaw/);
+
+  await writeSkill({
+    name: "missing-platform",
+    metadata: {},
+    readme: "# Missing Platform\n",
+    skillMd: "---\nname: missing-platform\nversion: 1.0.0\n---\n",
+  });
+  const missingPlatform = runValidator(["--skills", "skills/missing-platform"]);
+  assert.equal(missingPlatform.status, 1, "platform metadata is required for installer policy");
+  assert.match(missingPlatform.stderr, /Skill metadata does not declare a platform/);
+
+  await rm(path.join(tempRoot, "skills", "nanoclaw-example", "README.md"));
+  const missingNativeDoc = runValidator(["--skills", "skills/nanoclaw-example"]);
+  assert.equal(missingNativeDoc.status, 1, "not-applicable skills must still ship both documentation files");
+  assert.match(missingNativeDoc.stderr, /Missing required install documentation file/);
+
+  await writeFile(
+    agentTypesPath,
+    "export type AgentType = | 'codex' | 'hermes-agent' | 'nanoclaw' | 'openclaw' | 'universal';\n",
+  );
+  await writeSkill({
+    name: "nanoclaw-example",
+    metadata: { platform: "nanoclaw" },
+    readme:
+      "# NanoClaw Example\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n",
+    skillMd:
+      "---\nname: nanoclaw-example\nversion: 1.0.0\n---\n\nNanoClaw has no reviewed direct Agent Skills target. Use the [native installation guide](./INSTALL.md).\n",
+    installMd: "# Native installation\n",
+  });
+  const unreviewedUpstreamNano = runValidator(["--skills", "skills/nanoclaw-example"]);
+  assert.equal(unreviewedUpstreamNano.status, 0, "an upstream AgentType must not auto-activate an unreviewed harness mapping");
+  assert.match(unreviewedUpstreamNano.stdout, /not applicable[\s\S]*nanoclaw/);
+
+  await writeFile(
+    agentTypesPath,
+    "export type AgentType = | 'codex' | 'future-agent' | 'hermes-agent' | 'openclaw' | 'universal';\n",
+  );
+  await writeSkill({
+    name: "future-example",
+    metadata: { platform: "future-agent" },
+    readme: "# Future Example\n",
+    skillMd: "---\nname: future-example\nversion: 1.0.0\n---\n",
+  });
+  const unreviewedFutureTarget = runValidator(["--skills", "skills/future-example"]);
+  assert.equal(unreviewedFutureTarget.status, 1, "upstream additions must not authorize new platform mappings");
+  assert.match(unreviewedFutureTarget.stderr, /Unknown platform without a reviewed npx skills target: future-agent/);
+
+  await writeFile(
+    agentTypesPath,
+    "export type AgentType = | 'codex' | 'openclaw' | 'universal';\n",
+  );
+  const missingConfiguredHermes = runValidator(["--skills", "skills/hermes-example"]);
+  assert.equal(missingConfiguredHermes.status, 1, "a missing reviewed upstream target must fail closed");
+  assert.match(missingConfiguredHermes.stderr, /Configured npx skills target hermes-agent for hermes is unavailable/);
 
   assert.match(
     workflow,

--- a/scripts/test-skill-installability.mjs
+++ b/scripts/test-skill-installability.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  loadSkillInstallability,
+  requireSkillPublication,
+  resolveSkillInstallability,
+  runSkillInstallabilityCli,
+} from "./ci/skill_installability.mjs";
+
+const scriptPath = path.resolve("scripts/ci/skill_installability.mjs");
+const fixtureRoot = await mkdtemp(path.join(tmpdir(), "clawsec-installability-"));
+
+async function writeSkill(name, metadataSource) {
+  const skillDir = path.join(fixtureRoot, name);
+  await mkdir(skillDir, { recursive: true });
+  const source = typeof metadataSource === "string"
+    ? metadataSource
+    : `${JSON.stringify(metadataSource, null, 2)}\n`;
+  await writeFile(path.join(skillDir, "skill.json"), source);
+  return skillDir;
+}
+
+function runCli(skillDir, ...options) {
+  return spawnSync(process.execPath, [scriptPath, skillDir, ...options], {
+    encoding: "utf8",
+  });
+}
+
+try {
+  assert.deepEqual(resolveSkillInstallability({ name: "absent" }), {
+    installable: true,
+    explicitlyDeclared: false,
+  });
+  assert.deepEqual(resolveSkillInstallability({ name: "enabled", installable: true }), {
+    installable: true,
+    explicitlyDeclared: true,
+  });
+  assert.deepEqual(resolveSkillInstallability({ name: "disabled", installable: false }), {
+    installable: false,
+    explicitlyDeclared: true,
+  });
+  assert.throws(
+    () => resolveSkillInstallability({ installable: "false" }, "fixture/skill.json"),
+    /Invalid skill metadata in fixture\/skill\.json: "installable" must be a boolean when present/,
+  );
+  assert.throws(
+    () => resolveSkillInstallability([], "fixture/skill.json"),
+    /Invalid skill metadata in fixture\/skill\.json: expected a JSON object/,
+  );
+  assert.throws(
+    () => requireSkillPublication({ installable: false }, "fixture/skill.json"),
+    /Publication denied for fixture\/skill\.json: skill\.json declares "installable": false/,
+  );
+
+  const absentDir = await writeSkill("absent", { name: "absent", version: "0.0.1" });
+  const trueDir = await writeSkill("true", {
+    name: "true",
+    version: "0.0.1",
+    installable: true,
+  });
+  const falseDir = await writeSkill("false", {
+    name: "false",
+    version: "0.0.1",
+    installable: false,
+  });
+  const invalidTypeDir = await writeSkill("invalid-type", {
+    name: "invalid-type",
+    version: "0.0.1",
+    installable: "false",
+  });
+  const badJsonDir = await writeSkill("bad-json", "{ not-json\n");
+  const missingDir = path.join(fixtureRoot, "missing");
+
+  const absentResolution = await loadSkillInstallability(absentDir);
+  assert.equal(absentResolution.installable, true);
+  assert.equal(absentResolution.explicitlyDeclared, false);
+  assert.equal(absentResolution.skillJsonPath, path.join(absentDir, "skill.json"));
+
+  const importedCliResult = await runSkillInstallabilityCli([falseDir]);
+  assert.equal(importedCliResult.output, "false\n");
+  assert.equal(importedCliResult.resolution.installable, false);
+
+  for (const skillDir of [absentDir, trueDir]) {
+    const resolveResult = runCli(skillDir);
+    assert.equal(resolveResult.status, 0, resolveResult.stderr);
+    assert.equal(resolveResult.stdout, "true\n");
+    assert.equal(resolveResult.stderr, "");
+
+    const publicationResult = runCli(skillDir, "--require-publication");
+    assert.equal(publicationResult.status, 0, publicationResult.stderr);
+    assert.equal(publicationResult.stdout, "true\n");
+    assert.equal(publicationResult.stderr, "");
+  }
+
+  const falseResolveResult = runCli(falseDir);
+  assert.equal(falseResolveResult.status, 0, falseResolveResult.stderr);
+  assert.equal(falseResolveResult.stdout, "false\n");
+  assert.equal(falseResolveResult.stderr, "");
+
+  const falsePublicationResult = runCli(falseDir, "--require-publication");
+  assert.equal(falsePublicationResult.status, 1);
+  assert.equal(falsePublicationResult.stdout, "");
+  assert.equal(
+    falsePublicationResult.stderr,
+    `Publication denied for ${path.join(falseDir, "skill.json")}: skill.json declares "installable": false\n`,
+  );
+
+  const invalidTypeResult = runCli(invalidTypeDir);
+  assert.equal(invalidTypeResult.status, 1);
+  assert.equal(invalidTypeResult.stdout, "");
+  assert.equal(
+    invalidTypeResult.stderr,
+    `Invalid skill metadata in ${path.join(invalidTypeDir, "skill.json")}: "installable" must be a boolean when present\n`,
+  );
+
+  const badJsonResult = runCli(badJsonDir);
+  assert.equal(badJsonResult.status, 1);
+  assert.equal(badJsonResult.stdout, "");
+  assert.equal(
+    badJsonResult.stderr,
+    `Invalid JSON in skill metadata: ${path.join(badJsonDir, "skill.json")}\n`,
+  );
+
+  const missingResult = runCli(missingDir);
+  assert.equal(missingResult.status, 1);
+  assert.equal(missingResult.stdout, "");
+  assert.equal(
+    missingResult.stderr,
+    `Skill metadata not found: ${path.join(missingDir, "skill.json")}\n`,
+  );
+
+  const unknownOptionResult = spawnSync(
+    process.execPath,
+    [scriptPath, absentDir, "--unknown"],
+    { encoding: "utf8" },
+  );
+  assert.equal(unknownOptionResult.status, 1);
+  assert.match(unknownOptionResult.stderr, /^Unknown option: --unknown\nUsage:/);
+
+  const helpResult = spawnSync(process.execPath, [scriptPath, "--help"], { encoding: "utf8" });
+  assert.equal(helpResult.status, 0, helpResult.stderr);
+  assert.match(helpResult.stdout, /^Usage:/);
+
+  process.stdout.write("Skill installability contract tests passed.\n");
+} finally {
+  await rm(fixtureRoot, { recursive: true, force: true });
+}

--- a/scripts/test-skill-release-bundle-verifier.mjs
+++ b/scripts/test-skill-release-bundle-verifier.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const python = process.env.PYTHON_BIN || 'python3';
+const openssl = process.env.OPENSSL_BIN || 'openssl';
+const testPath = fileURLToPath(new URL('./ci/test_verify_skill_release_bundle.py', import.meta.url));
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    ...options,
+  });
+
+  assert.ifError(result.error);
+  return result;
+}
+
+const pythonVersion = run(python, ['--version']);
+assert.equal(
+  pythonVersion.status,
+  0,
+  `Python is required for release-bundle verifier tests:\n${pythonVersion.stderr}`,
+);
+
+const opensslVersion = run(openssl, ['version']);
+assert.equal(
+  opensslVersion.status,
+  0,
+  `OpenSSL 3 is required for release-bundle verifier tests:\n${opensslVersion.stderr}`,
+);
+assert.match(
+  opensslVersion.stdout.trim(),
+  /^OpenSSL 3(?:\.|\s)/,
+  `OpenSSL 3 is required for release-bundle verifier tests; got: ${opensslVersion.stdout.trim()}`,
+);
+
+const tests = run(python, [testPath], {
+  env: {
+    ...process.env,
+    OPENSSL_BIN: openssl,
+    PYTHONPYCACHEPREFIX: process.env.PYTHONPYCACHEPREFIX || '/tmp/clawsec-python-cache',
+  },
+  stdio: 'inherit',
+});
+
+assert.equal(tests.status, 0, 'Release-bundle verifier regression tests failed');

--- a/scripts/test-skill-release-script-installability.mjs
+++ b/scripts/test-skill-release-script-installability.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmod,
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const fixtureRoot = await mkdtemp(path.join(tmpdir(), "clawsec-release-script-installability-"));
+const skillDir = path.join(fixtureRoot, "skills", "retired-skill");
+const scriptsDir = path.join(fixtureRoot, "scripts");
+const ciDir = path.join(scriptsDir, "ci");
+const fakeBinDir = path.join(fixtureRoot, "fake-bin");
+const ghAttemptPath = path.join(fixtureRoot, "gh-attempted");
+const childPath = `${fakeBinDir}:${path.dirname(process.execPath)}:${process.env.PATH ?? ""}`;
+
+function run(command, args) {
+  return spawnSync(command, args, {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    env: { ...process.env, PATH: childPath },
+  });
+}
+
+function runGit(...args) {
+  const result = run("git", args);
+  assert.equal(
+    result.status,
+    0,
+    `git ${args.join(" ")} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  return result.stdout.trim();
+}
+
+try {
+  await Promise.all([
+    mkdir(skillDir, { recursive: true }),
+    mkdir(ciDir, { recursive: true }),
+    mkdir(fakeBinDir, { recursive: true }),
+  ]);
+  await Promise.all([
+    cp("scripts/release-skill.sh", path.join(scriptsDir, "release-skill.sh")),
+    cp("scripts/ci/skill_installability.mjs", path.join(ciDir, "skill_installability.mjs")),
+    writeFile(
+      path.join(skillDir, "skill.json"),
+      `${JSON.stringify({
+        name: "retired-skill",
+        version: "0.0.1",
+        installable: false,
+      }, null, 2)}\n`,
+    ),
+    writeFile(
+      path.join(skillDir, "CHANGELOG.md"),
+      "# Changelog\n\n## [0.0.2] - 2026-07-22\n\n- Test release.\n",
+    ),
+    writeFile(
+      path.join(fakeBinDir, "gh"),
+      `#!/bin/sh\nprintf attempted > "${ghAttemptPath}"\nexit 0\n`,
+    ),
+  ]);
+  await chmod(path.join(fakeBinDir, "gh"), 0o700);
+
+  runGit("init", "--initial-branch=main");
+  runGit("config", "user.name", "ClawSec Test");
+  runGit("config", "user.email", "clawsec-test@example.invalid");
+  runGit("config", "commit.gpgsign", "false");
+  runGit("config", "tag.gpgsign", "false");
+  runGit("add", ".");
+  runGit("commit", "-m", "test fixture");
+
+  const mainHead = runGit("rev-parse", "HEAD");
+  const fullRelease = run("bash", ["scripts/release-skill.sh", "retired-skill", "0.0.2"]);
+  assert.equal(fullRelease.status, 1, "main-branch release of a non-installable skill must fail");
+  assert.match(fullRelease.stderr, /Publication denied .*"installable": false/);
+  assert.equal(runGit("rev-parse", "HEAD"), mainHead, "denial must happen before commit creation");
+  assert.equal(runGit("status", "--short"), "", "denial must happen before file mutation or staging");
+  assert.equal(runGit("tag", "--list"), "", "denial must happen before tag creation");
+  assert.equal(existsSync(ghAttemptPath), false, "denial must happen before GitHub release creation");
+
+  runGit("switch", "-c", "review/non-installable");
+  const prepOnly = run("bash", ["scripts/release-skill.sh", "retired-skill", "0.0.2"]);
+  assert.equal(
+    prepOnly.status,
+    0,
+    `review-only version preparation failed\nstdout:\n${prepOnly.stdout}\nstderr:\n${prepOnly.stderr}`,
+  );
+  assert.match(prepOnly.stdout, /signed denial evidence/);
+  assert.match(
+    prepOnly.stdout,
+    /Do not create or push a public tag, GitHub Release, or skill-store publication/,
+  );
+  assert.equal(runGit("tag", "--list"), "", "review-only preparation must not create a tag");
+  assert.equal(existsSync(ghAttemptPath), false, "review-only preparation must not create a release");
+  assert.equal(runGit("status", "--short"), "", "review-only preparation must leave a clean commit");
+  const preparedSkill = JSON.parse(await readFile(path.join(skillDir, "skill.json"), "utf8"));
+  assert.equal(preparedSkill.version, "0.0.2");
+
+  process.stdout.write("Skill release script installability tests passed.\n");
+} finally {
+  await rm(fixtureRoot, { recursive: true, force: true });
+}

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -285,7 +285,13 @@ assert.match(
   'Skill release workflow must generate skill cards, permission summaries, and npx install instructions',
 );
 
-for (const artifact of ['skill-card.md', 'permissions.json', 'install.md', 'skillspector-report.md']) {
+for (const artifact of [
+  'skill-card.md',
+  'permissions.json',
+  'install.md',
+  'verify_skill_release_bundle.py',
+  'skillspector-report.md',
+]) {
   assert.match(
     workflow,
     new RegExp(`release-assets/${artifact.replace('.', '\\.')}`),
@@ -295,7 +301,13 @@ for (const artifact of ['skill-card.md', 'permissions.json', 'install.md', 'skil
 
 const escapeRegExp = (literal) => literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-for (const artifact of ['skill-card.md', 'permissions.json', 'install.md', 'skillspector-report.md']) {
+for (const artifact of [
+  'skill-card.md',
+  'permissions.json',
+  'install.md',
+  'verify_skill_release_bundle.py',
+  'skillspector-report.md',
+]) {
   assert.match(
     workflow,
     new RegExp(
@@ -344,7 +356,13 @@ assert.match(
 assert.match(
   workflow,
   /add_release_asset_checksum "install\.md"/,
-  'npx install/update instructions must be included in the signed checksums manifest',
+  'verify-first install instructions must be included in the signed checksums manifest',
+);
+
+assert.match(
+  workflow,
+  /add_release_asset_checksum "verify_skill_release_bundle\.py"/,
+  'the bounded release verifier must be included in the signed checksums manifest',
 );
 
 assert.match(

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -23,6 +23,12 @@ const patchClawhubTrustExtensions = await readFile(patchClawhubTrustExtensionsPa
 const guardClawhubSlugOwner = await readFile(guardClawhubSlugOwnerPath, 'utf8');
 const releaseSkillScript = await readFile(releaseSkillScriptPath, 'utf8');
 
+function requiredIndex(text, needle, message) {
+  const index = text.indexOf(needle);
+  assert.notEqual(index, -1, message);
+  return index;
+}
+
 const preservedHelperBlock = workflow.match(
   /- name: Prepare current ClawHub workflow helpers\s+run: \|\n(?<body>[\s\S]*?)\n\s+- name: Checkout tag/,
 )?.groups?.body;
@@ -31,6 +37,10 @@ const preservedHelperCopies = [...preservedHelperBlock.matchAll(
   /cp (scripts\/ci\/[^\s]+\.mjs) "\$RUNNER_TEMP\/([^"/]+\.mjs)"/g,
 )].map((match) => ({ source: match[1], destination: match[2] }));
 const preservedHelperDestinations = new Set(preservedHelperCopies.map(({ destination }) => destination));
+assert.ok(
+  preservedHelperDestinations.has('skill_installability.mjs'),
+  'Manual ClawHub republish must preserve the current installability policy before checking out an older tag',
+);
 
 for (const { source, destination } of preservedHelperCopies) {
   const sourceText = await readFile(new URL(`../${source}`, import.meta.url), 'utf8');
@@ -456,6 +466,57 @@ assert.match(
   'Skill release workflow must call the tag release simulation script',
 );
 
+const simulationJob = workflow.slice(
+  requiredIndex(workflow, '  simulate-tag-release-build:', 'PR tag simulation job must exist'),
+  requiredIndex(workflow, '  release-tag:', 'Tag release job must exist'),
+);
+const simulationRunIndex = requiredIndex(
+  simulationJob,
+  'node scripts/ci/simulate_skill_tag_release.mjs',
+  'PR validation must build signed simulation evidence',
+);
+const simulationInstallabilityIndex = requiredIndex(
+  simulationJob,
+  "installable=\"$(jq -r '.installable'",
+  'PR simulation must read the resolved installability decision from its signed-build summary',
+);
+const simulationSkipIndex = requiredIndex(
+  simulationJob,
+  'Non-installable package: signed denial evidence generated; skipping ClawHub package preparation.',
+  'PR simulation must skip ClawHub staging for non-installable packages',
+);
+const simulationClawhubIndex = requiredIndex(
+  simulationJob,
+  'clawhub_release_package.mjs prepare',
+  'PR simulation must retain ClawHub staging for installable packages',
+);
+assert.ok(
+  simulationRunIndex < simulationInstallabilityIndex
+    && simulationInstallabilityIndex < simulationSkipIndex
+    && simulationSkipIndex < simulationClawhubIndex,
+  'PR simulation must first build denial evidence, then branch before ClawHub package preparation',
+);
+assert.match(
+  simulationJob,
+  /if \[ "\$installable" = "false" \]; then[\s\S]*continue[\s\S]*test "\$installable" = "true"/,
+  'PR simulation must fail closed on invalid summary values and continue past ClawHub staging only for false',
+);
+assert.match(
+  simulationJob,
+  /jq -e '\(\.installable \| type\) == "boolean"' "\$summary_path"/,
+  'PR simulation must reject a missing or non-boolean installability decision',
+);
+assert.match(
+  simulationJob,
+  /jq -e --argjson expected_installable "\$installable"[\s\S]*'\.installable == \$expected_installable'[\s\S]*"\$release_dir\/permissions\.json"/,
+  'PR simulation must cross-check its summary decision against the signed denial permissions',
+);
+assert.match(
+  simulationJob,
+  /if \[ "\$installable" = "false" \]; then[\s\S]*test ! -e "\$clawhub_output"[\s\S]*continue/,
+  'PR simulation must prove it did not prepare a ClawHub package for non-installable evidence',
+);
+
 assert.ok(
   workflow.includes('simulated_version | test("^[0-9]+\\\\.[0-9]+\\\\.[0-9]+(-[a-zA-Z0-9]+)?$")'),
   'Skill release workflow must accept every prerelease version format that release-skill.sh accepts',
@@ -471,10 +532,110 @@ assert.ok(
   'release-skill.sh must update hardcoded release verification VERSION assignments when bumping a skill',
 );
 
+const releaseScriptInstallabilityIndex = requiredIndex(
+  releaseSkillScript,
+  'node scripts/ci/skill_installability.mjs "$SKILL_PATH" --require-publication',
+  'release-skill.sh must enforce publication eligibility in full-release mode',
+);
+for (const [needle, description] of [
+  ['jq --arg v "$VERSION"', 'version mutation'],
+  ['git add "$file"', 'staging'],
+  ['git commit -m', 'commit creation'],
+  ['git tag -a "$TAG"', 'tag creation'],
+  ['gh release create "$TAG"', 'GitHub release creation'],
+]) {
+  assert.ok(
+    releaseScriptInstallabilityIndex
+      < requiredIndex(releaseSkillScript, needle, `release-skill.sh must contain ${description}`),
+    `release-skill.sh must reject a non-installable full release before ${description}`,
+  );
+}
+assert.match(
+  releaseSkillScript,
+  /if \[\[ "\$IS_RELEASE_BRANCH" == "true" \|\| "\$FORCE_TAG" == "true" \]\]; then[\s\S]*skill_installability\.mjs "\$SKILL_PATH" --require-publication[\s\S]*else[\s\S]*skill_installability\.mjs "\$SKILL_PATH"/,
+  'release-skill.sh must validate all modes while requiring publication eligibility only for tag-capable mode',
+);
+assert.match(
+  releaseSkillScript,
+  /if \[\[ "\$INSTALLABLE" == "false" \]\]; then[\s\S]*signed denial evidence[\s\S]*Do not create or push a public tag, GitHub Release, or skill-store publication/,
+  'Non-installable prep mode must not print follow-up instructions that authorize publication',
+);
+
 assert.match(
   workflow,
   /clawhub_slug: \$\{\{ steps\.publishable\.outputs\.clawhub_slug \}\}/,
   'Skill release workflow must expose the resolved ClawHub slug from release-tag outputs',
+);
+
+assert.match(
+  workflow,
+  /installable: \$\{\{ steps\.installability\.outputs\.installable \}\}/,
+  'Tag releases must expose the shared installability decision as a job output',
+);
+
+assert.equal(
+  workflow.match(/skill_installability\.mjs"? "\$SKILL_PATH" --require-publication/g)?.length,
+  2,
+  'Only public tag release and manual republish entrypoints may require publication eligibility',
+);
+
+const releaseTagJob = workflow.slice(
+  requiredIndex(workflow, '  release-tag:', 'Tag release job must exist'),
+  requiredIndex(workflow, '  publish-clawhub:', 'Automatic ClawHub job must exist'),
+);
+const tagGateIndex = requiredIndex(
+  releaseTagJob,
+  '- name: Reject non-installable public release',
+  'Tag release must reject non-installable packages',
+);
+for (const [needle, description] of [
+  ['- name: Install SkillSpector', 'SkillSpector installation'],
+  ['- name: Sign embedded advisory feed and verify', 'embedded advisory signing'],
+  ['- name: Build quick install instructions', 'install-command generation'],
+  ['- name: Create GitHub Release', 'GitHub release creation'],
+]) {
+  assert.ok(
+    tagGateIndex < requiredIndex(releaseTagJob, needle, `Tag release must contain ${description}`),
+    `Tag release installability denial must happen before ${description}`,
+  );
+}
+assert.match(
+  releaseTagJob,
+  /node scripts\/ci\/skill_installability\.mjs "\$SKILL_PATH" --require-publication/,
+  'Tag release must enforce the shared installability contract',
+);
+
+const republishJob = workflow.slice(
+  requiredIndex(workflow, '  republish-clawhub:', 'Manual ClawHub republish job must exist'),
+);
+const republishCheckoutIndex = requiredIndex(
+  republishJob,
+  '- name: Checkout tag',
+  'Manual republish must inspect the selected immutable tag',
+);
+const republishGateIndex = requiredIndex(
+  republishJob,
+  '- name: Reject non-installable public republish',
+  'Manual republish must reject non-installable packages',
+);
+assert.ok(
+  republishCheckoutIndex < republishGateIndex,
+  'Manual republish must evaluate installability from the selected tag metadata',
+);
+for (const [needle, description] of [
+  ['- name: Prepare verified ClawHub release package', 'release asset download and package preparation'],
+  ['- name: Login to ClawHub', 'ClawHub authentication'],
+  ['- name: Publish to ClawHub', 'ClawHub publication'],
+]) {
+  assert.ok(
+    republishGateIndex < requiredIndex(republishJob, needle, `Manual republish must contain ${description}`),
+    `Manual republish installability denial must happen before ${description}`,
+  );
+}
+assert.match(
+  republishJob,
+  /node "\$RUNNER_TEMP\/skill_installability\.mjs" "\$SKILL_PATH" --require-publication/,
+  'Manual republish must enforce the preserved current installability contract against selected tag metadata',
 );
 
 assert.match(

--- a/scripts/test-skill-tag-release-simulation.mjs
+++ b/scripts/test-skill-tag-release-simulation.mjs
@@ -47,6 +47,7 @@ async function runSimulation({
   outputDir,
   expectedOriginal,
   expectedSimulated,
+  expectedInstallable = true,
   expectedAgents = [],
   verifyReleaseBundle = false,
   verifyEmbeddedAdvisory = false,
@@ -81,6 +82,7 @@ async function runSimulation({
   assert.equal(summary.skill, skillName);
   assert.equal(summary.original_version, expectedOriginal);
   assert.equal(summary.simulated_version, expectedSimulated);
+  assert.equal(summary.installable, expectedInstallable);
   assert.equal(summary.tag, expectedTag);
 
   const releaseAssetsDir = path.join(outputDir, "release-assets");
@@ -192,7 +194,7 @@ async function runSimulation({
     assert.equal(verifiedSkill.version, expectedSimulated);
   }
 
-  if (!verifyEmbeddedAdvisory) {
+  if (expectedInstallable && !verifyEmbeddedAdvisory) {
     const clawhubOutputDir = path.join(outputDir, "clawhub-package");
     const prepareOptions = {
       releaseDir: releaseAssetsDir,
@@ -252,7 +254,7 @@ async function runSimulation({
     }
   }
 
-  if (verifyEmbeddedAdvisory) {
+  if (expectedInstallable && verifyEmbeddedAdvisory) {
     const readArchiveEntry = (entry) => {
       const extracted = spawnSync("unzip", ["-p", archivePath, entry], {
         maxBuffer: 64 * 1024 * 1024,
@@ -408,6 +410,51 @@ async function runSimulation({
   }
 
   const install = await readFile(path.join(releaseAssetsDir, "install.md"), "utf8");
+  const permissions = JSON.parse(
+    await readFile(path.join(releaseAssetsDir, "permissions.json"), "utf8"),
+  );
+  assert.equal(permissions.installable, expectedInstallable);
+
+  if (!expectedInstallable) {
+    const card = await readFile(path.join(releaseAssetsDir, "skill-card.md"), "utf8");
+    assert.match(install, /^# Installation Unavailable for /m);
+    assert.match(install, /declares `installable: false`/);
+    assert.match(install, /no supported installation or activation path/);
+    assert.doesNotMatch(install, /```|\bcurl\b|\bpython3\b|\bnpx\b|--agent|\bunzip\b/);
+    assert.equal(permissions.platform, "not-applicable");
+    assert.deepEqual(permissions.required_binaries, []);
+    assert.deepEqual(permissions.optional_binaries, []);
+    assert.deepEqual(permissions.required_env, []);
+    assert.deepEqual(permissions.optional_env, []);
+    assert.deepEqual(permissions.capabilities, []);
+    assert.match(permissions.network_egress, /Not applicable: package is non-installable/);
+    assert.match(card, /declares `installable: false`/);
+    assert.match(card, /no supported execution or activation path/);
+    assert.doesNotMatch(card, /provides this capability|Use this skill for/);
+    assert.equal(
+      existsSync(path.join(outputDir, "clawhub-package")),
+      false,
+      "non-installable simulation must not prepare a ClawHub package",
+    );
+    const rejectedClawhubOutputDir = path.join(outputDir, "rejected-clawhub-package");
+    await assert.rejects(
+      prepareReleasePackage({
+        releaseDir: releaseAssetsDir,
+        outputDir: rejectedClawhubOutputDir,
+        skillName,
+        version: expectedSimulated,
+        canonicalKeyPath: path.join(releaseAssetsDir, "signing-public.pem"),
+      }),
+      /Publication denied .*skill\.json declares "installable": false/,
+    );
+    assert.deepEqual(
+      await readdir(rejectedClawhubOutputDir),
+      [],
+      "rejected non-installable release staging must leave no publishable package",
+    );
+    return;
+  }
+
   assert.match(install, /## Secure Path: Verify the Canonical Release Before Installation/);
   assert.match(install, new RegExp(`TAG="${expectedTag}"`));
   assert.match(install, new RegExp(`ARCHIVE="${expectedTag}\\.zip"`));
@@ -525,6 +572,27 @@ process.stdout.write(readFileSync(inspectFile, "utf8"));
     expectedOriginal: "0.0.11",
     expectedSimulated: "0.0.12",
     expectedAgents: ["openclaw"],
+  });
+
+  const nonInstallableSkillDir = await prereleaseFixture(
+    "skills/picoclaw-security-guardian",
+    "0.0.7",
+    "non-installable-fixture",
+  );
+  const nonInstallableSkillJsonPath = path.join(nonInstallableSkillDir, "skill.json");
+  const nonInstallableSkill = JSON.parse(await readFile(nonInstallableSkillJsonPath, "utf8"));
+  nonInstallableSkill.installable = false;
+  await writeFile(
+    nonInstallableSkillJsonPath,
+    `${JSON.stringify(nonInstallableSkill, null, 2)}\n`,
+  );
+  await runSimulation({
+    skillDir: nonInstallableSkillDir,
+    outputDir: path.join(tempRoot, "non-installable"),
+    expectedOriginal: "0.0.7",
+    expectedSimulated: "0.0.8",
+    expectedInstallable: false,
+    verifyReleaseBundle: true,
   });
 
   await runSimulation({

--- a/scripts/test-skill-tag-release-simulation.mjs
+++ b/scripts/test-skill-tag-release-simulation.mjs
@@ -47,7 +47,8 @@ async function runSimulation({
   outputDir,
   expectedOriginal,
   expectedSimulated,
-  expectedAgent,
+  expectedAgents = [],
+  verifyReleaseBundle = false,
   verifyEmbeddedAdvisory = false,
   expectedPreparationError = null,
   expectedExcludedPaths = [],
@@ -93,6 +94,7 @@ async function runSimulation({
     "skill-card.md",
     "permissions.json",
     "install.md",
+    "verify_skill_release_bundle.py",
     "skillspector-report.md",
     "checksums.sig",
     "signing-public.pem",
@@ -105,7 +107,15 @@ async function runSimulation({
     assert.ok(file.length > 0, `${artifact} should not be empty`);
   }
 
-  for (const artifact of ["skill.json", "SKILL.md", "skillspector-report.md"]) {
+  for (const artifact of [
+    "skill.json",
+    "SKILL.md",
+    "skill-card.md",
+    "permissions.json",
+    "install.md",
+    "verify_skill_release_bundle.py",
+    "skillspector-report.md",
+  ]) {
     const file = await readFile(path.join(releaseAssetsDir, artifact));
     assert.equal(
       checksums.files[artifact]?.sha256,
@@ -135,6 +145,51 @@ async function runSimulation({
       false,
       `simulated release archive must exclude test-only path: ${excludedPath}`,
     );
+  }
+
+  if (verifyReleaseBundle) {
+    const publicKeyPath = path.join(releaseAssetsDir, "signing-public.pem");
+    const publicKeyDer = spawnSync(
+      "openssl",
+      ["pkey", "-pubin", "-in", publicKeyPath, "-outform", "DER"],
+    );
+    assert.equal(
+      publicKeyDer.status,
+      0,
+      `failed to encode simulated release key: ${publicKeyDer.stderr?.toString() || ""}`,
+    );
+    const verifiedOutputDir = path.join(outputDir, "verified-release");
+    const verifier = spawnSync(
+      "python3",
+      [
+        path.join(releaseAssetsDir, "verify_skill_release_bundle.py"),
+        "--release-dir",
+        releaseAssetsDir,
+        "--output-dir",
+        verifiedOutputDir,
+        "--skill",
+        skillName,
+        "--version",
+        expectedSimulated,
+        "--tag",
+        expectedTag,
+        "--spki-sha256",
+        sha256(publicKeyDer.stdout),
+        "--openssl",
+        "openssl",
+      ],
+      { encoding: "utf8" },
+    );
+    assert.equal(
+      verifier.status,
+      0,
+      `shipped verifier rejected a signed simulated bundle\nstdout:\n${verifier.stdout}\nstderr:\n${verifier.stderr}`,
+    );
+    const verifiedSkill = JSON.parse(
+      await readFile(path.join(verifiedOutputDir, skillName, "skill.json"), "utf8"),
+    );
+    assert.equal(verifiedSkill.name, skillName);
+    assert.equal(verifiedSkill.version, expectedSimulated);
   }
 
   if (!verifyEmbeddedAdvisory) {
@@ -353,13 +408,37 @@ async function runSimulation({
   }
 
   const install = await readFile(path.join(releaseAssetsDir, "install.md"), "utf8");
-  assert.match(
-    install,
-    new RegExp(
-      `npx skills add prompt-security/clawsec#pull-request-head --skill ${skillName} --agent ${expectedAgent} --global --yes`,
-    ),
-  );
-  assert.match(install, new RegExp(`npx skills update ${skillName}`));
+  assert.match(install, /## Secure Path: Verify the Canonical Release Before Installation/);
+  assert.match(install, new RegExp(`TAG="${expectedTag}"`));
+  assert.match(install, new RegExp(`ARCHIVE="${expectedTag}\\.zip"`));
+  assert.match(install, /EXPECTED_KEY_SHA256="711424e4535f84093fefb024cd1ca4ec87439e53907b305b79a631d5befba9c8"/);
+  assert.match(install, /installed tree is not byte-bound|## Harness-Native Integration/);
+  assert.doesNotMatch(install, /npx skills (?:update|list)/);
+
+  const keyCheckIndex = install.indexOf('test "$EXPECTED_KEY_SHA256" = "$ACTUAL_KEY_SHA256"');
+  const signatureCheckIndex = install.indexOf("openssl pkeyutl -verify");
+  const verifierHashIndex = install.indexOf('test "$EXPECTED_VERIFIER_SHA" = "$ACTUAL_VERIFIER_SHA"');
+  const verifierExecutionIndex = install.indexOf("python3 verify_skill_release_bundle.py");
+  assert.ok(keyCheckIndex > 0 && keyCheckIndex < signatureCheckIndex);
+  assert.ok(signatureCheckIndex < verifierHashIndex);
+  assert.ok(verifierHashIndex < verifierExecutionIndex);
+  assert.doesNotMatch(install, /\bunzip\b/);
+
+  if (expectedAgents.length === 0) {
+    assert.match(install, /## Harness-Native Integration/);
+    assert.match(install, /no reviewed direct Vercel Agent Skills target/);
+    assert.doesNotMatch(install, /npx skills (?:add|update|list)/);
+  } else {
+    for (const expectedAgent of expectedAgents) {
+      assert.match(
+        install,
+        new RegExp(
+          `npx skills add prompt-security/clawsec#pull-request-head --skill ${skillName} --agent ${expectedAgent} --yes`,
+        ),
+      );
+    }
+    assert.ok(verifierExecutionIndex < install.indexOf("npx skills add"));
+  }
 }
 
 try {
@@ -435,7 +514,8 @@ process.stdout.write(readFileSync(inspectFile, "utf8"));
     outputDir: path.join(tempRoot, "stable"),
     expectedOriginal: "0.1.16",
     expectedSimulated: "0.1.17",
-    expectedAgent: "openclaw",
+    expectedAgents: ["openclaw"],
+    verifyReleaseBundle: true,
     verifyEmbeddedAdvisory: true,
   });
 
@@ -444,7 +524,7 @@ process.stdout.write(readFileSync(inspectFile, "utf8"));
     outputDir: path.join(tempRoot, "feed-only"),
     expectedOriginal: "0.0.11",
     expectedSimulated: "0.0.12",
-    expectedAgent: "openclaw",
+    expectedAgents: ["openclaw"],
   });
 
   await runSimulation({
@@ -452,7 +532,7 @@ process.stdout.write(readFileSync(inspectFile, "utf8"));
     outputDir: path.join(tempRoot, "beta"),
     expectedOriginal: "0.0.1-beta5",
     expectedSimulated: "0.0.1-beta6",
-    expectedAgent: "hermes-agent",
+    expectedAgents: ["hermes-agent"],
   });
 
   const alphaSkillDir = await prereleaseFixture("skills/picoclaw-self-pen-testing", "0.0.3-alpha1", "alpha-fixture");
@@ -461,7 +541,6 @@ process.stdout.write(readFileSync(inspectFile, "utf8"));
     outputDir: path.join(tempRoot, "alpha"),
     expectedOriginal: "0.0.3-alpha1",
     expectedSimulated: "0.0.3-alpha2",
-    expectedAgent: "openclaw",
   });
 
   const rcSkillDir = await prereleaseFixture("skills/picoclaw-security-guardian", "0.0.4-rc1", "rc-fixture");
@@ -470,7 +549,6 @@ process.stdout.write(readFileSync(inspectFile, "utf8"));
     outputDir: path.join(tempRoot, "rc"),
     expectedOriginal: "0.0.4-rc1",
     expectedSimulated: "0.0.4-rc2",
-    expectedAgent: "openclaw",
   });
 
   const previewSkillDir = await prereleaseFixture("skills/openclaw-traffic-guardian", "0.0.1-preview", "preview-fixture");
@@ -479,7 +557,7 @@ process.stdout.write(readFileSync(inspectFile, "utf8"));
     outputDir: path.join(tempRoot, "preview"),
     expectedOriginal: "0.0.1-preview",
     expectedSimulated: "0.0.1-preview1",
-    expectedAgent: "openclaw",
+    expectedAgents: ["openclaw"],
   });
 
   const testFilterSkillDir = await prereleaseFixture(
@@ -513,7 +591,6 @@ process.stdout.write(readFileSync(inspectFile, "utf8"));
     outputDir: path.join(tempRoot, "test-filter"),
     expectedOriginal: "0.0.5",
     expectedSimulated: "0.0.6",
-    expectedAgent: "openclaw",
     expectedExcludedPaths: testOnlyPaths,
   });
 
@@ -536,7 +613,6 @@ process.stdout.write(readFileSync(inspectFile, "utf8"));
     outputDir: path.join(tempRoot, "unsupported-client-file"),
     expectedOriginal: "0.0.5",
     expectedSimulated: "0.0.6",
-    expectedAgent: "openclaw",
     expectedPreparationError: /would omit non-placeholder package file: runtime\.bin/,
   });
 } finally {

--- a/scripts/test-skill-trust-packet.mjs
+++ b/scripts/test-skill-trust-packet.mjs
@@ -1,10 +1,18 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
 const outputDir = await mkdtemp(path.join(tmpdir(), "clawsec-trust-packet-"));
+
+async function loadSkillIdentity(skillDir) {
+  const skill = JSON.parse(await readFile(path.join(skillDir, "skill.json"), "utf8"));
+  return {
+    ...skill,
+    tag: `${skill.name}-v${skill.version}`,
+  };
+}
 
 function runTrustPacket(skillDir, targetDir, tag) {
   return spawnSync(
@@ -25,7 +33,20 @@ function runTrustPacket(skillDir, targetDir, tag) {
 }
 
 try {
-  const result = runTrustPacket("skills/clawsec-suite", outputDir, "clawsec-suite-v0.1.16");
+  const suite = await loadSkillIdentity("skills/clawsec-suite");
+  const mismatchedTagDir = path.join(outputDir, "mismatched-tag");
+  const mismatchedTag = runTrustPacket(
+    "skills/clawsec-suite",
+    mismatchedTagDir,
+    "clawsec-suite-v9.9.9",
+  );
+  assert.equal(mismatchedTag.status, 1, "a mismatched release tag must fail closed");
+  assert.match(
+    mismatchedTag.stderr,
+    new RegExp(`Release tag clawsec-suite-v9\\.9\\.9 does not match skill identity ${suite.tag.replaceAll(".", "\\.")}`),
+  );
+
+  const result = runTrustPacket("skills/clawsec-suite", outputDir, suite.tag);
 
   assert.equal(
     result.status,
@@ -42,11 +63,12 @@ try {
   assert.match(skillCard, /## License\/Terms of Use/);
   assert.match(skillCard, /AGPL-3\.0-or-later/);
   assert.match(skillCard, /skillspector-report\.md/);
-  assert.match(skillCard, /clawsec-suite-v0\.1\.16/);
+  assert.ok(skillCard.includes(suite.tag));
 
   assert.equal(permissions.skill, "clawsec-suite");
-  assert.equal(permissions.version, "0.1.16");
+  assert.equal(permissions.version, suite.version);
   assert.equal(permissions.platform, "openclaw");
+  assert.equal(permissions.installable, true);
   assert.deepEqual(
     permissions.required_binaries,
     ["node", "npx", "openclaw", "curl", "jq", "shasum", "openssl", "unzip"],
@@ -58,12 +80,12 @@ try {
   assert.match(releaseVerifier, /safe|archive/i);
 
   assert.match(install, /EXPECTED_KEY_SHA256="711424e4535f84093fefb024cd1ca4ec87439e53907b305b79a631d5befba9c8"/);
-  assert.match(install, /BASE_URL="https:\/\/github\.com\/prompt-security\/clawsec\/releases\/download\/clawsec-suite-v0\.1\.16"/);
-  assert.match(install, /ARCHIVE="clawsec-suite-v0\.1\.16\.zip"/);
+  assert.ok(install.includes(`BASE_URL="https://github.com/prompt-security/clawsec/releases/download/${suite.tag}"`));
+  assert.ok(install.includes(`ARCHIVE="${suite.tag}.zip"`));
   assert.match(install, /python3 verify_skill_release_bundle\.py[\s\S]*--release-dir "\$VERIFY_DIR"[\s\S]*--output-dir "\$VERIFY_DIR\/verified"/);
   assert.match(
     install,
-    /npx skills add prompt-security\/clawsec#clawsec-suite-v0\.1\.16 --skill clawsec-suite --agent openclaw --yes/,
+    new RegExp(`npx skills add prompt-security/clawsec#${suite.tag.replaceAll(".", "\\.")} --skill clawsec-suite --agent openclaw --yes`),
   );
   assert.match(install, /installed tree is not byte-bound to the signed release archive/);
   assert.doesNotMatch(install, /npx skills (?:update|list)/);
@@ -82,10 +104,11 @@ try {
   assert.doesNotMatch(install, /\bunzip\b/, "install instructions must not use raw archive extraction");
 
   const hermesOutputDir = path.join(outputDir, "hermes");
+  const hermes = await loadSkillIdentity("skills/hermes-attestation-guardian");
   const hermesResult = runTrustPacket(
     "skills/hermes-attestation-guardian",
     hermesOutputDir,
-    "hermes-attestation-guardian-v0.1.7",
+    hermes.tag,
   );
   assert.equal(
     hermesResult.status,
@@ -95,16 +118,14 @@ try {
   const hermesInstall = await readFile(path.join(hermesOutputDir, "install.md"), "utf8");
   assert.match(
     hermesInstall,
-    /npx skills add prompt-security\/clawsec#hermes-attestation-guardian-v0\.1\.7 --skill hermes-attestation-guardian --agent hermes-agent --yes/,
+    new RegExp(`npx skills add prompt-security/clawsec#${hermes.tag.replaceAll(".", "\\.")} --skill hermes-attestation-guardian --agent hermes-agent --yes`),
   );
 
-  for (const [skillDir, tag, platform] of [
-    ["skills/clawsec-nanoclaw", "clawsec-nanoclaw-v0.0.10", "nanoclaw"],
-    ["skills/picoclaw-security-guardian", "picoclaw-security-guardian-v0.0.3", "picoclaw"],
-  ]) {
+  for (const [skillDir, platform] of [["skills/picoclaw-security-guardian", "picoclaw"]]) {
     const skillName = path.basename(skillDir);
+    const identity = await loadSkillIdentity(skillDir);
     const nativeOutputDir = path.join(outputDir, skillName);
-    const nativeResult = runTrustPacket(skillDir, nativeOutputDir, tag);
+    const nativeResult = runTrustPacket(skillDir, nativeOutputDir, identity.tag);
     assert.equal(
       nativeResult.status,
       0,
@@ -117,8 +138,67 @@ try {
     assert.doesNotMatch(nativeInstall, /--agent openclaw/);
   }
 
+  const nonInstallableSource = path.join(outputDir, "non-installable-source", "clawsec-nanoclaw");
+  await cp("skills/clawsec-nanoclaw", nonInstallableSource, { recursive: true });
+  const nonInstallableJsonPath = path.join(nonInstallableSource, "skill.json");
+  const nonInstallableSkill = JSON.parse(await readFile(nonInstallableJsonPath, "utf8"));
+  nonInstallableSkill.installable = false;
+  nonInstallableSkill.platform = "retired-unmapped-harness";
+  delete nonInstallableSkill.nanoclaw;
+  await writeFile(nonInstallableJsonPath, `${JSON.stringify(nonInstallableSkill, null, 2)}\n`);
+
+  const nonInstallableOutput = path.join(outputDir, "non-installable-output");
+  const nonInstallableTag = `${nonInstallableSkill.name}-v${nonInstallableSkill.version}`;
+  const nonInstallableResult = runTrustPacket(
+    nonInstallableSource,
+    nonInstallableOutput,
+    nonInstallableTag,
+  );
+  assert.equal(
+    nonInstallableResult.status,
+    0,
+    `non-installable trust packet generation failed\nstdout:\n${nonInstallableResult.stdout}\nstderr:\n${nonInstallableResult.stderr}`,
+  );
+  const nonInstallableDoc = await readFile(path.join(nonInstallableOutput, "install.md"), "utf8");
+  const nonInstallableCard = await readFile(path.join(nonInstallableOutput, "skill-card.md"), "utf8");
+  const nonInstallablePermissions = JSON.parse(
+    await readFile(path.join(nonInstallableOutput, "permissions.json"), "utf8"),
+  );
+  assert.match(nonInstallableDoc, /^# Installation Unavailable for clawsec-nanoclaw/m);
+  assert.match(nonInstallableDoc, /declares `installable: false`/);
+  assert.match(nonInstallableDoc, /no supported installation or activation path/);
+  assert.doesNotMatch(nonInstallableDoc, /```|curl|python3|npx skills|--agent openclaw|\bcopy\b/i);
+  assert.match(nonInstallableCard, /declares `installable: false`/);
+  assert.match(nonInstallableCard, /no supported execution or activation path/);
+  assert.doesNotMatch(nonInstallableCard, /provides this capability|Use this skill for/);
+  assert.equal(nonInstallablePermissions.installable, false);
+  assert.equal(nonInstallablePermissions.platform, "not-applicable");
+  assert.deepEqual(nonInstallablePermissions.required_binaries, []);
+  assert.deepEqual(nonInstallablePermissions.optional_binaries, []);
+  assert.deepEqual(nonInstallablePermissions.required_env, []);
+  assert.deepEqual(nonInstallablePermissions.optional_env, []);
+  assert.deepEqual(nonInstallablePermissions.capabilities, []);
+  assert.match(nonInstallablePermissions.network_egress, /Not applicable: package is non-installable/);
+  assert.match(nonInstallablePermissions.persistence, /Not applicable: package is non-installable/);
+  assert.match(String(nonInstallablePermissions.automatic_execution), /Not applicable: package is non-installable/);
+
+  const invalidInstallableSource = path.join(outputDir, "invalid-installable-source", "clawsec-nanoclaw");
+  await cp("skills/clawsec-nanoclaw", invalidInstallableSource, { recursive: true });
+  const invalidInstallableJsonPath = path.join(invalidInstallableSource, "skill.json");
+  const invalidInstallableSkill = JSON.parse(await readFile(invalidInstallableJsonPath, "utf8"));
+  invalidInstallableSkill.installable = "false";
+  await writeFile(invalidInstallableJsonPath, `${JSON.stringify(invalidInstallableSkill, null, 2)}\n`);
+  const invalidInstallableResult = runTrustPacket(
+    invalidInstallableSource,
+    path.join(outputDir, "invalid-installable-output"),
+    `${invalidInstallableSkill.name}-v${invalidInstallableSkill.version}`,
+  );
+  assert.equal(invalidInstallableResult.status, 1, "non-boolean installable metadata must fail closed");
+  assert.match(invalidInstallableResult.stderr, /"installable" must be a boolean/);
+
   const multiOutputDir = path.join(outputDir, "clawtributor");
-  const multiResult = runTrustPacket("skills/clawtributor", multiOutputDir, "clawtributor-v0.1.4");
+  const clawtributor = await loadSkillIdentity("skills/clawtributor");
+  const multiResult = runTrustPacket("skills/clawtributor", multiOutputDir, clawtributor.tag);
   assert.equal(
     multiResult.status,
     0,

--- a/scripts/test-skill-trust-packet.mjs
+++ b/scripts/test-skill-trust-packet.mjs
@@ -18,7 +18,7 @@ function runTrustPacket(skillDir, targetDir, tag) {
       "--tag",
       tag,
       "--source-ref",
-      "main",
+      tag,
     ],
     { encoding: "utf8" },
   );
@@ -36,6 +36,7 @@ try {
   const skillCard = await readFile(path.join(outputDir, "skill-card.md"), "utf8");
   const permissions = JSON.parse(await readFile(path.join(outputDir, "permissions.json"), "utf8"));
   const install = await readFile(path.join(outputDir, "install.md"), "utf8");
+  const releaseVerifier = await readFile(path.join(outputDir, "verify_skill_release_bundle.py"), "utf8");
 
   assert.match(skillCard, /^# Skill Card/m);
   assert.match(skillCard, /## License\/Terms of Use/);
@@ -54,9 +55,31 @@ try {
   assert.match(permissions.persistence, /OpenClaw advisory hook/);
   assert.ok(Array.isArray(permissions.operator_review));
   assert.ok(permissions.operator_review.length > 0);
+  assert.match(releaseVerifier, /safe|archive/i);
 
-  assert.match(install, /npx skills add prompt-security\/clawsec --skill clawsec-suite --agent openclaw --global --yes/);
-  assert.match(install, /npx skills update clawsec-suite/);
+  assert.match(install, /EXPECTED_KEY_SHA256="711424e4535f84093fefb024cd1ca4ec87439e53907b305b79a631d5befba9c8"/);
+  assert.match(install, /BASE_URL="https:\/\/github\.com\/prompt-security\/clawsec\/releases\/download\/clawsec-suite-v0\.1\.16"/);
+  assert.match(install, /ARCHIVE="clawsec-suite-v0\.1\.16\.zip"/);
+  assert.match(install, /python3 verify_skill_release_bundle\.py[\s\S]*--release-dir "\$VERIFY_DIR"[\s\S]*--output-dir "\$VERIFY_DIR\/verified"/);
+  assert.match(
+    install,
+    /npx skills add prompt-security\/clawsec#clawsec-suite-v0\.1\.16 --skill clawsec-suite --agent openclaw --yes/,
+  );
+  assert.match(install, /installed tree is not byte-bound to the signed release archive/);
+  assert.doesNotMatch(install, /npx skills (?:update|list)/);
+  assert.doesNotMatch(install, /#main\b/);
+
+  const keyCheckIndex = install.indexOf('test "$EXPECTED_KEY_SHA256" = "$ACTUAL_KEY_SHA256"');
+  const signatureCheckIndex = install.indexOf("openssl pkeyutl -verify");
+  const verifierHashIndex = install.indexOf('test "$EXPECTED_VERIFIER_SHA" = "$ACTUAL_VERIFIER_SHA"');
+  const verifierExecutionIndex = install.indexOf("python3 verify_skill_release_bundle.py");
+  const resolverIndex = install.indexOf("npx skills add");
+  assert.ok(keyCheckIndex > 0, "key fingerprint verification must be present");
+  assert.ok(keyCheckIndex < signatureCheckIndex, "key verification must precede signature verification");
+  assert.ok(signatureCheckIndex < verifierHashIndex, "signature verification must precede verifier authentication");
+  assert.ok(verifierHashIndex < verifierExecutionIndex, "the verifier must be authenticated before execution");
+  assert.ok(verifierExecutionIndex < resolverIndex, "bounded verification must precede compatibility resolution");
+  assert.doesNotMatch(install, /\bunzip\b/, "install instructions must not use raw archive extraction");
 
   const hermesOutputDir = path.join(outputDir, "hermes");
   const hermesResult = runTrustPacket(
@@ -72,8 +95,39 @@ try {
   const hermesInstall = await readFile(path.join(hermesOutputDir, "install.md"), "utf8");
   assert.match(
     hermesInstall,
-    /npx skills add prompt-security\/clawsec --skill hermes-attestation-guardian --agent hermes-agent --global --yes/,
+    /npx skills add prompt-security\/clawsec#hermes-attestation-guardian-v0\.1\.7 --skill hermes-attestation-guardian --agent hermes-agent --yes/,
   );
+
+  for (const [skillDir, tag, platform] of [
+    ["skills/clawsec-nanoclaw", "clawsec-nanoclaw-v0.0.10", "nanoclaw"],
+    ["skills/picoclaw-security-guardian", "picoclaw-security-guardian-v0.0.3", "picoclaw"],
+  ]) {
+    const skillName = path.basename(skillDir);
+    const nativeOutputDir = path.join(outputDir, skillName);
+    const nativeResult = runTrustPacket(skillDir, nativeOutputDir, tag);
+    assert.equal(
+      nativeResult.status,
+      0,
+      `${skillName} trust packet generator failed\nstdout:\n${nativeResult.stdout}\nstderr:\n${nativeResult.stderr}`,
+    );
+    const nativeInstall = await readFile(path.join(nativeOutputDir, "install.md"), "utf8");
+    assert.match(nativeInstall, /## Harness-Native Integration/);
+    assert.match(nativeInstall, new RegExp(`${platform} has no reviewed direct Vercel Agent Skills target`));
+    assert.doesNotMatch(nativeInstall, /npx skills (?:add|update|list)/);
+    assert.doesNotMatch(nativeInstall, /--agent openclaw/);
+  }
+
+  const multiOutputDir = path.join(outputDir, "clawtributor");
+  const multiResult = runTrustPacket("skills/clawtributor", multiOutputDir, "clawtributor-v0.1.4");
+  assert.equal(
+    multiResult.status,
+    0,
+    `multi-platform trust packet generator failed\nstdout:\n${multiResult.stdout}\nstderr:\n${multiResult.stderr}`,
+  );
+  const multiInstall = await readFile(path.join(multiOutputDir, "install.md"), "utf8");
+  assert.match(multiInstall, /--agent openclaw --yes/);
+  assert.match(multiInstall, /--agent hermes-agent --yes/);
+  assert.match(multiInstall, /nanoclaw and picoclaw have no reviewed direct Agent Skills target/);
 } finally {
   await rm(outputDir, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary

- replace implicit installer fallback with an explicit reviewed target map: Codex, OpenClaw, and Hermes have direct Vercel Agent Skills targets; NanoClaw and PicoClaw are harness-native only
- generate signed install guidance that verifies the pinned release key, manifest, canonical archive, and bounded verifier before any optional compatibility resolver command
- ship and exercise a safe release-bundle verifier with traversal, collision, link, encryption, resource-limit, identity, digest, signature, and key checks
- define the optional `installable` metadata contract: absence means `true` for legacy compatibility, explicit `false` is denial-only, and any present non-boolean value fails closed
- produce CI test-signed, non-authorizing denial evidence for `installable: false` without install commands or ClawHub package preparation
- reject non-installable packages in the supported full-release helper, tag-release work, manual republish, and final verified-payload ClawHub preparation paths

## Security behavior

For an installable package, this PR keeps the verified archive and install documentation bound to the same exact payload. Optional source resolvers are described as compatibility transports, not as substitutes for ClawSec signature verification.

For `installable: false`, review simulation may emit an ephemeral-key test-signed denial packet, but no production release signature or installation authority is created. Full release mode rejects before local mutation, commit, tag creation, or GitHub CLI use; tag and manual-republish jobs reject before release/store work; the extracted signed payload is checked again before any ClawHub preparation.

This PR defines policy only. It does not mark an existing skill non-installable.

## Scope boundaries

- A manually pushed tag can still become a public ref before tag-triggered CI rejects downstream publication. Full public-ref prevention requires the separately designed controlled tag-creation workflow and repository tag ruleset.
- GitHub release-body install instructions are a separate pipeline surface and are not rewritten here.
- Existing skill documentation is not migrated here; each changed skill remains a focused PR.
- No tag, GitHub Release, store publication, catalog activation, or merge was performed.

## Remote acceptance

The exact current-head working tree was copied with `scp` and tested in a fresh quarantine on `davida@20.14.133.241` before commit and push.

- quarantine: `/tmp/clawsec-install-policy-final7.nDdEYh`
- clean working-tree archive SHA-256: `3da8050b89e967d91177cdfc7a395c5673c5df168726fd3cae95f9ad6c8913b8`
- all 18 PR-changed files matched the accepted remote tree byte-for-byte
- clean extraction with no AppleDouble sidecar files
- `npm ci`: 422 packages, zero reported vulnerabilities
- every `scripts/test-skill-*.mjs` test passed
- 19/19 hostile release-bundle archive tests passed
- direct release-script installability behavior passed
- workflow, tag simulation, trust-packet, path-policy, SemVer, slug, and trust-extension tests passed
- `bash -n scripts/release-skill.sh` passed
- ESLint passed with zero warnings
- `npx tsc --noEmit` passed
- `npm run build` passed and generated 115 wiki exports

Remote acceptance is the authoritative test evidence for this head.

## Release boundary

This PR remains draft-only. Do not merge, tag, create a GitHub Release, or publish to ClawHub or another skill store as part of this work.
