### PR TITLE
fix(web): enforce catalog installability lifecycle

### DIFF
--- a/components/SkillCard.tsx
+++ b/components/SkillCard.tsx
@@ -9,22 +9,36 @@ interface SkillCardProps {
 }
 
 export const SkillCard: React.FC<SkillCardProps> = ({ skill }) => {
-  const platforms = Array.isArray(skill.platforms) ? skill.platforms.slice(0, 4) : [];
+  const isInstallable = skill.installable !== false;
+  const platforms = isInstallable && Array.isArray(skill.platforms) ? skill.platforms.slice(0, 4) : [];
 
   return (
     <Link
-      to={`/skills/${skill.id}`}
-      className="group block bg-clawd-800 border border-clawd-700 rounded-lg p-5 hover:border-clawd-accent/30 hover:bg-clawd-800/80 transition-all duration-200"
+      to={`/skills/${encodeURIComponent(skill.id)}`}
+      className={`group block bg-clawd-800 border rounded-lg p-5 hover:bg-clawd-800/80 transition-all duration-200 ${
+        isInstallable
+          ? 'border-clawd-700 hover:border-clawd-accent/30'
+          : 'border-amber-500/50 hover:border-amber-400/70'
+      }`}
     >
       <div className="flex items-center gap-3 mb-3">
-        <span className="text-2xl">{skill.emoji || '📦'}</span>
-        <div>
+        <span className="text-2xl">{isInstallable ? skill.emoji || '📦' : '📦'}</span>
+        <div className="min-w-0">
           <h3 className="font-bold text-white group-hover:text-clawd-accent transition-colors">
             {skill.name}
           </h3>
           <span className="text-xs text-gray-500 font-mono">v{skill.version}</span>
         </div>
       </div>
+
+      {!isInstallable && (
+        <div
+          className="mb-3 inline-flex rounded-md border border-amber-500/50 bg-amber-500/10 px-2.5 py-1 text-xs font-semibold text-amber-200"
+          role="status"
+        >
+          Historical — not installable
+        </div>
+      )}
 
       <p className="text-sm text-gray-400 mb-4 line-clamp-2">
         {skill.description}
@@ -53,8 +67,14 @@ export const SkillCard: React.FC<SkillCardProps> = ({ skill }) => {
           {skill.category || 'utility'}
         </span>
         */}
-        <span className="text-clawd-accent text-sm flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity ml-auto">
-          View details <ArrowRight size={14} />
+        <span
+          className={`text-sm flex items-center gap-1 transition-opacity ml-auto ${
+            isInstallable
+              ? 'text-clawd-accent opacity-0 group-hover:opacity-100'
+              : 'text-amber-200 opacity-100'
+          }`}
+        >
+          {isInstallable ? 'View details' : 'View historical details'} <ArrowRight size={14} />
         </span>
       </div>
     </Link>

--- a/pages/SkillDetail.tsx
+++ b/pages/SkillDetail.tsx
@@ -1,122 +1,90 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, Copy, Check, Download, ExternalLink, FileText, Shield } from 'lucide-react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Footer } from '../components/Footer';
-import type { SkillJson, SkillChecksums } from '../types';
+import type {
+  SkillChecksums,
+  SkillDetailLoadResult,
+  SkillLifecycleView,
+} from '../types';
 import { getPlatformDescriptor } from '../utils/advisoryPlatforms';
 import { defaultMarkdownComponents } from '../utils/markdownComponents';
 import { stripFrontmatter } from '../utils/markdownHelpers.mjs';
 import { getRecommendedSkillPlatforms, resolveSkillPlatformMetadata } from '../utils/skillPlatforms';
+import {
+  getSkillLifecycleView,
+  loadSkillDetailData,
+} from '../utils/skillCatalogInstallability.mjs';
 
 const RELEASE_REPO_URL = 'https://github.com/prompt-security/clawsec';
-
-const isProbablyHtmlDocument = (text: string): boolean => {
-  const start = text.trimStart().slice(0, 200).toLowerCase();
-  return start.startsWith('<!doctype html') || start.startsWith('<html');
-};
+const isAbortError = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError';
 
 export const SkillDetail: React.FC = () => {
   const { skillId } = useParams<{ skillId: string }>();
-  const [skillData, setSkillData] = useState<SkillJson | null>(null);
-  const [checksums, setChecksums] = useState<SkillChecksums | null>(null);
-  const [doc, setDoc] = useState<{ filename: string; content: string } | null>(null);
+  const [detail, setDetail] = useState<SkillDetailLoadResult | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
 
   useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+
     const fetchSkillData = async () => {
-      if (!skillId) return;
+      setLoading(true);
+      setDetail(null);
+      setCopied(null);
+
+      if (!skillId) {
+        const view = getSkillLifecycleView('blocked') as SkillLifecycleView;
+        setDetail({
+          state: 'blocked',
+          reason: 'The requested skill has no catalog identity.',
+          record: null,
+          skillData: null,
+          checksums: null,
+          doc: null,
+          view,
+        });
+        setLoading(false);
+        return;
+      }
 
       try {
-        setDoc(null);
+        const result = await loadSkillDetailData(fetch, skillId, {
+          signal: controller.signal,
+        }) as SkillDetailLoadResult;
+        if (!active) return;
 
-        // Fetch skill.json
-        const skillResponse = await fetch(`/skills/${skillId}/skill.json`, {
-          headers: { Accept: 'application/json' }
+        setDetail({
+          ...result,
+          view: getSkillLifecycleView(result.state) as SkillLifecycleView,
         });
-        if (!skillResponse.ok) {
-          throw new Error('Skill not found');
-        }
-
-        const skillContentType = skillResponse.headers.get('content-type') ?? '';
-        const skillRaw = await skillResponse.text();
-        if (skillContentType.includes('text/html') || isProbablyHtmlDocument(skillRaw)) {
-          throw new Error('Skill not found');
-        }
-
-        let skill: SkillJson;
-        try {
-          skill = JSON.parse(skillRaw) as SkillJson;
-        } catch {
-          throw new Error('Invalid skill metadata');
-        }
-
-        setSkillData(skill);
-
-        // Fetch checksums.json
-        try {
-          const checksumsResponse = await fetch(`/skills/${skillId}/checksums.json`, {
-            headers: { Accept: 'application/json' }
-          });
-          if (checksumsResponse.ok) {
-            const checksumsContentType = checksumsResponse.headers.get('content-type') ?? '';
-            const checksumsRaw = await checksumsResponse.text();
-            if (!checksumsContentType.includes('text/html') && !isProbablyHtmlDocument(checksumsRaw)) {
-              try {
-                const checksumsData = JSON.parse(checksumsRaw) as SkillChecksums;
-                setChecksums(checksumsData);
-              } catch {
-                // Checksums malformed, ignore.
-              }
-            }
-          }
-        } catch {
-          // Checksums not available
-        }
-
-        // Fetch documentation (README.md preferred, fallback to SKILL.md).
-        // Note: Dev servers may fall back to serving index.html with 200 for missing files;
-        // guard against accidentally rendering HTML as docs.
-        try {
-          const fetchDocFile = async (filename: string) => {
-            const response = await fetch(`/skills/${skillId}/${filename}`, {
-              headers: { Accept: 'text/plain' }
-            });
-            if (!response.ok) return null;
-
-            const contentType = response.headers.get('content-type') ?? '';
-            const rawText = await response.text();
-
-            if (contentType.includes('text/html') || isProbablyHtmlDocument(rawText)) return null;
-
-            const text =
-              filename === 'SKILL.md' ? stripFrontmatter(rawText).trim() : rawText.trim();
-
-            return text.length > 0 ? text : null;
-          };
-
-          const candidates = ['README.md', 'SKILL.md'];
-          for (const filename of candidates) {
-            const content = await fetchDocFile(filename);
-            if (content) {
-              setDoc({ filename, content });
-              break;
-            }
-          }
-        } catch {
-          // Documentation not available
-        }
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load skill');
+        if (!active || isAbortError(err)) return;
+
+        setDetail({
+          state: 'blocked',
+          reason: 'The verified catalog could not authorize this skill detail page.',
+          record: null,
+          skillData: null,
+          checksums: null,
+          doc: null,
+          view: getSkillLifecycleView('blocked') as SkillLifecycleView,
+        });
       } finally {
-        setLoading(false);
+        if (active) setLoading(false);
       }
     };
 
     fetchSkillData();
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
   }, [skillId]);
 
   const handleCopy = (text: string, id: string) => {
@@ -124,58 +92,6 @@ export const SkillDetail: React.FC = () => {
     setCopied(id);
     setTimeout(() => setCopied(null), 2000);
   };
-
-  const releaseTag = skillData ? `${skillData.name}-v${skillData.version}` : '';
-  const skillInstructionsUrl = releaseTag
-    ? `${RELEASE_REPO_URL}/releases/download/${releaseTag}/SKILL.md`
-    : '';
-
-  const recommendedPlatforms = useMemo(
-    () => (skillData ? getRecommendedSkillPlatforms(skillData) : []),
-    [skillData]
-  );
-
-  const isOpenClawSkill = recommendedPlatforms.includes('openclaw');
-
-  const installCommand = skillData
-    ? isOpenClawSkill
-      ? `npx clawhub@latest install ${skillData.name}`
-      : `curl -sLO ${skillInstructionsUrl}`
-    : '';
-
-  const installLabel = isOpenClawSkill ? 'Via ClawHub' : 'Via SKILL.md instructions';
-  const installHelp = isOpenClawSkill
-    ? 'Recommended for OpenClaw-compatible skills.'
-    : 'Pull the published instruction file and follow the platform-specific setup steps.';
-
-  const releasePageUrl = useMemo(() => {
-    if (!skillData) return '';
-
-    try {
-      const url = new URL(skillData.homepage);
-      if (url.hostname === 'github.com') {
-        const [owner, repo] = url.pathname.split('/').filter(Boolean);
-        if (owner && repo) {
-          const repoBase = `${url.origin}/${owner}/${repo.replace(/\\.git$/, '')}`;
-          return `${repoBase}/releases/tag/${releaseTag}`;
-        }
-      }
-    } catch {
-      // ignore invalid URLs
-    }
-
-    return skillData.homepage;
-  }, [releaseTag, skillData]);
-
-  const platformMetadata = useMemo(
-    () => (skillData ? resolveSkillPlatformMetadata(skillData) : null),
-    [skillData]
-  );
-
-  const triggers = useMemo(() => {
-    if (!platformMetadata || !Array.isArray(platformMetadata.triggers)) return [];
-    return platformMetadata.triggers;
-  }, [platformMetadata]);
 
   if (loading) {
     return (
@@ -186,17 +102,148 @@ export const SkillDetail: React.FC = () => {
     );
   }
 
-  if (error || !skillData) {
+  if (!detail || detail.state === 'blocked') {
     return (
-      <div className="py-16 text-center">
-        <Shield className="w-16 h-16 mx-auto text-gray-600 mb-4" />
-        <h2 className="text-xl font-bold text-white mb-2">Skill Not Found</h2>
-        <p className="text-gray-400 mb-4">{error || 'This skill does not exist'}</p>
+      <div className="py-16 text-center" role="status">
+        <Shield className="w-16 h-16 mx-auto text-amber-300 mb-4" />
+        <h2 className="text-xl font-bold text-white mb-2">Skill Details Unavailable</h2>
+        <p className="text-gray-400 mb-4">
+          {detail?.reason || 'The verified catalog did not authorize this skill detail page.'}
+        </p>
         <Link to="/skills" className="text-clawd-accent hover:underline">
           Back to Skills Catalog
         </Link>
       </div>
     );
+  }
+
+  if (detail.state === 'historical') {
+    if (
+      !detail.record ||
+      detail.record.id !== skillId ||
+      !detail.view.historicalEvidence
+    ) {
+      return (
+        <div className="py-16 text-center" role="status">
+          <Shield className="w-16 h-16 mx-auto text-amber-300 mb-4" />
+          <h2 className="text-xl font-bold text-white mb-2">Historical Record Unavailable</h2>
+          <p className="text-gray-400 mb-4">The catalog record is missing required historical evidence.</p>
+          <Link to="/skills" className="text-clawd-accent hover:underline">
+            Back to Skills Catalog
+          </Link>
+        </div>
+      );
+    }
+
+    const record = detail.record;
+    const releaseEvidenceUrl = `${RELEASE_REPO_URL}/releases/tag/${encodeURIComponent(record.tag)}`;
+    const checksumEvidenceUrl = `/skills/${encodeURIComponent(record.id)}/checksums.json`;
+
+    return (
+      <div className="pt-8 space-y-8">
+        <Link
+          to="/skills"
+          className="inline-flex items-center gap-2 text-gray-400 hover:text-white transition-colors"
+        >
+          <ArrowLeft size={20} />
+          Back to Skills
+        </Link>
+
+        <section
+          className="rounded-xl border border-amber-500/60 bg-amber-500/10 p-6 space-y-4"
+          role="status"
+        >
+          <div className="flex items-start gap-4">
+            <Shield className="mt-1 h-8 w-8 flex-none text-amber-300" />
+            <div className="space-y-2">
+              <p className="text-sm font-semibold uppercase tracking-wide text-amber-200">
+                Historical — not installable
+              </p>
+              <h1 className="text-3xl font-bold text-white">{record.name}</h1>
+              <p className="font-mono text-sm text-gray-400">v{record.version}</p>
+              <p className="text-gray-300">{record.description}</p>
+              <p className="text-sm text-amber-100">
+                {detail.reason || 'This record is retained as historical evidence only. Installation and activation are disabled.'}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-xl font-bold text-white flex items-center gap-2">
+            <Shield size={20} />
+            Historical evidence
+          </h2>
+          <p className="text-sm text-gray-400">
+            These links document the retired release. They do not authorize installation, activation, or execution.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <a
+              href={releaseEvidenceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-between gap-3 rounded-lg border border-clawd-700 bg-clawd-800 p-4 text-white hover:border-amber-500/60"
+            >
+              <span>GitHub release/tag</span>
+              <ExternalLink size={16} className="text-amber-200" />
+            </a>
+            <a
+              href={checksumEvidenceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-between gap-3 rounded-lg border border-clawd-700 bg-clawd-800 p-4 text-white hover:border-amber-500/60"
+            >
+              <span>Checksum manifest</span>
+              <ExternalLink size={16} className="text-amber-200" />
+            </a>
+          </div>
+        </section>
+
+        <Footer />
+      </div>
+    );
+  }
+
+  const { record, skillData, checksums, doc, view } = detail;
+  if (!record || record.id !== skillId || !skillData || !view.canInstall) {
+    return (
+      <div className="py-16 text-center" role="status">
+        <Shield className="w-16 h-16 mx-auto text-amber-300 mb-4" />
+        <h2 className="text-xl font-bold text-white mb-2">Installation Unavailable</h2>
+        <p className="text-gray-400 mb-4">The verified catalog did not authorize an installation path.</p>
+        <Link to="/skills" className="text-clawd-accent hover:underline">
+          Back to Skills Catalog
+        </Link>
+      </div>
+    );
+  }
+
+  const releaseTag = record.tag;
+  const skillInstructionsUrl = `${RELEASE_REPO_URL}/releases/download/${encodeURIComponent(releaseTag)}/SKILL.md`;
+  const recommendedPlatforms = getRecommendedSkillPlatforms(skillData);
+  const isOpenClawSkill = recommendedPlatforms.includes('openclaw');
+  const installCommand = isOpenClawSkill
+    ? `npx clawhub@latest install ${skillData.name}`
+    : `curl -sLO ${skillInstructionsUrl}`;
+  const installLabel = isOpenClawSkill ? 'Via ClawHub' : 'Via SKILL.md instructions';
+  const installHelp = isOpenClawSkill
+    ? 'Recommended for OpenClaw-compatible skills.'
+    : 'Pull the published instruction file and follow the platform-specific setup steps.';
+  const platformMetadata = resolveSkillPlatformMetadata(skillData);
+  const triggers = Array.isArray(platformMetadata.triggers) ? platformMetadata.triggers : [];
+  let releasePageUrl = `${RELEASE_REPO_URL}/releases/tag/${encodeURIComponent(releaseTag)}`;
+
+  try {
+    const url = new URL(skillData.homepage);
+    if (url.hostname === 'github.com') {
+      const [owner, repo] = url.pathname.split('/').filter(Boolean);
+      if (owner && repo) {
+        const repoBase = `${url.origin}/${owner}/${repo.replace(/\\.git$/, '')}`;
+        releasePageUrl = `${repoBase}/releases/tag/${encodeURIComponent(releaseTag)}`;
+      }
+    }
+  } catch {
+    // Keep the canonical repository release URL.
   }
 
   return (
@@ -218,7 +265,7 @@ export const SkillDetail: React.FC = () => {
             <h1 className="text-3xl font-bold text-white mb-1">{skillData.name}</h1>
             <div className="flex items-center gap-3 text-sm">
               <span className="text-gray-500 font-mono">v{skillData.version}</span>
-              {recommendedPlatforms.slice(0, 4).map((platform) => {
+              {view.showPlatforms && recommendedPlatforms.slice(0, 4).map((platform) => {
                 const descriptor = getPlatformDescriptor(platform);
 
                 return (
@@ -258,32 +305,34 @@ export const SkillDetail: React.FC = () => {
       </section>
 
       {/* Install Command */}
-      <section className="space-y-4">
-        <h2 className="text-xl font-bold text-white flex items-center gap-2">
-          <Download size={20} />
-          Quick Install
-        </h2>
-        <div>
-          <p className="text-sm font-medium text-white">{installLabel}</p>
-          <p className="text-sm text-gray-400">{installHelp}</p>
-        </div>
-        <div className="bg-clawd-800 rounded-lg p-3 sm:p-4 flex items-center justify-between gap-2 sm:gap-4">
-          <code className="text-gray-200 font-mono text-xs sm:text-sm overflow-x-auto break-all min-w-0 flex-1">
-            {installCommand}
-          </code>
-          <button
-            onClick={() => handleCopy(installCommand, 'install')}
-            className="flex-shrink-0 p-2 rounded-md bg-clawd-700 hover:bg-clawd-600 transition-colors"
-            title="Copy to clipboard"
-          >
-            {copied === 'install' ? (
-              <Check size={20} className="text-green-400" />
-            ) : (
-              <Copy size={20} className="text-gray-400" />
-            )}
-          </button>
-        </div>
-      </section>
+      {view.canInstall && view.showCopyControls && (
+        <section className="space-y-4">
+          <h2 className="text-xl font-bold text-white flex items-center gap-2">
+            <Download size={20} />
+            Quick Install
+          </h2>
+          <div>
+            <p className="text-sm font-medium text-white">{installLabel}</p>
+            <p className="text-sm text-gray-400">{installHelp}</p>
+          </div>
+          <div className="bg-clawd-800 rounded-lg p-3 sm:p-4 flex items-center justify-between gap-2 sm:gap-4">
+            <code className="text-gray-200 font-mono text-xs sm:text-sm overflow-x-auto break-all min-w-0 flex-1">
+              {installCommand}
+            </code>
+            <button
+              onClick={() => handleCopy(installCommand, 'install')}
+              className="flex-shrink-0 p-2 rounded-md bg-clawd-700 hover:bg-clawd-600 transition-colors"
+              title="Copy to clipboard"
+            >
+              {copied === 'install' ? (
+                <Check size={20} className="text-green-400" />
+              ) : (
+                <Copy size={20} className="text-gray-400" />
+              )}
+            </button>
+          </div>
+        </section>
+      )}
 
       {/* Checksums */}
       {checksums && Object.keys(checksums.files).length > 0 && (
@@ -356,7 +405,7 @@ export const SkillDetail: React.FC = () => {
       )}
 
       {/* Documentation */}
-      {doc && (
+      {view.showDocumentation && doc && (
         <section className="space-y-4">
           <h2 className="text-xl font-bold text-white flex items-center gap-2">
             <FileText size={20} />
@@ -393,7 +442,7 @@ export const SkillDetail: React.FC = () => {
           </dl>
         </div>
 
-        {triggers.length > 0 && (
+        {view.showTriggers && triggers.length > 0 && (
           <div className="bg-clawd-800/50 border border-clawd-700 rounded-xl p-6 space-y-4">
             <h3 className="font-bold text-white">Trigger Phrases</h3>
             <div className="flex flex-wrap gap-2">

--- a/pages/SkillsCatalog.tsx
+++ b/pages/SkillsCatalog.tsx
@@ -3,27 +3,10 @@ import { Search as _Search, Filter as _Filter, Package, Sparkles, FileText, GitF
 import { SkillCard } from '../components/SkillCard';
 import { Footer } from '../components/Footer';
 import type { SkillMetadata, SkillsIndex } from '../types';
+import { loadSkillsIndex } from '../utils/skillCatalogInstallability.mjs';
 
-const SKILLS_INDEX_PATH = '/skills/index.json';
-
-const isProbablyHtmlDocument = (text: string): boolean => {
-  const start = text.trimStart().slice(0, 200).toLowerCase();
-  return start.startsWith('<!doctype html') || start.startsWith('<html');
-};
-
-const parseSkillsIndex = (raw: string): SkillsIndex | null => {
-  try {
-    const parsed = JSON.parse(raw) as Partial<SkillsIndex> | null;
-    if (!parsed || !Array.isArray(parsed.skills)) return null;
-    return {
-      version: typeof parsed.version === 'string' ? parsed.version : '1.0.0',
-      updated: typeof parsed.updated === 'string' ? parsed.updated : '',
-      skills: parsed.skills as SkillMetadata[],
-    };
-  } catch {
-    return null;
-  }
-};
+const isAbortError = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError';
 
 export const SkillsCatalog: React.FC = () => {
   const [skills, setSkills] = useState<SkillMetadata[]>([]);
@@ -34,49 +17,36 @@ export const SkillsCatalog: React.FC = () => {
   const [categoryFilter, _setCategoryFilter] = useState<string>('all');
 
   useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+
     const fetchSkills = async () => {
+      setLoading(true);
+      setError(null);
+
       try {
-        const response = await fetch(SKILLS_INDEX_PATH, {
-          headers: { Accept: 'application/json' },
-        });
-
-        // Missing index file is a valid "empty catalog" state.
-        if (response.status === 404) {
-          setSkills([]);
-          setFilteredSkills([]);
-          return;
-        }
-
-        if (!response.ok) {
-          throw new Error('Failed to fetch skills index');
-        }
-
-        const contentType = response.headers.get('content-type') ?? '';
-        const raw = await response.text();
-
-        // Some SPA setups return index.html with 200 for missing JSON files.
-        if (!raw.trim() || contentType.includes('text/html') || isProbablyHtmlDocument(raw)) {
-          setSkills([]);
-          setFilteredSkills([]);
-          return;
-        }
-
-        const data = parseSkillsIndex(raw);
-        if (!data) {
-          throw new Error('Invalid skills index format');
-        }
+        const data = await loadSkillsIndex(fetch, { signal: controller.signal }) as SkillsIndex;
+        if (!active) return;
 
         setSkills(data.skills);
         setFilteredSkills(data.skills);
       } catch (err) {
+        if (!active || isAbortError(err)) return;
         console.error('Failed to load skills index:', err);
-        setError('Failed to load skills catalog');
+        setSkills([]);
+        setFilteredSkills([]);
+        setError('The verified skills catalog is unavailable. Skill details and installation links are disabled.');
       } finally {
-        setLoading(false);
+        if (active) setLoading(false);
       }
     };
 
     fetchSkills();
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
   }, []);
 
   useEffect(() => {
@@ -120,11 +90,8 @@ export const SkillsCatalog: React.FC = () => {
       <div className="pt-[52px]">
         <div className="py-16 text-center">
           <Package className="w-16 h-16 mx-auto text-gray-600 mb-4" />
-          <h2 className="text-xl font-bold text-white mb-2">No Skills Available</h2>
+          <h2 className="text-xl font-bold text-white mb-2">Skills Catalog Unavailable</h2>
           <p className="text-gray-400 mb-4">{error}</p>
-          <p className="text-sm text-gray-500">
-            Skills will appear here after the first skill release.
-          </p>
         </div>
         <Footer />
       </div>

--- a/scripts/test-web-catalog-installability.mjs
+++ b/scripts/test-web-catalog-installability.mjs
@@ -1,0 +1,616 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  SKILLS_INDEX_PATH,
+  getSkillLifecycleView,
+  loadSkillDetailData,
+  loadSkillsIndex,
+  parseSkillsIndex,
+} from "../utils/skillCatalogInstallability.mjs";
+
+const RESULT_FIELDS = [
+  "state",
+  "reason",
+  "record",
+  "skillData",
+  "checksums",
+  "doc",
+  "view",
+];
+
+const INSTALLABLE_VIEW = {
+  canInstall: true,
+  showCopyControls: true,
+  showPlatforms: true,
+  showTriggers: true,
+  showDocumentation: true,
+  historicalEvidence: false,
+};
+
+const HISTORICAL_VIEW = {
+  canInstall: false,
+  showCopyControls: false,
+  showPlatforms: false,
+  showTriggers: false,
+  showDocumentation: false,
+  historicalEvidence: true,
+};
+
+const BLOCKED_VIEW = {
+  canInstall: false,
+  showCopyControls: false,
+  showPlatforms: false,
+  showTriggers: false,
+  showDocumentation: false,
+  historicalEvidence: false,
+};
+
+function catalogRecord(name, overrides = {}) {
+  const version = overrides.version ?? "1.2.3";
+  return {
+    id: name,
+    name,
+    version,
+    description: `${name} description`,
+    emoji: "🛡️",
+    category: "security",
+    platforms: ["openclaw"],
+    tag: `${name}-v${version}`,
+    ...overrides,
+  };
+}
+
+function skillMetadata(name, overrides = {}) {
+  return {
+    name,
+    version: "1.2.3",
+    description: `${name} description`,
+    author: "ClawSec",
+    license: "AGPL-3.0-or-later",
+    homepage: "https://github.com/prompt-security/clawsec",
+    keywords: ["security"],
+    sbom: { files: [] },
+    ...overrides,
+  };
+}
+
+function indexJson(skills) {
+  return JSON.stringify({
+    version: "1.0.0",
+    updated: "2026-07-23T00:00:00Z",
+    skills,
+  });
+}
+
+function response(body, { status = 200, contentType = "application/json" } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get(name) {
+        return name.toLowerCase() === "content-type" ? contentType : null;
+      },
+    },
+    async text() {
+      return body;
+    },
+  };
+}
+
+function createFetch(routes) {
+  const calls = [];
+  const fetchImpl = async (url, options = {}) => {
+    calls.push({ url, options });
+    if (!routes.has(url)) {
+      throw new Error(`Unexpected fetch: ${url}`);
+    }
+
+    const route = routes.get(url);
+    const value = typeof route === "function" ? await route({ url, options }) : route;
+    if (value instanceof Error) throw value;
+    return value;
+  };
+  return { fetchImpl, calls };
+}
+
+function abortError(message = "aborted") {
+  const error = new Error(message);
+  error.name = "AbortError";
+  return error;
+}
+
+function assertExactResultShape(result) {
+  assert.deepEqual(Object.keys(result), RESULT_FIELDS);
+}
+
+function assertBlocked(result) {
+  assertExactResultShape(result);
+  assert.equal(result.state, "blocked");
+  assert.deepEqual(result.view, BLOCKED_VIEW);
+  assert.equal(result.view.canInstall, false);
+  assert.equal(result.view.showCopyControls, false);
+  assert.equal(result.view.showPlatforms, false);
+  assert.equal(result.view.showTriggers, false);
+  assert.equal(result.view.showDocumentation, false);
+}
+
+test("lifecycle views expose actions only for installable records", () => {
+  assert.deepEqual(getSkillLifecycleView("installable"), INSTALLABLE_VIEW);
+  assert.deepEqual(getSkillLifecycleView("historical"), HISTORICAL_VIEW);
+  assert.deepEqual(getSkillLifecycleView("blocked"), BLOCKED_VIEW);
+  assert.throws(() => getSkillLifecycleView("unknown"), /Unknown skill lifecycle state/);
+});
+
+test("parseSkillsIndex accepts explicit booleans and preserves legacy absence", () => {
+  const parsed = parseSkillsIndex(indexJson([
+    catalogRecord("enabled", { installable: true }),
+    catalogRecord("historical", { installable: false }),
+    catalogRecord("legacy"),
+  ]));
+
+  assert.equal(parsed.skills[0].installable, true);
+  assert.equal(parsed.skills[1].installable, false);
+  assert.equal(Object.hasOwn(parsed.skills[2], "installable"), false);
+  assert.deepEqual(parsed.skills[2].platforms, ["openclaw"]);
+});
+
+test("parseSkillsIndex rejects malformed roots and arrays", () => {
+  assert.throws(() => parseSkillsIndex(42), /must be JSON text/);
+  assert.throws(() => parseSkillsIndex("{"), /invalid JSON/);
+  assert.throws(() => parseSkillsIndex("null"), /root must be an object/);
+  assert.throws(() => parseSkillsIndex("[]"), /root must be an object/);
+  assert.throws(() => parseSkillsIndex("{}"), /"skills" must be an array/);
+  assert.throws(() => parseSkillsIndex('{"skills":{}}'), /"skills" must be an array/);
+});
+
+test("parseSkillsIndex validates every render-required string field", () => {
+  const fields = ["id", "name", "version", "description", "emoji", "category", "tag"];
+  for (const field of fields) {
+    const blank = catalogRecord("fixture");
+    blank[field] = "   ";
+    assert.throws(
+      () => parseSkillsIndex(indexJson([blank])),
+      new RegExp(`field \\"${field}\\" must be a non-empty string`),
+    );
+
+    const wrongType = catalogRecord("fixture");
+    wrongType[field] = 1;
+    assert.throws(
+      () => parseSkillsIndex(indexJson([wrongType])),
+      new RegExp(`field \\"${field}\\" must be a non-empty string`),
+    );
+  }
+  assert.throws(
+    () => parseSkillsIndex(indexJson([catalogRecord("fixture", { id: "other" })])),
+    /"id" must exactly match "name"/,
+  );
+  assert.throws(
+    () => parseSkillsIndex(indexJson([catalogRecord("fixture", { tag: "wrong-v1.2.3" })])),
+    /"tag" must be "fixture-v1\.2\.3"/,
+  );
+});
+
+test("parseSkillsIndex rejects invalid platforms and lifecycle values", () => {
+  for (const platforms of ["openclaw", {}, ["openclaw", 1]]) {
+    assert.throws(
+      () => parseSkillsIndex(indexJson([catalogRecord("fixture", { platforms })])),
+      /"platforms" must be an array of strings/,
+    );
+  }
+
+  for (const installable of [null, "false", 0, {}, []]) {
+    assert.throws(
+      () => parseSkillsIndex(indexJson([catalogRecord("fixture", { installable })])),
+      /"installable" must be a boolean when present/,
+    );
+  }
+});
+
+test("parseSkillsIndex rejects duplicate catalog identities", () => {
+  const duplicate = catalogRecord("duplicate");
+  assert.throws(
+    () => parseSkillsIndex(indexJson([duplicate, { ...duplicate }])),
+    /duplicate id "duplicate"/,
+  );
+});
+
+test("loadSkillsIndex returns a strict index and forwards the abort signal", async () => {
+  const controller = new globalThis.AbortController();
+  const { fetchImpl, calls } = createFetch(new Map([
+    [SKILLS_INDEX_PATH, response(indexJson([catalogRecord("enabled")]))],
+  ]));
+
+  const index = await loadSkillsIndex(fetchImpl, { signal: controller.signal });
+  assert.equal(index.skills[0].name, "enabled");
+  assert.deepEqual(calls.map(({ url }) => url), [SKILLS_INDEX_PATH]);
+  assert.equal(calls[0].options.headers.Accept, "application/json");
+  assert.equal(calls[0].options.signal, controller.signal);
+});
+
+test("loadSkillsIndex throws for unavailable, empty, HTML, and malformed responses", async (t) => {
+  const cases = [
+    ["network failure", new Error("offline"), /offline/],
+    ["HTTP failure", response("missing", { status: 404, contentType: "text/plain" }), /HTTP 404/],
+    ["empty body", response(""), /response is empty/],
+    ["HTML content type", response("fallback", { contentType: "text/html" }), /HTML, not JSON/],
+    ["HTML body", response("<!doctype html><title>fallback</title>", { contentType: "text/plain" }), /HTML, not JSON/],
+    ["invalid JSON", response("not json"), /invalid JSON/],
+    ["non-array skills", response('{"skills":{}}'), /"skills" must be an array/],
+  ];
+
+  for (const [name, route, pattern] of cases) {
+    await t.test(name, async () => {
+      const { fetchImpl, calls } = createFetch(new Map([[SKILLS_INDEX_PATH, route]]));
+      await assert.rejects(loadSkillsIndex(fetchImpl), pattern);
+      assert.deepEqual(calls.map(({ url }) => url), [SKILLS_INDEX_PATH]);
+    });
+  }
+});
+
+test("direct detail blocks index failures without any per-skill request", async (t) => {
+  const duplicate = catalogRecord("duplicate");
+  const cases = [
+    ["network", new Error("offline")],
+    ["404", response("missing", { status: 404, contentType: "text/plain" })],
+    ["empty", response("")],
+    ["HTML", response("<html>fallback</html>", { contentType: "text/html" })],
+    ["invalid JSON", response("not json")],
+    ["non-array", response('{"skills":{}}')],
+    ["non-boolean lifecycle", response(indexJson([catalogRecord("enabled", { installable: "false" })]))],
+    ["duplicate record", response(indexJson([duplicate, { ...duplicate }]))],
+  ];
+
+  for (const [name, indexRoute] of cases) {
+    await t.test(name, async () => {
+      const { fetchImpl, calls } = createFetch(new Map([[SKILLS_INDEX_PATH, indexRoute]]));
+      const result = await loadSkillDetailData(fetchImpl, "enabled");
+      assertBlocked(result);
+      assert.equal(result.record, null);
+      assert.equal(result.skillData, null);
+      assert.equal(result.checksums, null);
+      assert.equal(result.doc, null);
+      assert.deepEqual(calls.map(({ url }) => url), [SKILLS_INDEX_PATH]);
+    });
+  }
+});
+
+test("a missing index record blocks the direct route without per-skill requests", async () => {
+  const { fetchImpl, calls } = createFetch(new Map([
+    [SKILLS_INDEX_PATH, response(indexJson([catalogRecord("other")]))],
+  ]));
+
+  const result = await loadSkillDetailData(fetchImpl, "missing");
+  assertBlocked(result);
+  assert.match(result.reason, /not present/);
+  assert.deepEqual(calls.map(({ url }) => url), [SKILLS_INDEX_PATH]);
+});
+
+test("an explicit index denial is historical and makes only the index request", async () => {
+  const deniedRecord = catalogRecord("historical", { installable: false });
+  const { fetchImpl, calls } = createFetch(new Map([
+    [SKILLS_INDEX_PATH, response(indexJson([deniedRecord]))],
+  ]));
+
+  const result = await loadSkillDetailData(fetchImpl, "historical");
+  assertExactResultShape(result);
+  assert.equal(result.state, "historical");
+  assert.equal(result.record.name, "historical");
+  assert.equal(result.skillData, null);
+  assert.equal(result.checksums, null);
+  assert.equal(result.doc, null);
+  assert.deepEqual(result.view, HISTORICAL_VIEW);
+  assert.deepEqual(calls.map(({ url }) => url), [SKILLS_INDEX_PATH]);
+});
+
+test("legacy-absent lifecycle preserves the complete installable experience", async () => {
+  const checksums = {
+    skill: "legacy",
+    version: "1.2.3",
+    tag: "legacy-v1.2.3",
+    files: { "SKILL.md": { sha256: "abc", size: 12 } },
+  };
+  const { fetchImpl, calls } = createFetch(new Map([
+    [SKILLS_INDEX_PATH, response(indexJson([catalogRecord("legacy")]))],
+    ["/skills/legacy/skill.json", response(JSON.stringify(skillMetadata("legacy")))],
+    ["/skills/legacy/checksums.json", response(JSON.stringify(checksums))],
+    ["/skills/legacy/README.md", response("# Legacy documentation", { contentType: "text/plain" })],
+  ]));
+
+  const result = await loadSkillDetailData(fetchImpl, "legacy");
+  assertExactResultShape(result);
+  assert.equal(result.state, "installable");
+  assert.equal(result.record.installable, undefined);
+  assert.equal(result.skillData.installable, undefined);
+  assert.deepEqual(result.checksums, checksums);
+  assert.deepEqual(result.doc, { filename: "README.md", content: "# Legacy documentation" });
+  assert.deepEqual(result.view, INSTALLABLE_VIEW);
+  assert.deepEqual(calls.map(({ url }) => url), [
+    SKILLS_INDEX_PATH,
+    "/skills/legacy/skill.json",
+    "/skills/legacy/checksums.json",
+    "/skills/legacy/README.md",
+  ]);
+  assert.equal(calls[1].options.headers.Accept, "application/json");
+  assert.equal(calls[3].options.headers.Accept, "text/plain");
+});
+
+test("explicit true at both layers remains installable", async () => {
+  const { fetchImpl, calls } = createFetch(new Map([
+    [SKILLS_INDEX_PATH, response(indexJson([catalogRecord("enabled", { installable: true })]))],
+    ["/skills/enabled/skill.json", response(JSON.stringify(skillMetadata("enabled", { installable: true })))],
+    ["/skills/enabled/checksums.json", response("{}")],
+    ["/skills/enabled/README.md", response("documentation", { contentType: "text/plain" })],
+  ]));
+
+  const result = await loadSkillDetailData(fetchImpl, "enabled");
+  assert.equal(result.state, "installable");
+  assert.deepEqual(result.view, INSTALLABLE_VIEW);
+  assert.deepEqual(calls.map(({ url }) => url), [
+    SKILLS_INDEX_PATH,
+    "/skills/enabled/skill.json",
+    "/skills/enabled/checksums.json",
+    "/skills/enabled/README.md",
+  ]);
+});
+
+test("detail metadata false adds a denial and suppresses checksums and docs", async () => {
+  const { fetchImpl, calls } = createFetch(new Map([
+    [SKILLS_INDEX_PATH, response(indexJson([catalogRecord("withdrawn", { installable: true })]))],
+    ["/skills/withdrawn/skill.json", response(JSON.stringify(skillMetadata("withdrawn", { installable: false })))],
+  ]));
+
+  const result = await loadSkillDetailData(fetchImpl, "withdrawn");
+  assert.equal(result.state, "historical");
+  assert.equal(result.skillData.installable, false);
+  assert.equal(result.checksums, null);
+  assert.equal(result.doc, null);
+  assert.deepEqual(result.view, HISTORICAL_VIEW);
+  assert.deepEqual(calls.map(({ url }) => url), [
+    SKILLS_INDEX_PATH,
+    "/skills/withdrawn/skill.json",
+  ]);
+});
+
+test("invalid detail lifecycle values block before checksums and docs", async (t) => {
+  for (const installable of [null, "false", 0, {}, []]) {
+    await t.test(JSON.stringify(installable), async () => {
+      const { fetchImpl, calls } = createFetch(new Map([
+        [SKILLS_INDEX_PATH, response(indexJson([catalogRecord("invalid")]))],
+        ["/skills/invalid/skill.json", response(JSON.stringify(skillMetadata("invalid", { installable })))],
+      ]));
+
+      const result = await loadSkillDetailData(fetchImpl, "invalid");
+      assertBlocked(result);
+      assert.match(result.reason, /"installable" must be a boolean/);
+      assert.deepEqual(calls.map(({ url }) => url), [
+        SKILLS_INDEX_PATH,
+        "/skills/invalid/skill.json",
+      ]);
+    });
+  }
+});
+
+test("detail identity, version, and tag mismatches fail closed", async (t) => {
+  const cases = [
+    ["name", skillMetadata("different"), /name does not match/],
+    ["version", skillMetadata("bound", { version: "9.9.9" }), /version does not match/],
+    ["tag", skillMetadata("bound", { tag: "bound-v9.9.9" }), /tag does not match/],
+  ];
+
+  for (const [name, detail, pattern] of cases) {
+    await t.test(name, async () => {
+      const { fetchImpl, calls } = createFetch(new Map([
+        [SKILLS_INDEX_PATH, response(indexJson([catalogRecord("bound")]))],
+        ["/skills/bound/skill.json", response(JSON.stringify(detail))],
+      ]));
+
+      const result = await loadSkillDetailData(fetchImpl, "bound");
+      assertBlocked(result);
+      assert.match(result.reason, pattern);
+      assert.deepEqual(calls.map(({ url }) => url), [
+        SKILLS_INDEX_PATH,
+        "/skills/bound/skill.json",
+      ]);
+    });
+  }
+});
+
+test("unavailable, empty, HTML, and malformed detail metadata block all later requests", async (t) => {
+  const cases = [
+    ["network", new Error("offline")],
+    ["HTTP", response("missing", { status: 404, contentType: "text/plain" })],
+    ["empty", response("")],
+    ["HTML content type", response("fallback", { contentType: "text/html" })],
+    ["HTML body", response("<!doctype html><title>fallback</title>", { contentType: "text/plain" })],
+    ["invalid JSON", response("not json")],
+    ["array root", response("[]")],
+  ];
+
+  for (const [name, skillRoute] of cases) {
+    await t.test(name, async () => {
+      const { fetchImpl, calls } = createFetch(new Map([
+        [SKILLS_INDEX_PATH, response(indexJson([catalogRecord("fixture")]))],
+        ["/skills/fixture/skill.json", skillRoute],
+      ]));
+
+      const result = await loadSkillDetailData(fetchImpl, "fixture");
+      assertBlocked(result);
+      assert.deepEqual(calls.map(({ url }) => url), [
+        SKILLS_INDEX_PATH,
+        "/skills/fixture/skill.json",
+      ]);
+    });
+  }
+});
+
+test("special skill identities are matched exactly and URL-encoded as one path segment", async () => {
+  const specialId = "odd skill/β?#";
+  const encoded = "odd%20skill%2F%CE%B2%3F%23";
+  const { fetchImpl, calls } = createFetch(new Map([
+    [SKILLS_INDEX_PATH, response(indexJson([catalogRecord(specialId)]))],
+    [`/skills/${encoded}/skill.json`, response(JSON.stringify(skillMetadata(specialId)))],
+    [`/skills/${encoded}/checksums.json`, response("{}")],
+    [`/skills/${encoded}/README.md`, response("special documentation", { contentType: "text/plain" })],
+  ]));
+
+  const result = await loadSkillDetailData(fetchImpl, specialId);
+  assert.equal(result.state, "installable");
+  assert.deepEqual(calls.map(({ url }) => url), [
+    SKILLS_INDEX_PATH,
+    `/skills/${encoded}/skill.json`,
+    `/skills/${encoded}/checksums.json`,
+    `/skills/${encoded}/README.md`,
+  ]);
+});
+
+test("malformed optional checksums are ignored and HTML README falls back to SKILL.md", async (t) => {
+  for (const [name, malformedChecksums] of [
+    ["invalid JSON", "not json"],
+    ["missing files map", "{}"],
+    ["missing release identity", JSON.stringify({ files: {} })],
+    ["wrong skill identity", JSON.stringify({ skill: "other", version: "1.2.3", tag: "fallback-v1.2.3", files: {} })],
+    ["wrong version identity", JSON.stringify({ skill: "fallback", version: "9.9.9", tag: "fallback-v1.2.3", files: {} })],
+    ["wrong tag identity", JSON.stringify({ skill: "fallback", version: "1.2.3", tag: "fallback-v9.9.9", files: {} })],
+    ["invalid file entry", JSON.stringify({
+      skill: "fallback",
+      version: "1.2.3",
+      tag: "fallback-v1.2.3",
+      files: { "SKILL.md": null },
+    })],
+    ["invalid file size", JSON.stringify({
+      skill: "fallback",
+      version: "1.2.3",
+      tag: "fallback-v1.2.3",
+      files: { "SKILL.md": { sha256: "abc", size: "1" } },
+    })],
+  ]) {
+    await t.test(name, async () => {
+      const { fetchImpl, calls } = createFetch(new Map([
+        [SKILLS_INDEX_PATH, response(indexJson([catalogRecord("fallback")]))],
+        ["/skills/fallback/skill.json", response(JSON.stringify(skillMetadata("fallback")))],
+        ["/skills/fallback/checksums.json", response(malformedChecksums)],
+        ["/skills/fallback/README.md", response("<html>SPA fallback</html>", { contentType: "text/html" })],
+        ["/skills/fallback/SKILL.md", response("---\nname: fallback\n---\nInstructions", { contentType: "text/plain" })],
+      ]));
+
+      const result = await loadSkillDetailData(fetchImpl, "fallback");
+      assert.equal(result.state, "installable");
+      assert.equal(result.checksums, null);
+      assert.deepEqual(result.doc, {
+        filename: "SKILL.md",
+        content: "---\nname: fallback\n---\nInstructions",
+      });
+      assert.deepEqual(calls.map(({ url }) => url), [
+        SKILLS_INDEX_PATH,
+        "/skills/fallback/skill.json",
+        "/skills/fallback/checksums.json",
+        "/skills/fallback/README.md",
+        "/skills/fallback/SKILL.md",
+      ]);
+    });
+  }
+});
+
+test("valid optional checksums remain available to the installable view", async () => {
+  const checksums = {
+    skill: "fallback",
+    version: "1.2.3",
+    tag: "fallback-v1.2.3",
+    files: {
+      "SKILL.md": {
+        sha256: "abc",
+        size: 12,
+        path: "SKILL.md",
+        url: "https://example.test/SKILL.md",
+      },
+    },
+  };
+  const { fetchImpl, calls } = createFetch(new Map([
+    [SKILLS_INDEX_PATH, response(indexJson([catalogRecord("fallback")]))],
+    ["/skills/fallback/skill.json", response(JSON.stringify(skillMetadata("fallback")))],
+    ["/skills/fallback/checksums.json", response(JSON.stringify(checksums))],
+    ["/skills/fallback/README.md", response("<html>SPA fallback</html>", { contentType: "text/html" })],
+    ["/skills/fallback/SKILL.md", response("---\nname: fallback\n---\nInstructions", { contentType: "text/plain" })],
+  ]));
+
+  const result = await loadSkillDetailData(fetchImpl, "fallback");
+  assert.equal(result.state, "installable");
+  assert.deepEqual(result.checksums, checksums);
+  assert.deepEqual(result.doc, {
+    filename: "SKILL.md",
+    content: "---\nname: fallback\n---\nInstructions",
+  });
+  assert.deepEqual(calls.map(({ url }) => url), [
+    SKILLS_INDEX_PATH,
+    "/skills/fallback/skill.json",
+    "/skills/fallback/checksums.json",
+    "/skills/fallback/README.md",
+    "/skills/fallback/SKILL.md",
+  ]);
+});
+
+test("optional endpoint failures remain non-authorizing display omissions", async () => {
+  const { fetchImpl, calls } = createFetch(new Map([
+    [SKILLS_INDEX_PATH, response(indexJson([catalogRecord("optional")]))],
+    ["/skills/optional/skill.json", response(JSON.stringify(skillMetadata("optional")))],
+    ["/skills/optional/checksums.json", new Error("checksums offline")],
+    ["/skills/optional/README.md", new Error("README offline")],
+    ["/skills/optional/SKILL.md", response("", { contentType: "text/plain" })],
+  ]));
+
+  const result = await loadSkillDetailData(fetchImpl, "optional");
+  assert.equal(result.state, "installable");
+  assert.equal(result.checksums, null);
+  assert.equal(result.doc, null);
+  assert.deepEqual(calls.map(({ url }) => url), [
+    SKILLS_INDEX_PATH,
+    "/skills/optional/skill.json",
+    "/skills/optional/checksums.json",
+    "/skills/optional/README.md",
+    "/skills/optional/SKILL.md",
+  ]);
+});
+
+test("AbortError is the only error class rethrown by the detail loader", async (t) => {
+  await t.test("index abort", async () => {
+    const expected = abortError("index aborted");
+    const { fetchImpl, calls } = createFetch(new Map([[SKILLS_INDEX_PATH, expected]]));
+    await assert.rejects(loadSkillDetailData(fetchImpl, "fixture"), (error) => error === expected);
+    assert.deepEqual(calls.map(({ url }) => url), [SKILLS_INDEX_PATH]);
+  });
+
+  await t.test("detail abort", async () => {
+    const expected = abortError("detail aborted");
+    const { fetchImpl, calls } = createFetch(new Map([
+      [SKILLS_INDEX_PATH, response(indexJson([catalogRecord("fixture")]))],
+      ["/skills/fixture/skill.json", expected],
+    ]));
+    await assert.rejects(loadSkillDetailData(fetchImpl, "fixture"), (error) => error === expected);
+    assert.deepEqual(calls.map(({ url }) => url), [
+      SKILLS_INDEX_PATH,
+      "/skills/fixture/skill.json",
+    ]);
+  });
+
+  await t.test("optional abort", async () => {
+    const expected = abortError("checksums aborted");
+    const { fetchImpl, calls } = createFetch(new Map([
+      [SKILLS_INDEX_PATH, response(indexJson([catalogRecord("fixture")]))],
+      ["/skills/fixture/skill.json", response(JSON.stringify(skillMetadata("fixture")))],
+      ["/skills/fixture/checksums.json", expected],
+    ]));
+    await assert.rejects(loadSkillDetailData(fetchImpl, "fixture"), (error) => error === expected);
+    assert.deepEqual(calls.map(({ url }) => url), [
+      SKILLS_INDEX_PATH,
+      "/skills/fixture/skill.json",
+      "/skills/fixture/checksums.json",
+    ]);
+  });
+
+  await t.test("generic errors block or omit instead of escaping", async () => {
+    const { fetchImpl } = createFetch(new Map([[SKILLS_INDEX_PATH, new Error("offline")]]));
+    const result = await loadSkillDetailData(fetchImpl, "fixture");
+    assertBlocked(result);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -88,6 +88,7 @@ export interface SkillMetadata {
   emoji: string;
   category: string;
   platforms?: AdvisoryPlatformSlug[];
+  installable?: boolean;
   tag: string;
 }
 
@@ -107,7 +108,7 @@ export interface SkillChecksums {
     sha256: string;
     size: number;
     path?: string;
-    url: string;
+    url?: string;
   }>;
 }
 
@@ -128,6 +129,7 @@ export interface SkillJson {
   name: string;
   version: string;
   description: string;
+  installable?: boolean;
   author: string;
   license: string;
   homepage: string;
@@ -145,4 +147,30 @@ export interface SkillJson {
   hermes?: SkillPlatformMetadata | null;
   nanoclaw?: SkillPlatformMetadata | null;
   picoclaw?: SkillPlatformMetadata | null;
+}
+
+export type SkillLifecycleState = 'installable' | 'historical' | 'blocked';
+
+export interface SkillLifecycleView {
+  canInstall: boolean;
+  showCopyControls: boolean;
+  showPlatforms: boolean;
+  showTriggers: boolean;
+  showDocumentation: boolean;
+  historicalEvidence: boolean;
+}
+
+export interface SkillDocumentation {
+  filename: string;
+  content: string;
+}
+
+export interface SkillDetailLoadResult {
+  state: SkillLifecycleState;
+  reason: string;
+  record: SkillMetadata | null;
+  skillData: SkillJson | null;
+  checksums: SkillChecksums | null;
+  doc: SkillDocumentation | null;
+  view: SkillLifecycleView;
 }

--- a/utils/skillCatalogInstallability.mjs
+++ b/utils/skillCatalogInstallability.mjs
@@ -1,0 +1,395 @@
+export const SKILLS_INDEX_PATH = "/skills/index.json";
+
+const RESULT_FIELDS = [
+  "state",
+  "reason",
+  "record",
+  "skillData",
+  "checksums",
+  "doc",
+  "view",
+];
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOwn(value, field) {
+  return Object.prototype.hasOwnProperty.call(value, field);
+}
+
+function requireNonEmptyString(value, field, source) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${source} field "${field}" must be a non-empty string`);
+  }
+  return value;
+}
+
+function validateOptionalInstallable(value, source) {
+  if (hasOwn(value, "installable") && typeof value.installable !== "boolean") {
+    throw new Error(`${source} field "installable" must be a boolean when present`);
+  }
+}
+
+function isProbablyHtmlDocument(text) {
+  const start = text.trimStart().slice(0, 200).toLowerCase();
+  return start.startsWith("<!doctype html") || start.startsWith("<html");
+}
+
+function responseContentType(response) {
+  return response?.headers?.get?.("content-type") ?? "";
+}
+
+function isHtmlResponse(response, text) {
+  return responseContentType(response).toLowerCase().includes("text/html")
+    || isProbablyHtmlDocument(text);
+}
+
+function isAbortError(error) {
+  return error !== null
+    && typeof error === "object"
+    && "name" in error
+    && error.name === "AbortError";
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function buildResult({
+  state,
+  reason,
+  record = null,
+  skillData = null,
+  checksums = null,
+  doc = null,
+}) {
+  const result = {
+    state,
+    reason,
+    record,
+    skillData,
+    checksums,
+    doc,
+    view: getSkillLifecycleView(state),
+  };
+
+  // Keep the public result stable even if this helper is refactored later.
+  if (Object.keys(result).some((field, index) => field !== RESULT_FIELDS[index])) {
+    throw new Error("Internal lifecycle result shape mismatch");
+  }
+
+  return result;
+}
+
+function blocked(reason, fields = {}) {
+  return buildResult({ state: "blocked", reason, ...fields });
+}
+
+function historical(reason, fields = {}) {
+  return buildResult({ state: "historical", reason, ...fields });
+}
+
+function validateIndexRecord(record, index) {
+  const source = `Skills index record ${index}`;
+  if (!isObject(record)) {
+    throw new Error(`${source} must be an object`);
+  }
+
+  for (const field of ["id", "name", "version", "description", "emoji", "category", "tag"]) {
+    requireNonEmptyString(record[field], field, source);
+  }
+
+  if (record.id !== record.name) {
+    throw new Error(`${source} field "id" must exactly match "name"`);
+  }
+
+  const expectedTag = `${record.name}-v${record.version}`;
+  if (record.tag !== expectedTag) {
+    throw new Error(`${source} field "tag" must be "${expectedTag}"`);
+  }
+
+  if (hasOwn(record, "platforms")) {
+    if (!Array.isArray(record.platforms) || record.platforms.some((platform) => typeof platform !== "string")) {
+      throw new Error(`${source} field "platforms" must be an array of strings when present`);
+    }
+  }
+
+  validateOptionalInstallable(record, source);
+
+  return {
+    ...record,
+    ...(Array.isArray(record.platforms) ? { platforms: [...record.platforms] } : {}),
+  };
+}
+
+export function parseSkillsIndex(raw) {
+  if (typeof raw !== "string") {
+    throw new Error("Skills index must be JSON text");
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("Skills index contains invalid JSON");
+  }
+
+  if (!isObject(parsed)) {
+    throw new Error("Skills index root must be an object");
+  }
+  if (!Array.isArray(parsed.skills)) {
+    throw new Error('Skills index field "skills" must be an array');
+  }
+
+  const seenIds = new Set();
+  const seenNames = new Set();
+  const skills = parsed.skills.map((record, index) => {
+    const validated = validateIndexRecord(record, index);
+    if (seenIds.has(validated.id)) {
+      throw new Error(`Skills index contains duplicate id "${validated.id}"`);
+    }
+    if (seenNames.has(validated.name)) {
+      throw new Error(`Skills index contains duplicate name "${validated.name}"`);
+    }
+    seenIds.add(validated.id);
+    seenNames.add(validated.name);
+    return validated;
+  });
+
+  return { ...parsed, skills };
+}
+
+export async function loadSkillsIndex(fetchImpl, { signal } = {}) {
+  if (typeof fetchImpl !== "function") {
+    throw new Error("A fetch implementation is required");
+  }
+
+  const response = await fetchImpl(SKILLS_INDEX_PATH, {
+    headers: { Accept: "application/json" },
+    signal,
+  });
+  if (!response?.ok) {
+    const status = Number.isInteger(response?.status) ? ` (HTTP ${response.status})` : "";
+    throw new Error(`Skills index is unavailable${status}`);
+  }
+
+  const raw = await response.text();
+  if (!raw.trim()) {
+    throw new Error("Skills index response is empty");
+  }
+  if (isHtmlResponse(response, raw)) {
+    throw new Error("Skills index response is HTML, not JSON");
+  }
+
+  return parseSkillsIndex(raw);
+}
+
+function parseSkillData(raw) {
+  let skill;
+  try {
+    skill = JSON.parse(raw);
+  } catch {
+    throw new Error("Skill metadata contains invalid JSON");
+  }
+
+  if (!isObject(skill)) {
+    throw new Error("Skill metadata root must be an object");
+  }
+  requireNonEmptyString(skill.name, "name", "Skill metadata");
+  requireNonEmptyString(skill.version, "version", "Skill metadata");
+  validateOptionalInstallable(skill, "Skill metadata");
+  if (hasOwn(skill, "tag")) {
+    requireNonEmptyString(skill.tag, "tag", "Skill metadata");
+  }
+  return skill;
+}
+
+function validateDetailIdentity(skillId, record, skillData) {
+  if (record.id !== skillId || record.name !== skillId) {
+    throw new Error("Catalog route identity does not match the requested skill");
+  }
+  if (skillData.name !== record.name) {
+    throw new Error("Skill metadata name does not match the catalog record");
+  }
+  if (skillData.version !== record.version) {
+    throw new Error("Skill metadata version does not match the catalog record");
+  }
+
+  const detailTag = hasOwn(skillData, "tag")
+    ? skillData.tag
+    : `${skillData.name}-v${skillData.version}`;
+  if (detailTag !== record.tag) {
+    throw new Error("Skill metadata tag does not match the catalog record");
+  }
+}
+
+async function fetchRequiredSkillData(fetchImpl, url, signal) {
+  const response = await fetchImpl(url, {
+    headers: { Accept: "application/json" },
+    signal,
+  });
+  if (!response?.ok) {
+    const status = Number.isInteger(response?.status) ? ` (HTTP ${response.status})` : "";
+    throw new Error(`Skill metadata is unavailable${status}`);
+  }
+
+  const raw = await response.text();
+  if (!raw.trim()) {
+    throw new Error("Skill metadata response is empty");
+  }
+  if (isHtmlResponse(response, raw)) {
+    throw new Error("Skill metadata response is HTML, not JSON");
+  }
+  return parseSkillData(raw);
+}
+
+async function fetchOptionalChecksums(fetchImpl, url, signal, expectedRecord) {
+  try {
+    const response = await fetchImpl(url, {
+      headers: { Accept: "application/json" },
+      signal,
+    });
+    if (!response?.ok) return null;
+
+    const raw = await response.text();
+    if (!raw.trim() || isHtmlResponse(response, raw)) return null;
+
+    const parsed = JSON.parse(raw);
+    if (
+      !isObject(parsed)
+      || parsed.skill !== expectedRecord.name
+      || parsed.version !== expectedRecord.version
+      || parsed.tag !== expectedRecord.tag
+      || !isObject(parsed.files)
+    ) {
+      return null;
+    }
+
+    for (const [filename, file] of Object.entries(parsed.files)) {
+      if (
+        !filename
+        || !isObject(file)
+        || typeof file.sha256 !== "string"
+        || !file.sha256.trim()
+        || typeof file.size !== "number"
+        || !Number.isFinite(file.size)
+        || file.size < 0
+        || (hasOwn(file, "path") && typeof file.path !== "string")
+        || (hasOwn(file, "url") && typeof file.url !== "string")
+      ) {
+        return null;
+      }
+    }
+
+    return parsed;
+  } catch (error) {
+    if (isAbortError(error)) throw error;
+    return null;
+  }
+}
+
+async function fetchOptionalDoc(fetchImpl, url, filename, signal) {
+  try {
+    const response = await fetchImpl(url, {
+      headers: { Accept: "text/plain" },
+      signal,
+    });
+    if (!response?.ok) return null;
+
+    const raw = await response.text();
+    if (!raw.trim() || isHtmlResponse(response, raw)) return null;
+    return { filename, content: raw.trim() };
+  } catch (error) {
+    if (isAbortError(error)) throw error;
+    return null;
+  }
+}
+
+export function getSkillLifecycleView(state) {
+  if (!new Set(["installable", "historical", "blocked"]).has(state)) {
+    throw new Error(`Unknown skill lifecycle state: ${state}`);
+  }
+
+  const installable = state === "installable";
+  return {
+    canInstall: installable,
+    showCopyControls: installable,
+    showPlatforms: installable,
+    showTriggers: installable,
+    showDocumentation: installable,
+    historicalEvidence: state === "historical",
+  };
+}
+
+export async function loadSkillDetailData(fetchImpl, skillId, { signal } = {}) {
+  let index;
+  try {
+    index = await loadSkillsIndex(fetchImpl, { signal });
+  } catch (error) {
+    if (isAbortError(error)) throw error;
+    return blocked(`Unable to verify catalog lifecycle: ${errorMessage(error)}`);
+  }
+
+  if (typeof skillId !== "string" || !skillId.trim()) {
+    return blocked("The requested skill identity is missing");
+  }
+
+  const record = index.skills.find((candidate) => candidate.id === skillId);
+  if (!record) {
+    return blocked("The requested skill is not present in the verified catalog index");
+  }
+
+  if (record.installable === false) {
+    return historical("The catalog marks this skill as historical and non-installable", { record });
+  }
+
+  const encodedSkillId = encodeURIComponent(skillId);
+  const skillJsonUrl = `/skills/${encodedSkillId}/skill.json`;
+  let skillData;
+  try {
+    skillData = await fetchRequiredSkillData(fetchImpl, skillJsonUrl, signal);
+    validateDetailIdentity(skillId, record, skillData);
+  } catch (error) {
+    if (isAbortError(error)) throw error;
+    return blocked(`Unable to verify skill metadata: ${errorMessage(error)}`, { record });
+  }
+
+  if (skillData.installable === false) {
+    return historical("The skill metadata marks this release as historical and non-installable", {
+      record,
+      skillData,
+    });
+  }
+
+  const checksums = await fetchOptionalChecksums(
+    fetchImpl,
+    `/skills/${encodedSkillId}/checksums.json`,
+    signal,
+    record,
+  );
+
+  let doc = await fetchOptionalDoc(
+    fetchImpl,
+    `/skills/${encodedSkillId}/README.md`,
+    "README.md",
+    signal,
+  );
+  if (!doc) {
+    doc = await fetchOptionalDoc(
+      fetchImpl,
+      `/skills/${encodedSkillId}/SKILL.md`,
+      "SKILL.md",
+      signal,
+    );
+  }
+
+  return buildResult({
+    state: "installable",
+    reason: "Catalog and skill metadata allow the installation experience",
+    record,
+    skillData,
+    checksums,
+    doc,
+  });
+}


### PR DESCRIPTION
# User description
## Summary

- enforce the projected catalog `installable` lifecycle on catalog cards and detail routes
- keep explicit non-installable records discoverable as conspicuous historical evidence
- suppress install commands, clipboard controls, platform affordances, triggers, and rendered README/SKILL content for every denied state
- fail closed on direct routes when the index is unavailable, malformed, duplicated, or missing the requested record
- let detail metadata add another denial without ever overriding the index

## Scope

This is the frontend-only consumer PR from the multi-harness design. It is stacked on `davida-ps/catalog-installability-projection-v1` (PR #311).

Changed paths:

- `components/SkillCard.tsx`
- `pages/SkillDetail.tsx`
- `pages/SkillsCatalog.tsx`
- `types.ts`
- `utils/skillCatalogInstallability.mjs`
- `scripts/test-web-catalog-installability.mjs`

It does not change Pages generation, any skill package, release policy, workflow, or publication path.

## Security behavior

- index explicit `true` and legacy-absent lifecycle preserve the existing installation experience
- index explicit `false` performs no per-skill fetch and renders only labeled release/tag and checksum-manifest evidence
- missing, invalid, HTML-fallback, non-array, non-boolean, or duplicated index data blocks the detail route
- release, detail, route, version, tag, and checksum-manifest identities must agree
- detail `installable:false` adds a denial before checksum or documentation fetches
- stale route requests are aborted and ignored
- malformed optional checksum/docs data is omitted without authorizing or crashing the page

## Remote validation

All executable validation ran only on `davida@20.14.133.241` in preserved quarantine:

`/tmp/clawsec-web-catalog.Uzbumv/source`

The remote checkout was pinned to projection head `ffe6281d809d980521a5375b7bf16777838cbe40`. Only the six reviewed files were transferred, and all post-test SHA-256 values matched the local source.

- `npm ci` — 422 packages, 0 vulnerabilities
- `node scripts/test-web-catalog-installability.mjs` — 64/64 assertions passed
- every `scripts/test-skill-*.mjs` — passed
- release-bundle verifier — all 19 hostile archive cases passed
- real catalog generation — NanoClaw `false`, legacy-absent Suite `true`
- `npx eslint . --ext .ts,.tsx,.js,.jsx,.mjs --max-warnings 0` — passed
- `npx tsc --noEmit` — passed
- `npm run build` — passed; 115 wiki exports generated

An ephemeral Playwright/Chromium installation was created only under the remote quarantine, outside the repository. Final rendered checks passed:

- NanoClaw direct detail shows `Historical — not installable`
- NanoClaw makes zero per-skill asset requests and exposes no install/copy/platform/trigger/documentation UI
- NanoClaw catalog card remains discoverable with historical labeling and no platform badge
- Suite retains the existing Quick Install path
- malformed-index and missing-record direct routes render the blocked state and make zero per-skill asset requests

The full skill-suite run used the previously reviewed narrow `zip -qr <archive> .` compatibility wrapper with SHA-256 `472456191504d886c5871da3e900797512ab9266b8426d736c6a0f48248046b0` because the remote host's system `zip` is incompatible with the tag-release simulation.

## Release impact

No tags, releases, publications, store writes, or merges are performed by this PR.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enforce the catalog <code>installable</code> lifecycle across <code>SkillCard</code>, <code>SkillsCatalog</code>, and <code>SkillDetail</code> so install actions, platform affordances, and rendered documentation only appear for authorized skills. Centralize catalog/detail verification in <code>skillCatalogInstallability</code> to keep denied records as historical evidence and block malformed or missing direct routes.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/312?tool=ast&topic=Catalog+flow>Catalog flow</a>
        </td><td>Gate the catalog cards and detail page on the verified lifecycle so non-installable skills show historical labeling, hide install/copy/docs UI, and fail closed on bad routes.<details><summary>Modified files (3)</summary><ul><li>components/SkillCard.tsx</li>
<li>pages/SkillDetail.tsx</li>
<li>pages/SkillsCatalog.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(web): enforce cata...</td><td>July 22, 2026</td></tr>
<tr><td>david@abutbul.com</td><td>fix(release): exclude ...</td><td>May 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/312?tool=ast&topic=Lifecycle+loader>Lifecycle loader</a>
        </td><td>Add lifecycle parsing and loading helpers that validate index/detail identities, suppress optional fetches, and lock in the blocked versus historical views with executable coverage.<details><summary>Modified files (3)</summary><ul><li>scripts/test-web-catalog-installability.mjs</li>
<li>types.ts</li>
<li>utils/skillCatalogInstallability.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(web): enforce cata...</td><td>July 22, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>feat(advisories): add ...</td><td>May 24, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/312?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>