### PR TITLE
test(release): derive suite simulation version

### DIFF
--- a/scripts/test-skill-tag-release-simulation.mjs
+++ b/scripts/test-skill-tag-release-simulation.mjs
@@ -26,6 +26,21 @@ function cloneJson(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
+async function stablePatchFixture(skillDir) {
+  const skill = JSON.parse(await readFile(path.join(skillDir, "skill.json"), "utf8"));
+  const version = typeof skill.version === "string" ? skill.version : "";
+  const match = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(version);
+  assert.ok(
+    match,
+    `${skill.name} tag-release fixture must start from a final SemVer`,
+  );
+
+  return {
+    expectedOriginal: version,
+    expectedSimulated: `${match[1]}.${match[2]}.${BigInt(match[3]) + 1n}`,
+  };
+}
+
 async function prereleaseFixture(sourceSkillDir, version, fixtureGroup) {
   const fixtureDir = path.join(tempRoot, fixtureGroup, path.basename(sourceSkillDir));
   await cp(sourceSkillDir, fixtureDir, { recursive: true });
@@ -556,11 +571,11 @@ process.stdout.write(readFileSync(inspectFile, "utf8"));
   );
   await chmod(fakeClawhub, 0o700);
 
+  const suiteVersionFixture = await stablePatchFixture("skills/clawsec-suite");
   await runSimulation({
     skillDir: "skills/clawsec-suite",
     outputDir: path.join(tempRoot, "stable"),
-    expectedOriginal: "0.1.16",
-    expectedSimulated: "0.1.17",
+    ...suiteVersionFixture,
     expectedAgents: ["openclaw"],
     verifyReleaseBundle: true,
     verifyEmbeddedAdvisory: true,


### PR DESCRIPTION
# User description
## Summary

- derive the Suite tag-release simulation input from the current `skill.json` version
- require a canonical final `major.minor.patch` version before simulating a stable patch release
- compute the expected next patch with a test-local regex and `BigInt`, independent of production increment logic

## Why

The shared release simulation hard-coded `clawsec-suite` as `0.1.16 -> 0.1.17`. Any legitimate Suite version bump made the shared test fail even though the production simulator correctly derived the next patch. This keeps the test meaningful without requiring version-specific churn in every changed-skill PR.

## Scope

This changes one shared test file only. It does not change a skill, release workflow, simulator, SemVer helper, tag, publication, or catalog.

## Remote validation

- fresh detached checkout at `ffe6281d809d980521a5375b7bf16777838cbe40`
- transferred file SHA-256: `e84d35ea1400b516e693b5e45bb4eaae588eb4a4a2a54beda5cada4027d16cb8`
- `node scripts/test-skill-release-semver.mjs`
- `node scripts/test-skill-tag-release-simulation.mjs`
- every `scripts/test-skill-*.mjs` regression, using a narrowly scoped test-only `zip -qr <archive> .` wrapper because the remote host has `7z` but no `zip`
- `npx eslint scripts/test-skill-tag-release-simulation.mjs --max-warnings 0`
- combined proof with the dependent Suite `0.1.17` candidate: all shared skill-release regressions passed and the simulator advanced it to `0.1.18`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Derive the shared Suite tag-release simulation input from <code>skill.json</code> so the release simulator validates the current stable version instead of a hard-coded patch. Add a test-local final-SemVer check and compute the next patch with regex plus <code>BigInt</code> before running <code>runSimulation</code>.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>test(release): derive ...</td><td>July 22, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(release): publish ...</td><td>July 14, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/313?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>