### PR TITLE
feat(release): establish non-installable documentation contract

### DIFF
--- a/scripts/ci/validate_skill_install_docs.mjs
+++ b/scripts/ci/validate_skill_install_docs.mjs
@@ -208,22 +208,21 @@ function stripHtmlComments(markdown) {
   return markdown.replace(/<!--[\s\S]*?(?:-->|$)/g, "");
 }
 
-function isSupportedFrontmatterScalar(value) {
-  const scalar = value.trim();
-  if (
-    !scalar ||
-    /[<>{}]/.test(scalar) ||
-    [...scalar].some((character) => {
-      const codePoint = character.codePointAt(0);
-      return !(
-        (codePoint >= 0x20 && codePoint <= 0x7e) ||
-        codePoint === 0x85 ||
-        (codePoint >= 0xa0 && codePoint <= 0xd7ff) ||
-        (codePoint >= 0xe000 && codePoint <= 0xfffd) ||
-        (codePoint >= 0x10000 && codePoint <= 0x10ffff)
-      );
-    })
-  ) {
+function hasOnlySupportedYamlCharacters(value) {
+  return [...value].every((character) => {
+    const codePoint = character.codePointAt(0);
+    return (
+      (codePoint >= 0x20 && codePoint <= 0x7e) ||
+      codePoint === 0x85 ||
+      (codePoint >= 0xa0 && codePoint <= 0xd7ff) ||
+      (codePoint >= 0xe000 && codePoint <= 0xfffd) ||
+      (codePoint >= 0x10000 && codePoint <= 0x10ffff)
+    );
+  });
+}
+
+function isSupportedFrontmatterScalar(scalar) {
+  if (!scalar || !hasOnlySupportedYamlCharacters(scalar) || /[<>{}]/.test(scalar)) {
     return false;
   }
   if (/^"(?:[^"\\]|\\["\\/bfnrt]|\\u[0-9A-Fa-f]{4})*"$/.test(scalar)) {
@@ -241,17 +240,17 @@ function isSupportedFrontmatterScalar(value) {
     !scalar.includes("[") &&
     !scalar.includes("]") &&
     !/(?:^|\s)#/.test(scalar) &&
-    !/:\s/.test(scalar)
+    !/:(?:\s|,|$)/.test(scalar)
   );
 }
 
 function frontmatterBodyStart(lines) {
-  if (lines[0]?.trimEnd() !== "---") {
+  if (!/^--- *$/.test(lines[0] || "")) {
     return 0;
   }
 
   const closingIndex = lines.findIndex(
-    (line, index) => index > 0 && line.trimEnd() === "---",
+    (line, index) => index > 0 && /^--- *$/.test(line),
   );
   if (closingIndex === -1) {
     return null;
@@ -264,10 +263,10 @@ function frontmatterBodyStart(lines) {
   let sawEntry = false;
 
   for (const rawLine of lines.slice(1, closingIndex)) {
-    if (rawLine.trim() === "") {
+    if (/^ *$/.test(rawLine)) {
       continue;
     }
-    if (rawLine.includes("\t")) {
+    if (!hasOnlySupportedYamlCharacters(rawLine)) {
       return null;
     }
 
@@ -277,7 +276,7 @@ function frontmatterBodyStart(lines) {
     }
 
     const indent = entry[1].length;
-    const value = (entry[3] || "").trim();
+    const value = (entry[3] || "").replace(/ +$/, "");
     if (indent % 2 !== 0 || (!sawEntry && indent !== 0)) {
       return null;
     }
@@ -329,11 +328,11 @@ function hasNonInstallableDocPrologue(markdown) {
     return false;
   }
 
-  while (lineIndex < lines.length && lines[lineIndex].trim() === "") {
+  while (lineIndex < lines.length && /^ *$/.test(lines[lineIndex])) {
     lineIndex += 1;
   }
 
-  return lines[lineIndex]?.trimEnd() === NON_INSTALLABLE_DOC_PROLOGUE;
+  return lines[lineIndex]?.replace(/ +$/, "") === NON_INSTALLABLE_DOC_PROLOGUE;
 }
 
 function tokenizeShellLine(line) {

--- a/scripts/ci/validate_skill_install_docs.mjs
+++ b/scripts/ci/validate_skill_install_docs.mjs
@@ -5,11 +5,14 @@ import { spawnSync } from "node:child_process";
 import https from "node:https";
 import path from "node:path";
 import { isTestReleasePath } from "./release_path_policy.mjs";
+import { resolveSkillInstallability } from "./skill_installability.mjs";
 import { resolveDirectSkillsCliTargets } from "./skill_platforms.mjs";
 
 const DEFAULT_REPOSITORY = "prompt-security/clawsec";
 const DEFAULT_AGENT_TYPES_URL = "https://raw.githubusercontent.com/vercel-labs/skills/main/src/types.ts";
 const DOC_FILENAMES = ["README.md", "SKILL.md"];
+const NON_INSTALLABLE_DOC_PROLOGUE =
+  "This skill is intentionally non-installable. Do not publish or install it through public skill channels.";
 const NO_DIRECT_TARGET_PATTERN = /no\s+(?:reviewed\s+)?direct[\s\S]{0,80}(?:Agent Skills|Skills CLI)[\s\S]{0,40}target/i;
 
 function usage() {
@@ -203,6 +206,30 @@ function logicalShellLines(markdown) {
 
 function stripHtmlComments(markdown) {
   return markdown.replace(/<!--[\s\S]*?(?:-->|$)/g, "");
+}
+
+function hasNonInstallableDocPrologue(markdown) {
+  const lines = markdown
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n?/g, "\n")
+    .split("\n");
+  let lineIndex = 0;
+
+  if (lines[0]?.trimEnd() === "---") {
+    lineIndex = lines.findIndex(
+      (line, index) => index > 0 && line.trimEnd() === "---",
+    );
+    if (lineIndex === -1) {
+      return false;
+    }
+    lineIndex += 1;
+  }
+
+  while (lineIndex < lines.length && lines[lineIndex].trim() === "") {
+    lineIndex += 1;
+  }
+
+  return lines[lineIndex]?.trimEnd() === NON_INSTALLABLE_DOC_PROLOGUE;
 }
 
 function tokenizeShellLine(line) {
@@ -440,27 +467,57 @@ function localInstallReferences(markdown, { docPath, skillRoot }) {
   return [...new Set(references)];
 }
 
-async function validateSkill({ root, skillDir, repository, agentTypes }) {
+async function validateSkill({ root, skillDir, repository, getAgentTypes }) {
   const skillJsonPath = path.join(root, skillDir, "skill.json");
   const skill = await readJson(skillJsonPath);
   const skillName = skill.name || path.basename(skillDir);
-  const resolution = resolveDirectSkillsCliTargets(skill, agentTypes);
+  const installability = resolveSkillInstallability(skill, skillJsonPath);
+  const resolution = installability.installable
+    ? resolveDirectSkillsCliTargets(skill, await getAgentTypes())
+    : null;
   const failures = [];
   const skillRoot = path.join(root, skillDir);
   const packagedFiles = packagedSkillFiles(skill);
 
-  for (const error of resolution.errors) {
+  for (const error of resolution?.errors || []) {
     failures.push(`Invalid npx skills target policy for ${skillDir}: ${error}`);
   }
 
   for (const filename of DOC_FILENAMES) {
     const docPath = path.join(root, skillDir, filename);
-    if (!existsSync(docPath)) {
+    let docStat;
+    try {
+      docStat = lstatSync(docPath);
+    } catch (error) {
+      if (error?.code !== "ENOENT") {
+        failures.push(
+          `Unable to inspect required install documentation file: ${path.join(skillDir, filename)}`,
+        );
+        continue;
+      }
       failures.push(`Missing required install documentation file: ${path.join(skillDir, filename)}`);
       continue;
     }
 
-    const markdown = stripHtmlComments(await readFile(docPath, "utf8"));
+    if (!docStat.isFile()) {
+      failures.push(
+        `Required install documentation path is not a regular file: ${path.join(skillDir, filename)}`,
+      );
+      continue;
+    }
+
+    const rawMarkdown = await readFile(docPath, "utf8");
+    if (!installability.installable) {
+      if (!hasNonInstallableDocPrologue(rawMarkdown)) {
+        failures.push(
+          `Missing required non-installable document prologue in ${path.join(skillDir, filename)}: ` +
+          NON_INSTALLABLE_DOC_PROLOGUE,
+        );
+      }
+      continue;
+    }
+
+    const markdown = stripHtmlComments(rawMarkdown);
     const commands = parseSkillsAddCommands(markdown);
     const commandsForSkill = commands.filter((command) => command.skillValues.includes(skillName));
     const malformedCommands = commands.filter(
@@ -538,6 +595,7 @@ async function validateSkill({ root, skillDir, repository, agentTypes }) {
   return {
     skillDir,
     skillName,
+    installability,
     resolution,
     failures,
   };
@@ -545,7 +603,11 @@ async function validateSkill({ root, skillDir, repository, agentTypes }) {
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
-  const agentTypes = parseAgentTypes(await readAgentTypeSource(options));
+  let agentTypesPromise;
+  const getAgentTypes = () => {
+    agentTypesPromise ??= readAgentTypeSource(options).then(parseAgentTypes);
+    return agentTypesPromise;
+  };
   let skillDirs = options.skillDirs;
 
   if (options.all) {
@@ -572,7 +634,7 @@ async function main() {
         root: options.root,
         skillDir,
         repository: options.repository,
-        agentTypes,
+        getAgentTypes,
       }),
     );
   }
@@ -586,6 +648,14 @@ async function main() {
   }
 
   for (const result of results) {
+    if (!result.installability.installable) {
+      console.log(
+        `Public install docs not applicable for ${result.skillName}: ` +
+        'skill.json declares "installable": false',
+      );
+      continue;
+    }
+
     if (result.resolution.status === "not_applicable") {
       console.log(
         `npx skills install docs not applicable for ${result.skillName}: ` +

--- a/scripts/ci/validate_skill_install_docs.mjs
+++ b/scripts/ci/validate_skill_install_docs.mjs
@@ -208,21 +208,125 @@ function stripHtmlComments(markdown) {
   return markdown.replace(/<!--[\s\S]*?(?:-->|$)/g, "");
 }
 
+function isSupportedFrontmatterScalar(value) {
+  const scalar = value.trim();
+  if (
+    !scalar ||
+    /[<>{}]/.test(scalar) ||
+    [...scalar].some((character) => {
+      const codePoint = character.codePointAt(0);
+      return !(
+        (codePoint >= 0x20 && codePoint <= 0x7e) ||
+        codePoint === 0x85 ||
+        (codePoint >= 0xa0 && codePoint <= 0xd7ff) ||
+        (codePoint >= 0xe000 && codePoint <= 0xfffd) ||
+        (codePoint >= 0x10000 && codePoint <= 0x10ffff)
+      );
+    })
+  ) {
+    return false;
+  }
+  if (/^"(?:[^"\\]|\\["\\/bfnrt]|\\u[0-9A-Fa-f]{4})*"$/.test(scalar)) {
+    return true;
+  }
+  if (/^'(?:[^']|'')*'$/.test(scalar)) {
+    return true;
+  }
+  if (/^\[(?:[A-Za-z0-9_.+/-]+(?:,\s*[A-Za-z0-9_.+/-]+)*)?\]$/.test(scalar)) {
+    return true;
+  }
+  const disallowedPlainScalarStart = "-?:,[]#&*!|>'\"%@`";
+  return (
+    !disallowedPlainScalarStart.includes(scalar[0]) &&
+    !scalar.includes("[") &&
+    !scalar.includes("]") &&
+    !/(?:^|\s)#/.test(scalar) &&
+    !/:\s/.test(scalar)
+  );
+}
+
+function frontmatterBodyStart(lines) {
+  if (lines[0]?.trimEnd() !== "---") {
+    return 0;
+  }
+
+  const closingIndex = lines.findIndex(
+    (line, index) => index > 0 && line.trimEnd() === "---",
+  );
+  if (closingIndex === -1) {
+    return null;
+  }
+
+  const indentationLevels = [0];
+  const keysByLevel = [new Set()];
+  let previousIndent = 0;
+  let previousOpensMapping = false;
+  let sawEntry = false;
+
+  for (const rawLine of lines.slice(1, closingIndex)) {
+    if (rawLine.trim() === "") {
+      continue;
+    }
+    if (rawLine.includes("\t")) {
+      return null;
+    }
+
+    const entry = rawLine.match(/^( *)([A-Za-z_][A-Za-z0-9_-]*):(?: +(.*))?$/);
+    if (!entry) {
+      return null;
+    }
+
+    const indent = entry[1].length;
+    const value = (entry[3] || "").trim();
+    if (indent % 2 !== 0 || (!sawEntry && indent !== 0)) {
+      return null;
+    }
+
+    if (sawEntry && indent > previousIndent) {
+      if (!previousOpensMapping || indent !== previousIndent + 2) {
+        return null;
+      }
+      indentationLevels.push(indent);
+      keysByLevel.push(new Set());
+    } else if (sawEntry && indent < previousIndent) {
+      if (previousOpensMapping) {
+        return null;
+      }
+      while (indentationLevels.at(-1) > indent) {
+        indentationLevels.pop();
+        keysByLevel.pop();
+      }
+      if (indentationLevels.at(-1) !== indent) {
+        return null;
+      }
+    } else if (sawEntry && previousOpensMapping) {
+      return null;
+    }
+
+    if (keysByLevel.at(-1).has(entry[2])) {
+      return null;
+    }
+    keysByLevel.at(-1).add(entry[2]);
+
+    previousIndent = indent;
+    previousOpensMapping = value === "";
+    if (!previousOpensMapping && !isSupportedFrontmatterScalar(value)) {
+      return null;
+    }
+    sawEntry = true;
+  }
+
+  return sawEntry && !previousOpensMapping ? closingIndex + 1 : null;
+}
+
 function hasNonInstallableDocPrologue(markdown) {
   const lines = markdown
     .replace(/^\uFEFF/, "")
     .replace(/\r\n?/g, "\n")
     .split("\n");
-  let lineIndex = 0;
-
-  if (lines[0]?.trimEnd() === "---") {
-    lineIndex = lines.findIndex(
-      (line, index) => index > 0 && line.trimEnd() === "---",
-    );
-    if (lineIndex === -1) {
-      return false;
-    }
-    lineIndex += 1;
+  let lineIndex = frontmatterBodyStart(lines);
+  if (lineIndex === null) {
+    return false;
   }
 
   while (lineIndex < lines.length && lines[lineIndex].trim() === "") {

--- a/scripts/test-skill-install-docs.mjs
+++ b/scripts/test-skill-install-docs.mjs
@@ -139,6 +139,46 @@ try {
       `${nonInstallableDocPrologue}\n`,
       `---\nname: bad\u007fvalue\n---\n${nonInstallableDocPrologue}\n`,
     ],
+    [
+      "non-installable-frontmatter-leading-trimmed-control",
+      `${nonInstallableDocPrologue}\n`,
+      `---\nname: \u000bok\n---\n${nonInstallableDocPrologue}\n`,
+    ],
+    [
+      "non-installable-frontmatter-trailing-trimmed-control",
+      `${nonInstallableDocPrologue}\n`,
+      `---\nname: ok\u000c\n---\n${nonInstallableDocPrologue}\n`,
+    ],
+    [
+      "non-installable-frontmatter-control-only-line",
+      `${nonInstallableDocPrologue}\n`,
+      `---\nname: fake\n\u000b\n---\n${nonInstallableDocPrologue}\n`,
+    ],
+    [
+      "non-installable-frontmatter-control-opener",
+      `${nonInstallableDocPrologue}\n`,
+      `---\u000b\nname: fake\n---\n${nonInstallableDocPrologue}\n`,
+    ],
+    [
+      "non-installable-frontmatter-control-closer",
+      `${nonInstallableDocPrologue}\n`,
+      `---\nname: fake\n---\u000c\n${nonInstallableDocPrologue}\n`,
+    ],
+    [
+      "non-installable-frontmatter-trailing-colon",
+      `${nonInstallableDocPrologue}\n`,
+      `---\nname: fake:\n---\n${nonInstallableDocPrologue}\n`,
+    ],
+    [
+      "non-installable-prologue-control-suffix",
+      `${nonInstallableDocPrologue}\u000b\n`,
+      `---\nname: non-installable-prologue-control-suffix\n---\n${nonInstallableDocPrologue}\n`,
+    ],
+    [
+      "non-installable-prologue-control-prefix-line",
+      `\u000c\n${nonInstallableDocPrologue}\n`,
+      `---\nname: non-installable-prologue-control-prefix-line\n---\n${nonInstallableDocPrologue}\n`,
+    ],
   ]) {
     await writeSkill({
       name,

--- a/scripts/test-skill-install-docs.mjs
+++ b/scripts/test-skill-install-docs.mjs
@@ -67,7 +67,9 @@ try {
     metadata: { installable: false },
     readme: `${nonInstallableDocPrologue}\n\n# Non-installable Example\n`,
     skillMd:
-      `\uFEFF---\r\nname: non-installable-example\r\nversion: 1.0.0\r\n---\r\n\r\n` +
+      `\uFEFF---\r\nname: non-installable-example\r\nversion: 1.0.0\r\nmetadata:\r\n` +
+      `  internal: true\r\nclawdis:\r\n  emoji: "shield"\r\n  requires:\r\n` +
+      `    bins: [bash, git, jq, gh]\r\n---\r\n\r\n` +
       `${nonInstallableDocPrologue}\r\n\r\n# Non-installable Example\r\n`,
   });
 
@@ -106,6 +108,36 @@ try {
       "non-installable-late-prologue",
       `# Late prologue\n\n${nonInstallableDocPrologue}\n`,
       `---\nname: non-installable-late-prologue\n---\n\n${nonInstallableDocPrologue}\n`,
+    ],
+    [
+      "non-installable-malformed-frontmatter-comment",
+      `${nonInstallableDocPrologue}\n`,
+      `---\nname: fake\n<!--\n---\n${nonInstallableDocPrologue}\n-->\n`,
+    ],
+    [
+      "non-installable-invalid-frontmatter-scalar",
+      `${nonInstallableDocPrologue}\n`,
+      `---\nname: [unterminated\n---\n${nonInstallableDocPrologue}\n`,
+    ],
+    [
+      "non-installable-frontmatter-no-separation",
+      `${nonInstallableDocPrologue}\n`,
+      `---\nname:fake\n---\n${nonInstallableDocPrologue}\n`,
+    ],
+    [
+      "non-installable-frontmatter-quoted-no-separation",
+      `${nonInstallableDocPrologue}\n`,
+      `---\nname:"fake"\n---\n${nonInstallableDocPrologue}\n`,
+    ],
+    [
+      "non-installable-frontmatter-list-no-separation",
+      `${nonInstallableDocPrologue}\n`,
+      `---\nbins:[bash, git]\n---\n${nonInstallableDocPrologue}\n`,
+    ],
+    [
+      "non-installable-frontmatter-control-character",
+      `${nonInstallableDocPrologue}\n`,
+      `---\nname: bad\u007fvalue\n---\n${nonInstallableDocPrologue}\n`,
     ],
   ]) {
     await writeSkill({

--- a/scripts/test-skill-install-docs.mjs
+++ b/scripts/test-skill-install-docs.mjs
@@ -8,11 +8,16 @@ const validator = "scripts/ci/validate_skill_install_docs.mjs";
 const workflow = await readFile(".github/workflows/controlled-skill-release.yml", "utf8");
 const tempRoot = await mkdtemp(path.join(tmpdir(), "clawsec-install-docs-"));
 const agentTypesPath = path.join(tempRoot, "vercel-types.ts");
+const nonInstallableDocPrologue =
+  "This skill is intentionally non-installable. Do not publish or install it through public skill channels.";
 
-function runValidator(args) {
+function runValidator(args, { agentTypesFile = agentTypesPath } = {}) {
+  const agentTypeArgs = agentTypesFile === null
+    ? []
+    : ["--agent-types-file", agentTypesFile];
   return spawnSync(
     process.execPath,
-    [validator, "--root", tempRoot, "--agent-types-file", agentTypesPath, ...args],
+    [validator, "--root", tempRoot, ...agentTypeArgs, ...args],
     {
       encoding: "utf8",
     },
@@ -56,6 +61,101 @@ try {
     agentTypesPath,
     "export type AgentType = | 'codex' | 'hermes-agent' | 'openclaw' | 'universal';\n",
   );
+
+  await writeSkill({
+    name: "non-installable-example",
+    metadata: { installable: false },
+    readme: `${nonInstallableDocPrologue}\n\n# Non-installable Example\n`,
+    skillMd:
+      `\uFEFF---\r\nname: non-installable-example\r\nversion: 1.0.0\r\n---\r\n\r\n` +
+      `${nonInstallableDocPrologue}\r\n\r\n# Non-installable Example\r\n`,
+  });
+
+  const offlineNonInstallable = runValidator(
+    ["--skills", "skills/non-installable-example"],
+    { agentTypesFile: path.join(tempRoot, "missing-agent-types.ts") },
+  );
+  assert.equal(
+    offlineNonInstallable.status,
+    0,
+    `non-installable docs must not load AgentTypes\nstdout:\n${offlineNonInstallable.stdout}\n` +
+      `stderr:\n${offlineNonInstallable.stderr}`,
+  );
+  assert.match(
+    offlineNonInstallable.stdout,
+    /Public install docs not applicable for non-installable-example: skill\.json declares "installable": false/,
+  );
+
+  for (const [name, readme, skillMd] of [
+    [
+      "non-installable-missing-prologue",
+      "# Missing prologue\n",
+      `---\nname: non-installable-missing-prologue\n---\n\n${nonInstallableDocPrologue}\n`,
+    ],
+    [
+      "non-installable-frontmatter-only",
+      `${nonInstallableDocPrologue}\n`,
+      `---\nname: non-installable-frontmatter-only\ndescription: ${nonInstallableDocPrologue}\n---\n\n# Hidden denial\n`,
+    ],
+    [
+      "non-installable-indented-prologue",
+      `  ${nonInstallableDocPrologue}\n`,
+      `---\nname: non-installable-indented-prologue\n---\n\n${nonInstallableDocPrologue}\n`,
+    ],
+    [
+      "non-installable-late-prologue",
+      `# Late prologue\n\n${nonInstallableDocPrologue}\n`,
+      `---\nname: non-installable-late-prologue\n---\n\n${nonInstallableDocPrologue}\n`,
+    ],
+  ]) {
+    await writeSkill({
+      name,
+      metadata: { installable: false },
+      readme,
+      skillMd,
+    });
+    const invalidPrologue = runValidator(
+      ["--skills", `skills/${name}`],
+      { agentTypesFile: path.join(tempRoot, "missing-agent-types.ts") },
+    );
+    assert.equal(invalidPrologue.status, 1, `${name} must fail the fixed-prologue contract`);
+    assert.match(invalidPrologue.stderr, /Missing required non-installable document prologue/);
+  }
+
+  await writeSkill({
+    name: "non-installable-invalid-type",
+    metadata: { installable: "false" },
+    readme: `${nonInstallableDocPrologue}\n`,
+    skillMd: `${nonInstallableDocPrologue}\n`,
+  });
+  const invalidInstallableType = runValidator(
+    ["--skills", "skills/non-installable-invalid-type"],
+    { agentTypesFile: path.join(tempRoot, "missing-agent-types.ts") },
+  );
+  assert.equal(invalidInstallableType.status, 1, "installable metadata must be a strict boolean");
+  assert.match(invalidInstallableType.stderr, /"installable" must be a boolean when present/);
+
+  const externalDoc = path.join(tempRoot, "external-doc.md");
+  await writeFile(externalDoc, `${nonInstallableDocPrologue}\n`);
+  for (const filename of ["README.md", "SKILL.md"]) {
+    const name = `non-installable-symlink-${filename === "README.md" ? "readme" : "skill"}`;
+    await writeSkill({
+      name,
+      metadata: { installable: false },
+      readme: `${nonInstallableDocPrologue}\n`,
+      skillMd: `${nonInstallableDocPrologue}\n`,
+    });
+    const docPath = path.join(tempRoot, "skills", name, filename);
+    await rm(docPath);
+    await symlink(externalDoc, docPath);
+
+    const symlinkedDoc = runValidator(
+      ["--skills", `skills/${name}`],
+      { agentTypesFile: path.join(tempRoot, "missing-agent-types.ts") },
+    );
+    assert.equal(symlinkedDoc.status, 1, `${filename} symlinks must fail the regular-file contract`);
+    assert.match(symlinkedDoc.stderr, /Required install documentation path is not a regular file/);
+  }
 
   await writeSkill({
     name: "hermes-example",


### PR DESCRIPTION
## Summary

- Resolve `skill.json` installability before applying public Skills CLI documentation rules.
- For `installable: false`, require the exact non-installable notice as the first nonblank document body line in both `README.md` and `SKILL.md`.
- Accept only an unambiguous, dependency-free YAML mapping subset before that prologue; malformed or ambiguous frontmatter fails closed.
- Skip AgentType loading entirely for non-installable-only validation and cache it once when an installable skill requires it.
- Require both documentation paths to be regular files, rejecting symlinks and special entries.

## Deliberate boundary

This PR establishes the metadata/documentation/offline contract only. It does **not** interpret later prose or detect public installer commands. That scanner is a separate prerequisite PR, and no skill should adopt `installable: false` until that stacked control is proven.

The frontmatter recognizer is intentionally narrower than general YAML. It supports the nested mapping, quoted/plain scalar, and simple inline command-list shape needed by the planned internal `claw-release` skill. The validator runs in workflow paths that do not install repository dependencies, so this unit does not add a YAML runtime dependency or silently widen those workflows.

## Remote proof

Tested only on `davida@20.14.133.241` from a fresh clone of public base `2b0bf7f7232de6d8915f1b389d9f74ddc3aa3f6a`.

Final transferred hashes:

- `scripts/ci/validate_skill_install_docs.mjs`: `879dd99b4a98c02362075b602668b868dd8967208e4392fa10795b31806c1ff1`
- `scripts/test-skill-install-docs.mjs`: `498d2e0b40f5efe7a52d892d12975ca1d714d7491e593199cd0706ab9988fe60`

Passed remotely:

- syntax checks and focused install-doc tests
- installability, release-script, and release-workflow regressions
- all `scripts/test-skill-*.mjs`
- repository-wide ESLint
- `npx tsc --noEmit`
- production build
- `git diff --check`
- independent 36/36 adversarial frontmatter matrix
- regressions for trimmed VT/FF controls, control-only lines, malformed delimiter suffixes, and trailing-colon scalars
- byte-for-byte unchanged `--all` output and status versus the unmodified base for current repository skills

No merge, tag, GitHub Release, skill-store publication, catalog activation, or release action was performed.
