### PR TITLE
fix(release): block public prerelease tags

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -1098,8 +1098,66 @@ jobs:
             echo "::endgroup::"
           done
 
+  stable-publication-policy:
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.policy.outputs.tag }}
+      skill_name: ${{ steps.policy.outputs.skill_name }}
+      version: ${{ steps.policy.outputs.version }}
+      publication_eligible: ${{ steps.policy.outputs.publication_eligible }}
+      reason_code: ${{ steps.policy.outputs.reason_code }}
+    steps:
+      - name: Checkout protected default-branch policy
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+
+      - name: Enforce final-version public tag policy
+        id: policy
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_REF: ${{ github.ref }}
+          REQUESTED_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          decision="$(node scripts/ci/stable_tag_policy.mjs --tag "$REQUESTED_TAG")"
+          printf '%s\n' "$decision" | jq -e \
+            '.publication_eligible == true and .stable_authorized == false' >/dev/null
+
+          validated_tag="$(printf '%s\n' "$decision" | jq -r '.tag')"
+          skill_name="$(printf '%s\n' "$decision" | jq -r '.package_name')"
+          version="$(printf '%s\n' "$decision" | jq -r '.version')"
+          reason_code="$(printf '%s\n' "$decision" | jq -r '.reason_code')"
+
+          if [ "$EVENT_NAME" = "push" ]; then
+            test "$REQUESTED_REF" = "refs/tags/${validated_tag}"
+          else
+            git show-ref --verify --quiet "refs/tags/${validated_tag}"
+          fi
+
+          {
+            printf 'tag=%s\n' "$validated_tag"
+            printf 'skill_name=%s\n' "$skill_name"
+            printf 'version=%s\n' "$version"
+            printf 'publication_eligible=true\n'
+            printf 'reason_code=%s\n' "$reason_code"
+          } >> "$GITHUB_OUTPUT"
+
   release-tag:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: stable-publication-policy
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1113,23 +1171,24 @@ jobs:
       publish_clawhub: ${{ steps.publishable.outputs.publish_clawhub }}
       clawhub_slug: ${{ steps.publishable.outputs.clawhub_slug }}
     steps:
-      - name: Parse tag
+      - name: Use validated stable publication policy outputs
         id: parse
+        env:
+          VALIDATED_TAG: ${{ needs.stable-publication-policy.outputs.tag }}
+          VALIDATED_SKILL_NAME: ${{ needs.stable-publication-policy.outputs.skill_name }}
+          VALIDATED_VERSION: ${{ needs.stable-publication-policy.outputs.version }}
         run: |
-          TAG="${{ github.ref_name }}"
-          # Extract skill name (everything before -v)
-          SKILL_NAME="${TAG%-v*}"
-          # Extract version (everything after -v)
-          VERSION="${TAG#*-v}"
-
-          echo "skill_name=${SKILL_NAME}" >> $GITHUB_OUTPUT
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "skill_path=skills/${SKILL_NAME}" >> $GITHUB_OUTPUT
-
-          echo "Parsed tag: skill=${SKILL_NAME}, version=${VERSION}"
+          set -euo pipefail
+          printf 'skill_name=%s\n' "$VALIDATED_SKILL_NAME" >> "$GITHUB_OUTPUT"
+          printf 'version=%s\n' "$VALIDATED_VERSION" >> "$GITHUB_OUTPUT"
+          printf 'skill_path=skills/%s\n' "$VALIDATED_SKILL_NAME" >> "$GITHUB_OUTPUT"
+          printf 'Validated tag: %s\n' "$VALIDATED_TAG"
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/tags/${{ needs.stable-publication-policy.outputs.tag }}
+          persist-credentials: false
 
       - name: Verify signing key consistency (repo + docs)
         run: ./scripts/ci/verify_signing_key_consistency.sh
@@ -1332,7 +1391,7 @@ jobs:
           SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
           SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
           VERSION="${{ steps.parse.outputs.version }}"
-          TAG="${{ github.ref_name }}"
+          TAG="${{ needs.stable-publication-policy.outputs.tag }}"
 
           mkdir -p release-assets
 
@@ -1627,7 +1686,7 @@ jobs:
           CLAWHUB_SLUG="${{ steps.publishable.outputs.clawhub_slug }}"
           VERSION="${{ steps.parse.outputs.version }}"
           REPO="${{ github.repository }}"
-          TAG="${{ github.ref_name }}"
+          TAG="${{ needs.stable-publication-policy.outputs.tag }}"
 
           {
             echo "quick_install<<INSTALL_EOF"
@@ -1712,7 +1771,7 @@ jobs:
           CHANGELOG: ${{ steps.changelog.outputs.changelog }}
           QUICK_INSTALL: ${{ steps.install.outputs.quick_install }}
           REPO: ${{ github.repository }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ needs.stable-publication-policy.outputs.tag }}
         run: |
           set -euo pipefail
           node -e '
@@ -1757,11 +1816,11 @@ jobs:
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: "${{ steps.parse.outputs.skill_name }} ${{ steps.parse.outputs.version }}"
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ needs.stable-publication-policy.outputs.tag }}
           files: release-assets/*
           body_path: ${{ runner.temp }}/skill-release-body.md
           draft: false
-          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+          prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -1769,8 +1828,12 @@ jobs:
     # Separate blocking job for ClawHub publishing - runs after GitHub release.
     # It publishes the verified GitHub release payload, never the raw source directory.
     # Retriggerable: can be manually triggered for failed publishes.
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    needs: release-tag
+    if: >-
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/') &&
+      needs.stable-publication-policy.outputs.publication_eligible == 'true' &&
+      needs.release-tag.outputs.publish_clawhub == 'true'
+    needs: [stable-publication-policy, release-tag]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1786,6 +1849,9 @@ jobs:
       - name: Checkout
         if: needs.release-tag.outputs.publish_clawhub == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/tags/${{ needs.stable-publication-policy.outputs.tag }}
+          persist-credentials: false
 
       - name: Setup Node
         if: needs.release-tag.outputs.publish_clawhub == 'true'
@@ -1802,7 +1868,7 @@ jobs:
           set -euo pipefail
           SKILL_NAME="${{ needs.release-tag.outputs.skill_name }}"
           VERSION="${{ needs.release-tag.outputs.version }}"
-          TAG="${{ github.ref_name }}"
+          TAG="${{ needs.stable-publication-policy.outputs.tag }}"
           RELEASE_DIR="$RUNNER_TEMP/clawhub-release"
           OUTPUT_DIR="$RUNNER_TEMP/clawhub-package"
 
@@ -1958,30 +2024,34 @@ jobs:
   republish-clawhub:
     # Manual workflow to republish a specific tag to ClawHub
     # Usage: Go to Actions → Skill Release → Run workflow → Enter tag name
-    if: github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      needs.stable-publication-policy.outputs.publication_eligible == 'true'
+    needs: stable-publication-policy
     runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
       CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
     steps:
-      - name: Parse tag
+      - name: Use validated stable publication policy outputs
         id: parse
+        env:
+          VALIDATED_TAG: ${{ needs.stable-publication-policy.outputs.tag }}
+          VALIDATED_SKILL_NAME: ${{ needs.stable-publication-policy.outputs.skill_name }}
+          VALIDATED_VERSION: ${{ needs.stable-publication-policy.outputs.version }}
         run: |
-          TAG="${{ github.event.inputs.tag }}"
-          # Extract skill name (everything before -v)
-          SKILL_NAME="${TAG%-v*}"
-          # Extract version (everything after -v)
-          VERSION="${TAG#*-v}"
-
-          echo "skill_name=${SKILL_NAME}" >> $GITHUB_OUTPUT
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "skill_path=skills/${SKILL_NAME}" >> $GITHUB_OUTPUT
-
-          echo "Parsed tag: skill=${SKILL_NAME}, version=${VERSION}"
+          set -euo pipefail
+          printf 'skill_name=%s\n' "$VALIDATED_SKILL_NAME" >> "$GITHUB_OUTPUT"
+          printf 'version=%s\n' "$VALIDATED_VERSION" >> "$GITHUB_OUTPUT"
+          printf 'skill_path=skills/%s\n' "$VALIDATED_SKILL_NAME" >> "$GITHUB_OUTPUT"
+          printf 'Validated tag: %s\n' "$VALIDATED_TAG"
 
       - name: Checkout workflow helpers
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Prepare current ClawHub workflow helpers
         run: |
@@ -1995,7 +2065,8 @@ jobs:
       - name: Checkout tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.inputs.tag }}
+          ref: refs/tags/${{ needs.stable-publication-policy.outputs.tag }}
+          persist-credentials: false
 
       - name: Validate skill exists
         run: |
@@ -2045,7 +2116,7 @@ jobs:
           set -euo pipefail
           SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
           VERSION="${{ steps.parse.outputs.version }}"
-          TAG="${{ github.event.inputs.tag }}"
+          TAG="${{ needs.stable-publication-policy.outputs.tag }}"
           RELEASE_DIR="$RUNNER_TEMP/clawhub-release"
           OUTPUT_DIR="$RUNNER_TEMP/clawhub-package"
 

--- a/scripts/ci/stable_tag_policy.mjs
+++ b/scripts/ci/stable_tag_policy.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  evaluatePublicationVersion,
+  parsePackageTag,
+} from "./lifecycle_semver.mjs";
+
+export const STABLE_TAG_POLICY = "clawsec.stable-tag-policy/v1";
+export const LEGACY_PRERELEASE_INVENTORY_SHA256 =
+  "f688f138685126e6bb234151f7fa5d737096b525191922ad06d2cfaa49ba1720";
+
+const DEFAULT_INVENTORY_PATH = fileURLToPath(
+  new URL("../../contracts/release-policy/legacy-prereleases-v1.json", import.meta.url),
+);
+const REQUIRED_DENIAL_FIELDS = [
+  "authorization_granted",
+  "public_write_authorized",
+  "tag_creation_permitted",
+  "github_release_creation_permitted",
+  "store_publication_permitted",
+  "catalog_activation_permitted",
+  "active_resolution",
+  "discovery_publication_permitted",
+  "republish_permitted",
+  "ref_or_asset_mutation_permitted",
+];
+
+function policyError(message) {
+  return new Error(`Legacy prerelease inventory rejected: ${message}`);
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function validateLegacyPrereleaseInventory(inventory) {
+  if (!isObject(inventory)) {
+    throw policyError("root must be an object");
+  }
+  if (inventory.schema !== "clawsec.legacy-prerelease-inventory/v1") {
+    throw policyError("unexpected schema");
+  }
+  if (!isObject(inventory.policy)) {
+    throw policyError("policy must be an object");
+  }
+  if (inventory.policy.classification !== "frozen_legacy_public_prerelease_history") {
+    throw policyError("unexpected policy classification");
+  }
+  if (inventory.policy.retention !== "fetchable_history") {
+    throw policyError("unexpected retention policy");
+  }
+  if (inventory.policy.historical_fetch_only !== true) {
+    throw policyError("history must be fetch-only");
+  }
+  for (const field of REQUIRED_DENIAL_FIELDS) {
+    if (inventory.policy[field] !== false) {
+      throw policyError(`${field} must be exactly false`);
+    }
+  }
+  if (!Array.isArray(inventory.tags) || inventory.tags.length === 0) {
+    throw policyError("tags must be a non-empty array");
+  }
+  if (!isObject(inventory.counts) || inventory.counts.tags !== inventory.tags.length) {
+    throw policyError("tag count mismatch");
+  }
+
+  const historicalTags = new Set();
+  for (const record of inventory.tags) {
+    if (!isObject(record) || typeof record.name !== "string" || record.name.length === 0) {
+      throw policyError("every tag record must have a non-empty name");
+    }
+    if (historicalTags.has(record.name)) {
+      throw policyError("duplicate tag name");
+    }
+    let parsed;
+    try {
+      parsed = parsePackageTag(record.name);
+    } catch {
+      throw policyError("historical tag must remain a valid package-qualified tag");
+    }
+    const publication = evaluatePublicationVersion(parsed.version);
+    if (publication.publicPublicationEligible) {
+      throw policyError("historical inventory must not contain a publication-eligible tag");
+    }
+    historicalTags.add(record.name);
+  }
+
+  return historicalTags;
+}
+
+export async function loadLegacyPrereleaseInventory(inventoryPath = DEFAULT_INVENTORY_PATH) {
+  let raw;
+  try {
+    raw = await readFile(inventoryPath, "utf8");
+  } catch {
+    throw policyError("snapshot is unavailable");
+  }
+
+  const digest = createHash("sha256").update(raw).digest("hex");
+  if (digest !== LEGACY_PRERELEASE_INVENTORY_SHA256) {
+    throw policyError("snapshot digest does not match the reviewed policy data");
+  }
+
+  let inventory;
+  try {
+    inventory = JSON.parse(raw);
+  } catch {
+    throw policyError("snapshot is not valid JSON");
+  }
+  return {
+    inventory,
+    historicalTags: validateLegacyPrereleaseInventory(inventory),
+    digest,
+  };
+}
+
+function deniedDecision(reasonCode, overrides = {}) {
+  return {
+    policy: STABLE_TAG_POLICY,
+    publication_eligible: false,
+    stable_authorized: false,
+    historical_fetch_only: false,
+    reason_code: reasonCode,
+    package_name: null,
+    version: null,
+    tag: null,
+    ...overrides,
+  };
+}
+
+export function evaluateStableTagPolicy({ tag, historicalTags } = {}) {
+  if (!(historicalTags instanceof Set)) {
+    throw new Error("historicalTags must be a validated Set");
+  }
+
+  let parsedTag;
+  try {
+    parsedTag = parsePackageTag(tag);
+  } catch {
+    return deniedDecision("invalid_package_tag");
+  }
+
+  const identity = {
+    tag: parsedTag.raw,
+    package_name: parsedTag.packageName,
+    version: parsedTag.version,
+  };
+  if (historicalTags.has(parsedTag.raw)) {
+    return deniedDecision("frozen_legacy_history_non_authorized", {
+      ...identity,
+      historical_fetch_only: true,
+    });
+  }
+
+  const publication = evaluatePublicationVersion(parsedTag.version);
+  return {
+    policy: STABLE_TAG_POLICY,
+    publication_eligible: publication.publicPublicationEligible,
+    stable_authorized: false,
+    historical_fetch_only: false,
+    reason_code: publication.reasonCode,
+    lifecycle_class: publication.lifecycleClass,
+    ...identity,
+  };
+}
+
+function parseArguments(argv) {
+  let tag;
+  let inventoryPath = DEFAULT_INVENTORY_PATH;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--tag" && tag === undefined && index + 1 < argv.length) {
+      tag = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (
+      argument === "--inventory"
+      && inventoryPath === DEFAULT_INVENTORY_PATH
+      && index + 1 < argv.length
+    ) {
+      inventoryPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    throw new Error("usage: stable_tag_policy.mjs --tag <package-vversion> [--inventory <path>]");
+  }
+
+  if (tag === undefined) {
+    throw new Error("usage: stable_tag_policy.mjs --tag <package-vversion> [--inventory <path>]");
+  }
+  return { tag, inventoryPath };
+}
+
+async function main() {
+  try {
+    const { tag, inventoryPath } = parseArguments(process.argv.slice(2));
+    const { historicalTags } = await loadLegacyPrereleaseInventory(inventoryPath);
+    const decision = evaluateStableTagPolicy({ tag, historicalTags });
+    process.stdout.write(`${JSON.stringify(decision)}\n`);
+    if (!decision.publication_eligible) {
+      process.stderr.write(
+        `Stable tag policy denied public publication: ${decision.reason_code}\n`,
+      );
+      process.exitCode = 2;
+    }
+  } catch (error) {
+    process.stderr.write(`Stable tag policy unavailable: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/release-skill.sh
+++ b/scripts/release-skill.sh
@@ -75,19 +75,21 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
+TAG="${SKILL_NAME}-v${VERSION}"
+
+# This is the public release helper, not the private beta/RC candidate builder.
+# Enforce the shared stable-tag policy before any source, Git, tag, or release mutation.
+if ! node scripts/ci/stable_tag_policy.mjs --tag "$TAG" >/dev/null; then
+  echo "Error: Public release preparation requires a strict final SemVer tag." >&2
+  echo "Build beta and RC candidates through the private lab-candidate flow." >&2
+  exit 1
+fi
+
 if [[ "$IS_RELEASE_BRANCH" == "true" || "$FORCE_TAG" == "true" ]]; then
   INSTALLABLE="$(node scripts/ci/skill_installability.mjs "$SKILL_PATH" --require-publication)"
 else
   INSTALLABLE="$(node scripts/ci/skill_installability.mjs "$SKILL_PATH")"
 fi
-
-# Validate semver format (supports prerelease like 1.0.0-beta1)
-if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
-  echo "Error: Invalid version format. Use semver (e.g., 1.0.0, 1.1.0-beta1)"
-  exit 1
-fi
-
-TAG="${SKILL_NAME}-v${VERSION}"
 
 # Check for uncommitted changes in skill directory
 if ! git diff --quiet "$SKILL_PATH/" 2>/dev/null; then

--- a/scripts/test-skill-release-script-installability.mjs
+++ b/scripts/test-skill-release-script-installability.mjs
@@ -17,6 +17,7 @@ const fixtureRoot = await mkdtemp(path.join(tmpdir(), "clawsec-release-script-in
 const skillDir = path.join(fixtureRoot, "skills", "retired-skill");
 const scriptsDir = path.join(fixtureRoot, "scripts");
 const ciDir = path.join(scriptsDir, "ci");
+const releasePolicyDir = path.join(fixtureRoot, "contracts", "release-policy");
 const fakeBinDir = path.join(fixtureRoot, "fake-bin");
 const ghAttemptPath = path.join(fixtureRoot, "gh-attempted");
 const childPath = `${fakeBinDir}:${path.dirname(process.execPath)}:${process.env.PATH ?? ""}`;
@@ -43,11 +44,18 @@ try {
   await Promise.all([
     mkdir(skillDir, { recursive: true }),
     mkdir(ciDir, { recursive: true }),
+    mkdir(releasePolicyDir, { recursive: true }),
     mkdir(fakeBinDir, { recursive: true }),
   ]);
   await Promise.all([
     cp("scripts/release-skill.sh", path.join(scriptsDir, "release-skill.sh")),
     cp("scripts/ci/skill_installability.mjs", path.join(ciDir, "skill_installability.mjs")),
+    cp("scripts/ci/stable_tag_policy.mjs", path.join(ciDir, "stable_tag_policy.mjs")),
+    cp("scripts/ci/lifecycle_semver.mjs", path.join(ciDir, "lifecycle_semver.mjs")),
+    cp(
+      "contracts/release-policy/legacy-prereleases-v1.json",
+      path.join(releasePolicyDir, "legacy-prereleases-v1.json"),
+    ),
     writeFile(
       path.join(skillDir, "skill.json"),
       `${JSON.stringify({

--- a/scripts/test-skill-stable-tag-policy.mjs
+++ b/scripts/test-skill-stable-tag-policy.mjs
@@ -1,0 +1,425 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import {
+  chmod,
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  LEGACY_PRERELEASE_INVENTORY_SHA256,
+  evaluateStableTagPolicy,
+  loadLegacyPrereleaseInventory,
+  validateLegacyPrereleaseInventory,
+} from "./ci/stable_tag_policy.mjs";
+
+const helperPath = fileURLToPath(new URL("./ci/stable_tag_policy.mjs", import.meta.url));
+const workflowPath = fileURLToPath(
+  new URL("../.github/workflows/skill-release.yml", import.meta.url),
+);
+const releaseScriptPath = fileURLToPath(new URL("./release-skill.sh", import.meta.url));
+const inventoryPath = fileURLToPath(
+  new URL("../contracts/release-policy/legacy-prereleases-v1.json", import.meta.url),
+);
+const lifecyclePath = fileURLToPath(new URL("./ci/lifecycle_semver.mjs", import.meta.url));
+const installabilityPath = fileURLToPath(
+  new URL("./ci/skill_installability.mjs", import.meta.url),
+);
+
+function requiredIndex(text, needle, message) {
+  const index = text.indexOf(needle);
+  assert.notEqual(index, -1, message);
+  return index;
+}
+
+function runHelper(...args) {
+  return spawnSync(process.execPath, [helperPath, ...args], {
+    encoding: "utf8",
+  });
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+const {
+  inventory,
+  historicalTags,
+  digest: inventoryDigest,
+} = await loadLegacyPrereleaseInventory();
+assert.equal(inventoryDigest, LEGACY_PRERELEASE_INVENTORY_SHA256);
+assert.equal(historicalTags.size, 15);
+
+for (const tag of historicalTags) {
+  const decision = evaluateStableTagPolicy({ tag, historicalTags });
+  assert.equal(decision.publication_eligible, false, `${tag} must remain denied`);
+  assert.equal(decision.stable_authorized, false);
+  assert.equal(decision.historical_fetch_only, true);
+  assert.equal(decision.reason_code, "frozen_legacy_history_non_authorized");
+}
+
+for (const [tag, packageName, version] of [
+  ["clawsec-suite-v0.1.0", "clawsec-suite", "0.1.0"],
+  ["clawsec-suite-v0.0.0", "clawsec-suite", "0.0.0"],
+  ["agent-v-tools-v1.2.3", "agent-v-tools", "1.2.3"],
+  [
+    "clawsec-core-openclaw-v18446744073709551616.99999999999999999999.0",
+    "clawsec-core-openclaw",
+    "18446744073709551616.99999999999999999999.0",
+  ],
+]) {
+  const decision = evaluateStableTagPolicy({ tag, historicalTags });
+  assert.equal(decision.publication_eligible, true, `${tag} should pass the temporary gate`);
+  assert.equal(decision.stable_authorized, false, "final SemVer is not stable authorization");
+  assert.equal(decision.reason_code, "final_version_eligible_not_authorized");
+  assert.equal(decision.package_name, packageName);
+  assert.equal(decision.version, version);
+  assert.equal(decision.tag, tag);
+}
+
+const deniedValidTags = new Map([
+  ["clawsec-suite-v0.2.0-beta.1", "candidate_prerelease_lab_only"],
+  ["clawsec-suite-v0.2.0-rc.1", "candidate_prerelease_lab_only"],
+  ["clawsec-suite-v0.2.0-beta1", "legacy_prerelease_non_authorized"],
+  ["clawsec-suite-v0.2.0-rc1", "legacy_prerelease_non_authorized"],
+  ["clawsec-suite-v0.2.0-alpha.1", "legacy_prerelease_non_authorized"],
+  ["clawsec-suite-v0.2.0-preview", "legacy_prerelease_non_authorized"],
+  ["clawsec-suite-v0.2.0-canary.7", "legacy_prerelease_non_authorized"],
+  ["clawsec-suite-v0.2.0-nightly.20260723", "legacy_prerelease_non_authorized"],
+  ["clawsec-suite-v0.2.0-dev", "legacy_prerelease_non_authorized"],
+  ["clawsec-suite-v0.2.0-beta-1", "legacy_prerelease_non_authorized"],
+  ["clawsec-suite-v0.2.0-beta.1.extra", "legacy_prerelease_non_authorized"],
+  ["clawsec-suite-v0.2.0-1", "legacy_prerelease_non_authorized"],
+  ["clawsec-suite-v0.2.0+build.1", "build_metadata_disallowed"],
+  ["clawsec-suite-v0.2.0-beta.1+build.1", "build_metadata_disallowed"],
+]);
+
+for (const [tag, reasonCode] of deniedValidTags) {
+  const decision = evaluateStableTagPolicy({ tag, historicalTags });
+  assert.equal(decision.publication_eligible, false, `${tag} must be denied`);
+  assert.equal(decision.stable_authorized, false);
+  assert.equal(decision.reason_code, reasonCode);
+}
+
+for (const tag of [
+  "",
+  "v1.2.3",
+  "clawsec-suite-1.2.3",
+  "clawsec-suite-v1.2",
+  "clawsec-suite-v01.2.3",
+  "ClawSec-suite-v1.2.3",
+  "clawsec_suite-v1.2.3",
+  "clawsec-suite-V1.2.3",
+  "clawsec-suite-v1.2.3-beta.01",
+  " clawsec-suite-v1.2.3",
+  "clawsec-suite-v1.2.3 ",
+  "clawsec-suite-v1.2.3\noutput=true",
+  "clawsec-suite-v1.2.3\t",
+  "clawsec-suite-v1.2.3\u00a0",
+  "clawsec-suite-v1.2.3\u200b",
+  "clawsec-suite-ｖ1.2.3",
+  "clawsec-suite-v１.２.３",
+  "clawsec-suite-v1.2.3;echo-owned",
+  "clawsec-suite-v1.2.3$(touch-owned)",
+  'clawsec-suite-v1.2.3"',
+]) {
+  const decision = evaluateStableTagPolicy({ tag, historicalTags });
+  assert.equal(decision.publication_eligible, false, `malformed tag must fail: ${JSON.stringify(tag)}`);
+  assert.equal(decision.reason_code, "invalid_package_tag");
+  assert.equal(decision.tag, null, "invalid input must not be reflected into workflow outputs");
+}
+
+const requiredFalseFields = [
+  "authorization_granted",
+  "public_write_authorized",
+  "tag_creation_permitted",
+  "github_release_creation_permitted",
+  "store_publication_permitted",
+  "catalog_activation_permitted",
+  "active_resolution",
+  "discovery_publication_permitted",
+  "republish_permitted",
+  "ref_or_asset_mutation_permitted",
+];
+for (const field of requiredFalseFields) {
+  for (const unsafeValue of [true, "false", 0, null]) {
+    const changed = cloneJson(inventory);
+    changed.policy[field] = unsafeValue;
+    assert.throws(
+      () => validateLegacyPrereleaseInventory(changed),
+      new RegExp(`${field} must be exactly false`),
+    );
+  }
+}
+
+for (const [field, unsafeValue] of [
+  ["historical_fetch_only", false],
+  ["classification", "authorized_history"],
+  ["retention", "republishable"],
+]) {
+  const changed = cloneJson(inventory);
+  changed.policy[field] = unsafeValue;
+  assert.throws(() => validateLegacyPrereleaseInventory(changed));
+}
+
+const duplicateInventory = cloneJson(inventory);
+duplicateInventory.tags.push(cloneJson(duplicateInventory.tags[0]));
+duplicateInventory.counts.tags += 1;
+assert.throws(
+  () => validateLegacyPrereleaseInventory(duplicateInventory),
+  /duplicate tag name/,
+);
+
+const finalVersionInventory = cloneJson(inventory);
+finalVersionInventory.tags[0].name = "clawsec-suite-v9.9.9";
+assert.throws(
+  () => validateLegacyPrereleaseInventory(finalVersionInventory),
+  /must not contain a publication-eligible tag/,
+);
+
+const allowedCli = runHelper("--tag", "agent-v-tools-v1.2.3");
+assert.equal(allowedCli.status, 0, allowedCli.stderr);
+assert.equal(JSON.parse(allowedCli.stdout).publication_eligible, true);
+
+const deniedCli = runHelper(
+  "--tag",
+  "hermes-traffic-guardian-v0.0.1-beta5",
+);
+assert.equal(deniedCli.status, 2);
+assert.equal(JSON.parse(deniedCli.stdout).historical_fetch_only, true);
+assert.match(deniedCli.stderr, /frozen_legacy_history_non_authorized/);
+
+const injectionCli = runHelper("--tag", "clawsec-suite-v1.2.3\noutput=true");
+assert.equal(injectionCli.status, 2);
+assert.equal(JSON.parse(injectionCli.stdout).tag, null);
+assert.doesNotMatch(injectionCli.stderr, /output=true/);
+
+const badArgsCli = runHelper("--unknown", "value");
+assert.equal(badArgsCli.status, 1);
+assert.match(badArgsCli.stderr, /usage:/);
+
+const tamperedDir = await mkdtemp(path.join(tmpdir(), "clawsec-stable-tag-tampered-"));
+try {
+  const tamperedPath = path.join(tamperedDir, "inventory.json");
+  await writeFile(
+    tamperedPath,
+    `${(await readFile(inventoryPath, "utf8")).trimEnd()} \n`,
+    "utf8",
+  );
+  await assert.rejects(
+    () => loadLegacyPrereleaseInventory(tamperedPath),
+    /snapshot digest does not match/,
+  );
+  const tamperedCli = runHelper(
+    "--tag",
+    "clawsec-suite-v1.2.3",
+    "--inventory",
+    tamperedPath,
+  );
+  assert.equal(tamperedCli.status, 1);
+  assert.match(tamperedCli.stderr, /snapshot digest does not match/);
+} finally {
+  await rm(tamperedDir, { recursive: true, force: true });
+}
+
+const workflow = await readFile(workflowPath, "utf8");
+const releaseScript = await readFile(releaseScriptPath, "utf8");
+const policyJobStart = requiredIndex(
+  workflow,
+  "  stable-publication-policy:",
+  "workflow must define a read-only stable publication policy job",
+);
+const releaseJobStart = requiredIndex(workflow, "  release-tag:", "release-tag job must exist");
+const publishJobStart = requiredIndex(
+  workflow,
+  "  publish-clawhub:",
+  "publish-clawhub job must exist",
+);
+const republishJobStart = requiredIndex(
+  workflow,
+  "  republish-clawhub:",
+  "republish-clawhub job must exist",
+);
+assert.ok(policyJobStart < releaseJobStart);
+assert.ok(releaseJobStart < publishJobStart);
+assert.ok(publishJobStart < republishJobStart);
+
+const policyJob = workflow.slice(policyJobStart, releaseJobStart);
+const releaseJob = workflow.slice(releaseJobStart, publishJobStart);
+const publishJob = workflow.slice(publishJobStart, republishJobStart);
+const republishJob = workflow.slice(republishJobStart);
+
+assert.match(policyJob, /permissions:\n\s+contents: read/);
+assert.doesNotMatch(policyJob, /contents: write|pages: write|id-token: write|secrets\.|CLAWHUB_TOKEN/);
+assert.match(policyJob, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
+assert.match(policyJob, /fetch-depth: 0[\s\S]*persist-credentials: false/);
+assert.match(policyJob, /REQUESTED_TAG: \$\{\{ github\.event_name == 'workflow_dispatch'/);
+assert.match(policyJob, /stable_tag_policy\.mjs --tag "\$REQUESTED_TAG"/);
+assert.match(policyJob, /git show-ref --verify --quiet "refs\/tags\/\$\{validated_tag\}"/);
+assert.match(policyJob, /"\$REQUESTED_REF" = "refs\/tags\/\$\{validated_tag\}"/);
+
+assert.match(releaseJob, /needs: stable-publication-policy/);
+assert.match(releaseJob, /permissions:\n\s+contents: write/);
+assert.match(releaseJob, /VALIDATED_TAG: \$\{\{ needs\.stable-publication-policy\.outputs\.tag \}\}/);
+assert.doesNotMatch(releaseJob, /github\.ref_name|github\.event\.inputs\.tag/);
+assert.match(
+  releaseJob,
+  /ref: refs\/tags\/\$\{\{ needs\.stable-publication-policy\.outputs\.tag \}\}/,
+);
+assert.match(releaseJob, /tag_name: \$\{\{ needs\.stable-publication-policy\.outputs\.tag \}\}/);
+assert.match(releaseJob, /prerelease: false/);
+
+assert.match(publishJob, /needs: \[stable-publication-policy, release-tag\]/);
+assert.match(publishJob, /needs\.stable-publication-policy\.outputs\.publication_eligible == 'true'/);
+assert.match(publishJob, /CLAWHUB_TOKEN: \$\{\{ secrets\.CLAWHUB_TOKEN \}\}/);
+assert.match(
+  publishJob,
+  /ref: refs\/tags\/\$\{\{ needs\.stable-publication-policy\.outputs\.tag \}\}/,
+);
+
+assert.match(republishJob, /needs: stable-publication-policy/);
+assert.match(republishJob, /needs\.stable-publication-policy\.outputs\.publication_eligible == 'true'/);
+assert.match(republishJob, /VALIDATED_TAG: \$\{\{ needs\.stable-publication-policy\.outputs\.tag \}\}/);
+assert.doesNotMatch(republishJob, /github\.event\.inputs\.tag|github\.ref_name/);
+assert.match(
+  republishJob,
+  /Checkout workflow helpers[\s\S]*ref: \$\{\{ github\.event\.repository\.default_branch \}\}[\s\S]*persist-credentials: false/,
+);
+assert.match(
+  republishJob,
+  /Checkout tag[\s\S]*ref: refs\/tags\/\$\{\{ needs\.stable-publication-policy\.outputs\.tag \}\}[\s\S]*persist-credentials: false/,
+);
+assert.match(republishJob, /CLAWHUB_TOKEN: \$\{\{ secrets\.CLAWHUB_TOKEN \}\}/);
+
+assert.doesNotMatch(
+  workflow,
+  /TAG="\$\{\{ (?:github\.ref_name|github\.event\.inputs\.tag) \}\}"/,
+  "raw event tag strings must never be interpolated into shell source",
+);
+
+const scriptPolicyIndex = requiredIndex(
+  releaseScript,
+  'node scripts/ci/stable_tag_policy.mjs --tag "$TAG"',
+  "release-skill.sh must call the shared stable tag policy",
+);
+for (const [needle, operation] of [
+  ["TEMP_DIR=$(mktemp -d)", "temporary mutation staging"],
+  ['jq --arg v "$VERSION"', "skill metadata write"],
+  ['git add "$file"', "Git staging"],
+  ['git commit -m "chore($SKILL_NAME): bump version to $VERSION"', "Git commit"],
+  ['git tag -a "$TAG"', "tag creation"],
+  ['gh release create "$TAG"', "GitHub Release creation"],
+]) {
+  assert.ok(
+    scriptPolicyIndex < requiredIndex(releaseScript, needle, `${operation} must remain present`),
+    `stable tag policy must run before ${operation}`,
+  );
+}
+assert.doesNotMatch(
+  releaseScript,
+  /Validate semver format \(supports prerelease|Invalid version format\. Use semver|if ! \[\[ "\$VERSION" =~/,
+  "release-skill.sh must not retain a second prerelease parser",
+);
+
+const fixtureRoot = await mkdtemp(path.join(tmpdir(), "clawsec-stable-tag-release-script-"));
+const fixtureSkillDir = path.join(fixtureRoot, "skills", "stable-skill");
+const fixtureCiDir = path.join(fixtureRoot, "scripts", "ci");
+const fixturePolicyDir = path.join(fixtureRoot, "contracts", "release-policy");
+const fakeBinDir = path.join(fixtureRoot, "fake-bin");
+const ghAttemptPath = path.join(fixtureRoot, "gh-attempted");
+const childPath = `${fakeBinDir}:${path.dirname(process.execPath)}:${process.env.PATH ?? ""}`;
+
+function runFixture(command, args) {
+  return spawnSync(command, args, {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    env: { ...process.env, PATH: childPath },
+  });
+}
+
+function runFixtureGit(...args) {
+  const result = runFixture("git", args);
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+try {
+  await Promise.all([
+    mkdir(fixtureSkillDir, { recursive: true }),
+    mkdir(fixtureCiDir, { recursive: true }),
+    mkdir(fixturePolicyDir, { recursive: true }),
+    mkdir(fakeBinDir, { recursive: true }),
+  ]);
+  await Promise.all([
+    cp(releaseScriptPath, path.join(fixtureRoot, "scripts", "release-skill.sh")),
+    cp(helperPath, path.join(fixtureCiDir, "stable_tag_policy.mjs")),
+    cp(lifecyclePath, path.join(fixtureCiDir, "lifecycle_semver.mjs")),
+    cp(installabilityPath, path.join(fixtureCiDir, "skill_installability.mjs")),
+    cp(inventoryPath, path.join(fixturePolicyDir, "legacy-prereleases-v1.json")),
+    writeFile(
+      path.join(fixtureSkillDir, "skill.json"),
+      `${JSON.stringify({ name: "stable-skill", version: "0.1.0", installable: true }, null, 2)}\n`,
+    ),
+    writeFile(
+      path.join(fakeBinDir, "gh"),
+      `#!/bin/sh\nprintf attempted > "${ghAttemptPath}"\nexit 0\n`,
+    ),
+  ]);
+  await chmod(path.join(fakeBinDir, "gh"), 0o700);
+
+  runFixtureGit("init", "--initial-branch=main");
+  runFixtureGit("config", "user.name", "ClawSec Test");
+  runFixtureGit("config", "user.email", "clawsec-test@example.invalid");
+  runFixtureGit("config", "commit.gpgsign", "false");
+  runFixtureGit("config", "tag.gpgsign", "false");
+  runFixtureGit("add", ".");
+  runFixtureGit("commit", "-m", "stable policy fixture");
+
+  const initialHead = runFixtureGit("rev-parse", "HEAD");
+  for (const version of [
+    "0.2.0-beta1",
+    "0.2.0-beta.1",
+    "0.2.0-rc1",
+    "0.2.0-rc.1",
+    "0.2.0-alpha.1",
+    "0.2.0-preview",
+    "0.2.0+build.1",
+    "0.2.0\noutput=true",
+  ]) {
+    const result = runFixture("bash", ["scripts/release-skill.sh", "stable-skill", version]);
+    assert.equal(result.status, 1, `${version} unexpectedly passed\n${result.stdout}\n${result.stderr}`);
+    assert.equal(runFixtureGit("rev-parse", "HEAD"), initialHead);
+    assert.equal(runFixtureGit("status", "--short"), "");
+    assert.equal(runFixtureGit("tag", "--list"), "");
+    assert.equal(existsSync(ghAttemptPath), false);
+  }
+
+  runFixtureGit("switch", "-c", "review/candidate");
+  for (const args of [
+    ["stable-skill", "0.2.0-beta.2"],
+    ["stable-skill", "0.2.0-rc.2", "--force-tag"],
+  ]) {
+    const result = runFixture("bash", ["scripts/release-skill.sh", ...args]);
+    assert.equal(result.status, 1, `feature-branch candidate unexpectedly passed: ${args.join(" ")}`);
+    assert.equal(runFixtureGit("rev-parse", "HEAD"), initialHead);
+    assert.equal(runFixtureGit("status", "--short"), "");
+    assert.equal(runFixtureGit("tag", "--list"), "");
+    assert.equal(existsSync(ghAttemptPath), false);
+  }
+} finally {
+  await rm(fixtureRoot, { recursive: true, force: true });
+}
+
+process.stdout.write(
+  "Stable tag policy tests passed: final versions eligible-not-authorized; prereleases fail closed.\n",
+);


### PR DESCRIPTION
# User description
## Summary

- Add a fail-closed stable-tag policy backed by the reviewed lifecycle parser and frozen legacy-prerelease inventory.
- Gate tag-push releases and manual ClawHub republish in a read-only job before write permissions, signing keys, or store credentials are available.
- Apply the same policy to `scripts/release-skill.sh` before source, Git, tag, or GitHub mutations.
- Cover canonical beta/RC, legacy prereleases, build metadata, malformed and injection-shaped tags, inventory tampering, workflow ordering, and direct-script non-mutation.

## Why

The existing broad tag trigger and manual republish path can accept prerelease-shaped tags and reach public GitHub Release or ClawHub operations. The frozen legacy inventory is historical evidence only; membership must never authorize publication or mutation.

## Security outcome

No new prerelease input can reach the supported GitHub Release or ClawHub publication entrypoints. Strict final SemVer passes only as `final_version_eligible_not_authorized`; this PR does not claim stable authorization.

## Stacked base

This draft targets the integration-only `davida-ps/stable-tag-policy-prereqs-v1` branch, which composes the already separated work from #307, #309, #310, and #315. Retarget this PR to `main` after those prerequisites merge.

Stable tag provenance and authorization remain for `controlled-tag-creation-v1` plus repository tag rules. Independent Pages/catalog stable selection remains a separate unit.

## Remote validation

Validated only on `davida@20.14.133.241` in fresh workspace `/tmp/clawsec-stable-tag-policy.9KpoHn/source`.

- SHA-256 parity confirmed for every composed changed file.
- `bash -n scripts/release-skill.sh`
- Focused stable-tag and release workflow/installability tests
- Every root `scripts/test-skill-*.mjs` test
- Full ESLint with zero warnings
- `npx tsc --noEmit`
- `npm run build`

An independent delegate reviewed the final remote composite and reported no blocker.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce a shared stable-tag policy in <code>scripts/ci/stable_tag_policy.mjs</code> that validates package tags against the frozen legacy prerelease inventory and only classifies final SemVer as publication-eligible. Gate <code>.github/workflows/skill-release.yml</code> and <code>scripts/release-skill.sh</code> on that policy so GitHub Release, ClawHub republish, and tag-mutation paths cannot run from prerelease-shaped input.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/316?tool=ast&topic=Release+gating>Release gating</a>
        </td><td>Gate the release workflow and <code>scripts/release-skill.sh</code> on validated stable-tag outputs before any write permissions, signing keys, or ClawHub credentials are available.<details><summary>Modified files (3)</summary><ul><li>.github/workflows/skill-release.yml</li>
<li>scripts/release-skill.sh</li>
<li>scripts/test-skill-release-script-installability.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(release): block pu...</td><td>July 23, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(release): publish ...</td><td>July 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/316?tool=ast&topic=Tag+policy>Tag policy</a>
        </td><td>Add <code>stable_tag_policy</code> inventory validation and tests to reject prerelease, malformed, injected, and tampered tags while keeping final SemVer non-authorized.<details><summary>Modified files (2)</summary><ul><li>scripts/ci/stable_tag_policy.mjs</li>
<li>scripts/test-skill-stable-tag-policy.mjs</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(release): block pu...</td><td>July 23, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/316?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>