### PR TITLE
fix(release): enforce non-installable documentation policy

### DIFF
--- a/scripts/ci/noninstallable_public_installer_policy.mjs
+++ b/scripts/ci/noninstallable_public_installer_policy.mjs
@@ -1,0 +1,1085 @@
+import { TextDecoder } from "node:util";
+
+const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
+const CONTROL_OR_FORMAT = /[\p{Cc}\p{Cf}]/u;
+const DEFAULT_IGNORABLE = /\p{Default_Ignorable_Code_Point}/u;
+const WHITE_SPACE = /\p{White_Space}/u;
+const EXPANSION_MARKER = "\uE000";
+const CORE_ENTITIES = new Map([
+  ["amp", "&"],
+  ["apos", "'"],
+  ["gt", ">"],
+  ["lt", "<"],
+  ["nbsp", "\u00a0"],
+  ["quot", '"'],
+]);
+
+function flagDecodedSyntaxDelimiter(decoded, encoding, issues) {
+  if (/[\s'"`<>]/u.test(decoded)) {
+    issues.add(
+      `${encoding}-encoded syntax delimiter is not allowed in non-installable documentation`,
+    );
+  }
+}
+
+function decodeMarkdown(input, issues) {
+  if (typeof input === "string") {
+    return input;
+  }
+  try {
+    return UTF8_DECODER.decode(input);
+  } catch {
+    issues.add("documentation is not valid UTF-8");
+    return null;
+  }
+}
+
+function decodeEntityPass(value, issues) {
+  const numericDecoded = value.replace(
+    /&#(?:x([0-9a-f]+)|([0-9]+));/gi,
+    (entity, hexadecimal, decimal) => {
+      const codePoint = Number.parseInt(hexadecimal || decimal, hexadecimal ? 16 : 10);
+      if (
+        !Number.isSafeInteger(codePoint) ||
+        codePoint > 0x10ffff ||
+        (codePoint >= 0xd800 && codePoint <= 0xdfff)
+      ) {
+        issues.add(`invalid numeric HTML entity: ${entity}`);
+        return entity;
+      }
+      const decoded = String.fromCodePoint(codePoint);
+      flagDecodedSyntaxDelimiter(decoded, "HTML", issues);
+      return decoded;
+    },
+  );
+  return numericDecoded.replace(/&([a-z][a-z0-9]+);/gi, (entity, name) => {
+    const decoded = CORE_ENTITIES.get(name.toLowerCase());
+    if (decoded === undefined) {
+      return entity;
+    }
+    flagDecodedSyntaxDelimiter(decoded, "HTML", issues);
+    return decoded;
+  });
+}
+
+function decodePercentPass(value, issues) {
+  return value.replace(/(?:%[0-9a-f]{2})+/gi, (encoded) => {
+    try {
+      const decoded = decodeURIComponent(encoded);
+      flagDecodedSyntaxDelimiter(decoded, "percent", issues);
+      return decoded;
+    } catch {
+      issues.add(`invalid percent-encoded UTF-8 sequence: ${encoded}`);
+      return encoded;
+    }
+  });
+}
+
+function decodeEntities(value, issues) {
+  let decoded = value;
+  for (let pass = 0; pass < 8; pass += 1) {
+    const next = decodeEntityPass(decodePercentPass(decoded, issues), issues);
+    if (next === decoded) {
+      break;
+    }
+    decoded = next;
+  }
+  if (/&#/.test(decoded)) {
+    issues.add("malformed or excessively nested numeric HTML entity");
+  }
+  if (/&[a-z][a-z0-9]+;/i.test(decoded)) {
+    issues.add("unsupported or excessively nested named HTML entity");
+  }
+  return decoded;
+}
+
+function validateCharacters(value, issues) {
+  for (const character of value) {
+    if (character === "\n" || character === " ") {
+      continue;
+    }
+    if (CONTROL_OR_FORMAT.test(character)) {
+      issues.add("control, zero-width, or bidirectional formatting character is not allowed");
+      return;
+    }
+    if (DEFAULT_IGNORABLE.test(character)) {
+      issues.add("default-ignorable, zero-width, or variation character is not allowed");
+      return;
+    }
+    if (WHITE_SPACE.test(character)) {
+      issues.add("non-ASCII whitespace is not allowed");
+      return;
+    }
+    const compatibilityNormalized = character.normalize("NFKC");
+    if (
+      compatibilityNormalized !== character &&
+      /[\s'"`<>]/u.test(compatibilityNormalized)
+    ) {
+      issues.add("Unicode compatibility character normalizes to a syntax delimiter");
+      return;
+    }
+  }
+}
+
+function findMarkupEnd(value, start) {
+  let quote = "";
+  for (let index = start + 1; index < value.length; index += 1) {
+    const character = value[index];
+    if (quote) {
+      if (character === quote) {
+        quote = "";
+      }
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === ">") {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function shellProtectedLessThanPositions(value) {
+  const protectedPositions = new Set();
+  let quote = "";
+  let token = "";
+
+  const tokenContainsUrl = () =>
+    /[a-z][a-z0-9+.-]*:\/\/[^\s]*$/i.test(token);
+  const appendTokenCharacter = (character) => {
+    token += /\s/u.test(character) ? "_" : character;
+  };
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (character === "\n") {
+      quote = "";
+      token = "";
+      continue;
+    }
+    if (quote) {
+      if (character === quote) {
+        quote = "";
+      } else if (character === "<") {
+        if (tokenContainsUrl()) {
+          protectedPositions.add(index);
+        }
+        token += character;
+      } else if (
+        quote === '"' &&
+        character === "\\" &&
+        index + 1 < value.length
+      ) {
+        if (value[index + 1] === "<") {
+          if (tokenContainsUrl()) {
+            protectedPositions.add(index + 1);
+          }
+        }
+        appendTokenCharacter(value[index + 1]);
+        index += 1;
+      } else {
+        appendTokenCharacter(character);
+      }
+      continue;
+    }
+
+    if (character === "'" || character === '"') {
+      quote = character;
+    } else if (character === "\\" && index + 1 < value.length) {
+      if (value[index + 1] === "<") {
+        if (tokenContainsUrl()) {
+          protectedPositions.add(index + 1);
+        }
+      }
+      appendTokenCharacter(value[index + 1]);
+      index += 1;
+    } else if (/\s/u.test(character) || /[;&|()]/.test(character)) {
+      token = "";
+    } else {
+      token += character;
+    }
+  }
+
+  return protectedPositions;
+}
+
+function markupViews(value, issues) {
+  let removed = "";
+  let spaced = "";
+  let index = 0;
+  const protectedLessThan = shellProtectedLessThanPositions(value);
+
+  while (index < value.length) {
+    if (value.startsWith("<!--", index)) {
+      const end = value.indexOf("-->", index + 4);
+      if (end === -1) {
+        issues.add("unterminated HTML comment is not allowed");
+        break;
+      }
+      spaced += " ";
+      index = end + 3;
+      continue;
+    }
+
+    const tagStart =
+      value[index] === "<" &&
+      !protectedLessThan.has(index) &&
+      /[A-Za-z/!?]/.test(value[index + 1] || "");
+    if (tagStart) {
+      const end = findMarkupEnd(value, index);
+      if (end === -1) {
+        issues.add("unterminated HTML tag is not allowed");
+        break;
+      }
+      spaced += " ";
+      index = end + 1;
+      continue;
+    }
+
+    removed += value[index];
+    spaced += value[index];
+    index += 1;
+  }
+
+  return [removed, spaced];
+}
+
+function findBalancedEnd(value, start, open, close) {
+  let depth = 0;
+  let quote = "";
+  for (let index = start; index < value.length; index += 1) {
+    const character = value[index];
+    if (character === "\\") {
+      index += 1;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) {
+        quote = "";
+      }
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === open) {
+      depth += 1;
+    } else if (character === close) {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return -1;
+}
+
+function validateMarkdownLinkPolicy(value, issues) {
+  const inlineOrReferenceLink = /\][ \t\n]*(?:\(|\[)/;
+  const withoutPlainIpv6Urls = value.replace(
+    /\b[a-z][a-z0-9+.-]{1,31}:\/\/(?:[^/\s@]+@)?\[[^\]\s/]+\]:[0-9]+/gi,
+    "",
+  );
+  const referenceDefinition = withoutPlainIpv6Urls.includes("]:");
+  const automaticLink = /<(?:[a-z][a-z0-9+.-]{1,31}:[^<>\s]*|[^<>\s@]+@[^<>\s@]+)>/i;
+  const htmlLinkOrImage = /<\s*\/?\s*(?:a|image|img)\b/i;
+  if (
+    inlineOrReferenceLink.test(value) ||
+    referenceDefinition ||
+    automaticLink.test(value) ||
+    htmlLinkOrImage.test(value)
+  ) {
+    issues.add(
+      "Markdown links and images are not allowed in non-installable documentation; use plain URLs",
+    );
+  }
+}
+
+function validateShellSyntaxPolicy(value, issues) {
+  if (value.includes("$(")) {
+    issues.add("shell command substitution is not allowed in non-installable documentation");
+  }
+}
+
+function flagNonFenceBackticks(value, issues) {
+  if (value.includes("`")) {
+    issues.add(
+      "non-fence backticks are not allowed in non-installable documentation; use fenced code blocks",
+    );
+  }
+}
+
+function projectMarkdownFences(value, issues) {
+  const projected = [];
+  let fenceCharacter = "";
+  let fenceWidth = 0;
+
+  for (const line of value.split("\n")) {
+    if (!fenceCharacter) {
+      const opening = line.match(/^( {0,3})(`{3,}|~{3,})(.*)$/);
+      if (opening) {
+        const delimiter = opening[2];
+        const infoString = opening[3];
+        if (delimiter[0] === "`" && infoString.includes("`")) {
+          flagNonFenceBackticks(line, issues);
+          projected.push(line);
+          continue;
+        }
+        flagNonFenceBackticks(infoString, issues);
+        fenceCharacter = delimiter[0];
+        fenceWidth = delimiter.length;
+        projected.push(`${opening[1]}${infoString}`);
+        continue;
+      }
+      flagNonFenceBackticks(line, issues);
+      projected.push(line);
+      continue;
+    }
+
+    const closing = line.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/);
+    if (
+      closing &&
+      closing[1][0] === fenceCharacter &&
+      closing[1].length >= fenceWidth
+    ) {
+      fenceCharacter = "";
+      fenceWidth = 0;
+      projected.push("");
+      continue;
+    }
+    flagNonFenceBackticks(line, issues);
+    projected.push(line);
+  }
+
+  return projected.join("\n");
+}
+
+function decodeAsciiEscapes(value) {
+  return value
+    .replace(/\\x([0-9a-f]{2})/gi, (_escape, hexadecimal) =>
+      String.fromCodePoint(Number.parseInt(hexadecimal, 16)))
+    .replace(
+      /\\u(?:\{([0-9A-Fa-f]{1,6})\}|([0-9A-Fa-f]{4}))/g,
+      (escape, braced, fixed) => {
+        const codePoint = Number.parseInt(braced || fixed, 16);
+        return codePoint <= 0x10ffff && !(codePoint >= 0xd800 && codePoint <= 0xdfff)
+          ? String.fromCodePoint(codePoint)
+          : escape;
+      },
+    );
+}
+
+const ANSI_SIMPLE_ESCAPES = new Map([
+  ["a", "\u0007"],
+  ["b", "\b"],
+  ["e", "\u001b"],
+  ["E", "\u001b"],
+  ["f", "\f"],
+  ["n", "\n"],
+  ["r", "\r"],
+  ["t", "\t"],
+  ["v", "\v"],
+  ["\\", "\\"],
+  ["'", "'"],
+  ['"', '"'],
+  ["?", "?"],
+]);
+
+function ansiCodePoint(match, radix) {
+  const codePoint = Number.parseInt(match, radix);
+  return (
+    codePoint <= 0x10ffff &&
+    !(codePoint >= 0xd800 && codePoint <= 0xdfff)
+  )
+    ? String.fromCodePoint(codePoint)
+    : null;
+}
+
+function decodeAnsiCString(value) {
+  let output = "";
+
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] !== "\\" || index + 1 >= value.length) {
+      output += value[index];
+      continue;
+    }
+
+    const remaining = value.slice(index + 1);
+    const simple = ANSI_SIMPLE_ESCAPES.get(remaining[0]);
+    if (simple !== undefined) {
+      output += simple;
+      index += 1;
+      continue;
+    }
+
+    const control = remaining.match(/^c(.)/s);
+    if (control) {
+      output += String.fromCodePoint(control[1].toUpperCase().codePointAt(0) & 0x1f);
+      index += control[0].length;
+      continue;
+    }
+
+    const hexadecimal = remaining.match(/^x([0-9a-f]{1,2})/i);
+    if (hexadecimal) {
+      output += ansiCodePoint(hexadecimal[1], 16);
+      index += hexadecimal[0].length;
+      continue;
+    }
+
+    const unicode = remaining.match(/^u([0-9A-Fa-f]{1,4})/);
+    if (unicode) {
+      output += ansiCodePoint(unicode[1], 16) ?? `\\${unicode[0]}`;
+      index += unicode[0].length;
+      continue;
+    }
+
+    const longUnicode = remaining.match(/^U([0-9A-Fa-f]{1,8})/);
+    if (longUnicode) {
+      output += ansiCodePoint(longUnicode[1], 16) ?? `\\${longUnicode[0]}`;
+      index += longUnicode[0].length;
+      continue;
+    }
+
+    const octal = remaining.match(/^([0-7]{1,3})/);
+    if (octal) {
+      output += ansiCodePoint(octal[1], 8);
+      index += octal[0].length;
+      continue;
+    }
+
+    output += `\\${remaining[0]}`;
+    index += 1;
+  }
+
+  return output;
+}
+
+function joinLiteralObfuscators(value) {
+  return decodeAsciiEscapes(value)
+    .replaceAll("\\", "")
+    .replace(/['"`*~]/g, "");
+}
+
+function shellQuotedTokenView(value) {
+  let output = "";
+  let quote = "";
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (!quote) {
+      if (character === "\\" && index + 1 < value.length) {
+        const escaped = value[index + 1];
+        if (escaped !== "\n") {
+          output += /[\s'"`<>]/u.test(escaped) ? "_" : escaped;
+        }
+        index += 1;
+      } else if (character === "'" || character === '"') {
+        quote = character;
+      } else {
+        output += character;
+      }
+      continue;
+    }
+
+    if (character === quote) {
+      quote = "";
+      continue;
+    }
+    if (quote === '"' && character === "\\" && index + 1 < value.length) {
+      const escaped = value[index + 1];
+      if (['$', "`", '"', "\\", "\n"].includes(escaped)) {
+        output += /[\s'"`<>]/u.test(escaped) ? "_" : escaped;
+        index += 1;
+        continue;
+      }
+    }
+    output += /[\s'"`<>]/u.test(character) ? "_" : character;
+  }
+
+  return output;
+}
+
+function findQuotedEnd(value, start, quote) {
+  for (let index = start + 1; index < value.length; index += 1) {
+    if (value[index] === "\n") {
+      return -1;
+    }
+    if (value[index] === "\\") {
+      index += 1;
+    } else if (value[index] === quote) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function shellExpansionSpans(value) {
+  const spans = [];
+  for (let index = 0; index < value.length; index += 1) {
+    let end = -1;
+    if (value[index] === "`") {
+      end = findQuotedEnd(value, index, "`");
+    } else if (value[index] === "$" && ["'", '"'].includes(value[index + 1])) {
+      end = findQuotedEnd(value, index + 1, value[index + 1]);
+    } else if (value.startsWith("${", index)) {
+      end = findBalancedEnd(value, index + 1, "{", "}");
+    } else if (value.startsWith("$(", index)) {
+      end = findBalancedEnd(value, index + 1, "(", ")");
+    } else if (value[index] === "$") {
+      const variable = value.slice(index).match(/^\$(?:[A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*#?$!-])/);
+      if (variable) {
+        end = index + variable[0].length - 1;
+      }
+    }
+    if (end > index) {
+      spans.push({ start: index, end });
+      index = end;
+    }
+  }
+  return spans;
+}
+
+function replaceSpans(value, spans, replacement) {
+  let output = "";
+  let cursor = 0;
+  for (const span of spans) {
+    output += value.slice(cursor, span.start);
+    output += replacement;
+    cursor = span.end + 1;
+  }
+  return output + value.slice(cursor);
+}
+
+function staticallyKnownExpansion(expansion) {
+  if (expansion.startsWith("$'")) {
+    return {
+      canBeUnknown: false,
+      conditional: false,
+      value: decodeAnsiCString(expansion.slice(2, -1)),
+    };
+  }
+  if (expansion.startsWith('$"')) {
+    return {
+      canBeUnknown: false,
+      conditional: false,
+      value: expansion.slice(2, -1),
+    };
+  }
+  if (!expansion.startsWith("${")) {
+    return null;
+  }
+  const body = expansion.slice(2, -1);
+  const parameterDefault = body.match(
+    /^(?:[A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*#?$!_-])(?::?([-+=]))([\s\S]*)$/,
+  );
+  if (!parameterDefault) {
+    return null;
+  }
+  return {
+    canBeUnknown: parameterDefault[1] !== "+",
+    conditional: true,
+    value: parameterDefault[2],
+  };
+}
+
+function staticallyKnownExpansionViews(value, spans, issues) {
+  const descriptors = spans.map((span) =>
+    staticallyKnownExpansion(value.slice(span.start, span.end + 1)));
+  const conditionalCount = descriptors.filter(
+    (descriptor) => descriptor?.conditional,
+  ).length;
+  const hasKnownExpansion = descriptors.some(Boolean);
+  if (!hasKnownExpansion) {
+    return [];
+  }
+
+  const render = (mask) => {
+    let output = "";
+    let cursor = 0;
+    let conditionalIndex = 0;
+    for (let index = 0; index < spans.length; index += 1) {
+      const span = spans[index];
+      const descriptor = descriptors[index];
+      output += value.slice(cursor, span.start);
+      if (!descriptor) {
+        output += value.slice(span.start, span.end + 1);
+      } else if (!descriptor.conditional) {
+        output += descriptor.value;
+      } else {
+        output += (mask & (1 << conditionalIndex)) === 0
+          ? (
+            descriptor.canBeUnknown
+              ? value.slice(span.start, span.end + 1)
+              : ""
+          )
+          : descriptor.value;
+        conditionalIndex += 1;
+      }
+      cursor = span.end + 1;
+    }
+    return output + value.slice(cursor);
+  };
+
+  if (conditionalCount > 4) {
+    issues.add("too many interacting statically known shell expansions");
+    const allKnownMask = (2 ** conditionalCount) - 1;
+    return [render(0), render(allKnownMask)];
+  }
+
+  const views = [];
+  for (let mask = 0; mask < 2 ** conditionalCount; mask += 1) {
+    views.push(render(mask));
+  }
+  return views;
+}
+
+function isSubsequence(candidate, value) {
+  let candidateIndex = 0;
+  for (const character of value) {
+    if (character === candidate[candidateIndex]) {
+      candidateIndex += 1;
+    }
+  }
+  return candidateIndex === candidate.length;
+}
+
+function minimumAuthorityEvidence(authority) {
+  return Math.max(2, authority.length - 2);
+}
+
+function flagAmbiguousAuthorityFragments(value, spans, issues) {
+  if (spans.length === 0) {
+    return;
+  }
+  const marked = joinLiteralObfuscators(replaceSpans(value, spans, EXPANSION_MARKER))
+    .normalize("NFKC")
+    .toLowerCase();
+  for (const candidate of marked.match(/[a-z_\uE000]+/g) || []) {
+    if (!candidate.includes(EXPANSION_MARKER)) {
+      continue;
+    }
+    const skeleton = candidate.replaceAll(EXPANSION_MARKER, "");
+    for (const authority of ["skills", "clawhub", "install_skill"]) {
+      if (
+        skeleton.length >= minimumAuthorityEvidence(authority) &&
+        isSubsequence(skeleton, authority)
+      ) {
+        issues.add("ambiguous public installer authority fragmentation");
+      }
+    }
+  }
+}
+
+function normalizedAuthorityText(value) {
+  return value
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(
+      /\b(skills|clawhub)(?:-v?[0-9][a-z0-9._+-]*)?(?:[^a-z0-9_\s'"`<>\uE000-][^\s'"`<>\uE000]*)?/g,
+      "$1",
+    );
+}
+
+function tokenCouldForm(
+  token,
+  target,
+  { allowFullyDynamic = false, minimumLiteralLength = 1 } = {},
+) {
+  if (token === target) {
+    return true;
+  }
+  if (!token.includes(EXPANSION_MARKER)) {
+    return false;
+  }
+  const skeleton = token.replaceAll(EXPANSION_MARKER, "");
+  return (
+    (allowFullyDynamic && !skeleton) ||
+    (
+      skeleton.length >= minimumLiteralLength &&
+      isSubsequence(skeleton, target)
+    )
+  );
+}
+
+function expansionMarkerVariants(marked, issues) {
+  const markerCount = [...marked].filter(
+    (character) => character === EXPANSION_MARKER,
+  ).length;
+  if (markerCount > 10) {
+    issues.add("too many interacting shell expansions in non-installable documentation");
+    return [marked];
+  }
+
+  const variants = [];
+  for (let mask = 0; mask < 2 ** markerCount; mask += 1) {
+    let markerIndex = 0;
+    let variant = "";
+    for (const character of marked) {
+      if (character !== EXPANSION_MARKER) {
+        variant += character;
+        continue;
+      }
+      variant += (mask & (1 << markerIndex)) === 0 ? EXPANSION_MARKER : " ";
+      markerIndex += 1;
+    }
+    variants.push(variant);
+  }
+  return variants;
+}
+
+function flagPotentialInstallerComposition(value, spans, issues) {
+  if (spans.length === 0) {
+    return;
+  }
+  const marked = normalizedAuthorityText(
+    joinLiteralObfuscators(replaceSpans(value, spans, EXPANSION_MARKER)),
+  );
+  for (const variant of expansionMarkerVariants(marked, issues)) {
+    const tokens = variant.match(/[a-z0-9_\uE000]+/g) || [];
+    for (let index = 0; index < tokens.length; index += 1) {
+      const authority = tokens[index];
+      const action = tokens[index + 1] || "";
+      if (
+        (
+          tokenCouldForm(authority, "skills", {
+            allowFullyDynamic: true,
+            minimumLiteralLength: minimumAuthorityEvidence("skills"),
+          }) &&
+          ["add", "install", "update"].some((candidate) =>
+            tokenCouldForm(action, candidate, { allowFullyDynamic: true }))
+        ) ||
+        (
+          tokenCouldForm(authority, "clawhub", {
+            allowFullyDynamic: true,
+            minimumLiteralLength: minimumAuthorityEvidence("clawhub"),
+          }) &&
+          tokenCouldForm(action, "install", { allowFullyDynamic: true })
+        ) ||
+        tokenCouldForm(authority, "install_skill", {
+          minimumLiteralLength: minimumAuthorityEvidence("install_skill"),
+        })
+      ) {
+        issues.add("ambiguous dynamic public installer authority and action");
+      }
+    }
+  }
+}
+
+function expansionBody(expansion) {
+  if (
+    expansion.startsWith("${") ||
+    expansion.startsWith("$(") ||
+    expansion.startsWith("$'") ||
+    expansion.startsWith('$"')
+  ) {
+    return expansion.slice(2, -1);
+  }
+  if (expansion.startsWith("`")) {
+    return expansion.slice(1, -1);
+  }
+  return "";
+}
+
+function flagInstallerWithinExpansion(value, spans, issues, depth = 0) {
+  if (depth >= 8) {
+    issues.add("excessively nested shell expansion in non-installable documentation");
+    return;
+  }
+  for (const span of spans) {
+    const body = expansionBody(value.slice(span.start, span.end + 1));
+    if (!body) {
+      continue;
+    }
+    scanAuthorityTails(body, issues);
+    scanAuthorityTails(joinLiteralObfuscators(body), issues);
+    const innerSpans = shellExpansionSpans(body);
+    flagPotentialInstallerComposition(body, innerSpans, issues);
+    if (innerSpans.length > 0) {
+      flagInstallerWithinExpansion(body, innerSpans, issues, depth + 1);
+    }
+  }
+}
+
+function flagAmbiguousInstallerTail(value, spans, issues) {
+  if (spans.length === 0) {
+    return;
+  }
+  const marked = normalizedAuthorityText(
+    joinLiteralObfuscators(replaceSpans(value, spans, EXPANSION_MARKER)),
+  );
+  const tokens = marked.match(/[a-z0-9_\uE000]+/g) || [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    const next = tokens[index + 1] || "";
+    const markerCount = [...token].filter((character) => character === EXPANSION_MARKER).length;
+    const skeleton = token.replaceAll(EXPANSION_MARKER, "");
+    const dynamicAction = ["add", "install", "update"].some(
+      (action) => skeleton && isSubsequence(skeleton, action),
+    );
+    if (markerCount >= 2 && (!skeleton || dynamicAction)) {
+      issues.add("ambiguous dynamic public installer authority");
+    } else if (
+      ["skills", "clawhub"].includes(token) &&
+      next.includes(EXPANSION_MARKER)
+    ) {
+      issues.add("ambiguous public installer action after installer authority");
+    } else if (
+      token === EXPANSION_MARKER &&
+      (next === EXPANSION_MARKER || ["add", "install", "update"].includes(next))
+    ) {
+      issues.add("ambiguous dynamic public installer authority");
+    }
+  }
+}
+
+function expansionViews(value, issues) {
+  const spans = shellExpansionSpans(value);
+  const descriptors = spans.map((span) =>
+    staticallyKnownExpansion(value.slice(span.start, span.end + 1)));
+  const hasBoundedStaticExpansion = descriptors.some(
+    (descriptor) => descriptor && !descriptor.canBeUnknown,
+  );
+  if (!hasBoundedStaticExpansion) {
+    flagAmbiguousAuthorityFragments(value, spans, issues);
+    flagPotentialInstallerComposition(value, spans, issues);
+    flagAmbiguousInstallerTail(value, spans, issues);
+  }
+  flagInstallerWithinExpansion(value, spans, issues);
+  return [
+    value,
+    ...staticallyKnownExpansionViews(value, spans, issues),
+    replaceSpans(value, spans, ""),
+    replaceSpans(value, spans, " "),
+  ];
+}
+
+function collectExpansionSurfaces(initial, issues) {
+  const surfaces = new Set();
+  const queue = [initial];
+
+  while (queue.length > 0) {
+    const value = queue.shift();
+    if (surfaces.has(value)) {
+      continue;
+    }
+    if (surfaces.size >= 64) {
+      issues.add("too many interacting documentation decoding surfaces");
+      break;
+    }
+    surfaces.add(value);
+    validateCharacters(value, issues);
+    validateShellSyntaxPolicy(value, issues);
+
+    const spans = shellExpansionSpans(value);
+    const hasBoundedStaticExpansion = spans.some((span) => {
+      const descriptor = staticallyKnownExpansion(
+        value.slice(span.start, span.end + 1),
+      );
+      return descriptor && !descriptor.canBeUnknown;
+    });
+    if (!hasBoundedStaticExpansion) {
+      const quotedToken = shellQuotedTokenView(value);
+      if (!surfaces.has(quotedToken)) {
+        queue.push(quotedToken);
+      }
+      const joined = joinLiteralObfuscators(value);
+      if (!surfaces.has(joined)) {
+        queue.push(joined);
+      }
+    }
+    for (const expanded of expansionViews(value, issues)) {
+      if (!surfaces.has(expanded)) {
+        queue.push(expanded);
+      }
+    }
+  }
+
+  return surfaces;
+}
+
+function authorityTokens(value) {
+  const versionless = normalizedAuthorityText(value);
+  return versionless.match(/[a-z0-9_]+/g) || [];
+}
+
+function scanAuthorityTails(value, issues) {
+  const tokens = authorityTokens(value);
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    const next = tokens[index + 1] || "";
+    if (token === "skills" && ["add", "install", "update"].includes(next)) {
+      issues.add(`forbidden public installer authority: skills ${next}`);
+    } else if (token === "clawhub" && next === "install") {
+      issues.add("forbidden public installer authority: clawhub install");
+    } else if (token === "install_skill") {
+      issues.add("forbidden public installer authority: install_skill");
+    }
+  }
+}
+
+function executableName(token) {
+  const basename = token
+    .normalize("NFKC")
+    .toLowerCase()
+    .split(/[\\/]/)
+    .at(-1);
+  return (basename || "")
+    .replace(/\.(?:cmd|exe|ps1)$/i, "")
+    .replace(/@[^@/]+$/, "");
+}
+
+function isRemotePackageUrl(token) {
+  return /^[a-z][a-z0-9+.-]*:\/\/\S+$/i.test(token);
+}
+
+function shellCommandWordGroups(value) {
+  const groups = [];
+  let words = [];
+  let word = "";
+  let quote = "";
+
+  const appendProtected = (character) => {
+    word += /[\s'"`<>]/u.test(character) ? "_" : character;
+  };
+  const flushWord = () => {
+    if (word) {
+      words.push(word);
+      word = "";
+    }
+  };
+  const flushGroup = () => {
+    flushWord();
+    if (words.length > 0) {
+      groups.push(words);
+      words = [];
+    }
+  };
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (quote) {
+      if (character === quote) {
+        quote = "";
+      } else if (
+        quote === '"' &&
+        character === "\\" &&
+        index + 1 < value.length &&
+        ['$', "`", '"', "\\", "\n"].includes(value[index + 1])
+      ) {
+        const escaped = value[index + 1];
+        if (escaped !== "\n") {
+          appendProtected(escaped);
+        }
+        index += 1;
+      } else {
+        appendProtected(character);
+      }
+      continue;
+    }
+
+    if (character === "\\" && index + 1 < value.length) {
+      const escaped = value[index + 1];
+      if (escaped !== "\n") {
+        appendProtected(escaped);
+      }
+      index += 1;
+    } else if (character === "#" && word === "") {
+      flushGroup();
+      const newline = value.indexOf("\n", index + 1);
+      if (newline === -1) {
+        break;
+      }
+      index = newline;
+    } else if (character === "'" || character === '"') {
+      quote = character;
+    } else if (character === "\n" || /[;&|()]/.test(character)) {
+      flushGroup();
+    } else if (/\s/u.test(character)) {
+      flushWord();
+    } else {
+      word += character;
+    }
+  }
+  flushGroup();
+
+  return groups;
+}
+
+function scanUrlExecutorTails(value, issues) {
+  for (const words of shellCommandWordGroups(value.normalize("NFKC"))) {
+    for (let index = 0; index < words.length; index += 1) {
+      const command = executableName(words[index]);
+      let launcher = "";
+      let cursor = index + 1;
+
+      if (["npx", "bunx", "pnpx"].includes(command)) {
+        launcher = command;
+      } else if (
+        ["npm", "pnpm", "yarn"].includes(command) &&
+        ["exec", "dlx"].includes(executableName(words[cursor] || ""))
+      ) {
+        launcher = `${command} ${executableName(words[cursor])}`;
+        cursor += 1;
+      } else {
+        continue;
+      }
+
+      for (; cursor < words.length; cursor += 1) {
+        if (!isRemotePackageUrl(words[cursor])) {
+          continue;
+        }
+        let actionIndex = cursor + 1;
+        while (words[actionIndex] === "--") {
+          actionIndex += 1;
+        }
+        const action = executableName(words[actionIndex] || "");
+        if (["add", "install", "update"].includes(action)) {
+          issues.add(
+            `forbidden remote package executor with installer action: ${launcher} URL ${action}`,
+          );
+        }
+        break;
+      }
+    }
+  }
+}
+
+export function inspectNonInstallableMarkdown(input) {
+  const issues = new Set();
+  const markdown = decodeMarkdown(input, issues);
+  if (markdown === null) {
+    return { markdown: null, issues: [...issues] };
+  }
+
+  const lineNormalized = markdown
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n?/g, "\n");
+  validateCharacters(lineNormalized, issues);
+  validateMarkdownLinkPolicy(lineNormalized, issues);
+  validateShellSyntaxPolicy(lineNormalized, issues);
+
+  const normalized = lineNormalized.normalize("NFKC");
+  const structuralBases = new Set([normalized, ...markupViews(normalized, issues)]);
+
+  const bases = new Set();
+  for (const structuralBase of structuralBases) {
+    const decoded = decodeEntities(structuralBase, issues);
+    validateCharacters(decoded, issues);
+    bases.add(decoded.normalize("NFKC"));
+  }
+
+  const surfaces = new Set();
+  for (const base of bases) {
+    const shellBase = projectMarkdownFences(base, issues);
+    for (const surface of collectExpansionSurfaces(shellBase, issues)) {
+      surfaces.add(surface);
+    }
+  }
+  for (const surface of surfaces) {
+    scanAuthorityTails(surface, issues);
+    scanUrlExecutorTails(surface, issues);
+  }
+
+  return {
+    markdown,
+    issues: [...issues],
+  };
+}

--- a/scripts/ci/validate_skill_install_docs.mjs
+++ b/scripts/ci/validate_skill_install_docs.mjs
@@ -4,6 +4,7 @@ import { existsSync, lstatSync, realpathSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import https from "node:https";
 import path from "node:path";
+import { inspectNonInstallableMarkdown } from "./noninstallable_public_installer_policy.mjs";
 import { isTestReleasePath } from "./release_path_policy.mjs";
 import { resolveSkillInstallability } from "./skill_installability.mjs";
 import { resolveDirectSkillsCliTargets } from "./skill_platforms.mjs";
@@ -537,6 +538,18 @@ function packagedSkillFiles(skill) {
   return files;
 }
 
+function hasUnsafePackagePathCharacter(value) {
+  return [...value].some((character) => {
+    const codePoint = character.codePointAt(0);
+    return (
+      codePoint < 0x20 ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 ||
+      codePoint === 0x2029
+    );
+  });
+}
+
 function localInstallReferences(markdown, { docPath, skillRoot }) {
   const references = [];
   for (const match of markdown.matchAll(/\[([^\]]+)\]\(([^)]+)\)/g)) {
@@ -568,6 +581,25 @@ function localInstallReferences(markdown, { docPath, skillRoot }) {
     }
   }
   return [...new Set(references)];
+}
+
+async function validateNonInstallableMarkdown({ docPath, displayPath, requirePrologue }) {
+  const failures = [];
+  const inspection = inspectNonInstallableMarkdown(await readFile(docPath));
+  if (
+    requirePrologue &&
+    inspection.markdown !== null &&
+    !hasNonInstallableDocPrologue(inspection.markdown)
+  ) {
+    failures.push(
+      `Missing required non-installable document prologue in ${displayPath}: ` +
+      NON_INSTALLABLE_DOC_PROLOGUE,
+    );
+  }
+  for (const issue of inspection.issues) {
+    failures.push(`Invalid non-installable documentation in ${displayPath}: ${issue}.`);
+  }
+  return failures;
 }
 
 async function validateSkill({ root, skillDir, repository, getAgentTypes }) {
@@ -609,17 +641,16 @@ async function validateSkill({ root, skillDir, repository, getAgentTypes }) {
       continue;
     }
 
-    const rawMarkdown = await readFile(docPath, "utf8");
     if (!installability.installable) {
-      if (!hasNonInstallableDocPrologue(rawMarkdown)) {
-        failures.push(
-          `Missing required non-installable document prologue in ${path.join(skillDir, filename)}: ` +
-          NON_INSTALLABLE_DOC_PROLOGUE,
-        );
-      }
+      failures.push(...await validateNonInstallableMarkdown({
+        docPath,
+        displayPath: path.join(skillDir, filename),
+        requirePrologue: true,
+      }));
       continue;
     }
 
+    const rawMarkdown = await readFile(docPath, "utf8");
     const markdown = stripHtmlComments(rawMarkdown);
     const commands = parseSkillsAddCommands(markdown);
     const commandsForSkill = commands.filter((command) => command.skillValues.includes(skillName));
@@ -692,6 +723,55 @@ async function validateSkill({ root, skillDir, repository, getAgentTypes }) {
         const command = `npx skills add ${repository} --skill ${skillName} -a ${agent} -y`;
         failures.push(`Missing required npx skills install command in ${path.join(skillDir, filename)}: ${command}`);
       }
+    }
+  }
+
+  if (!installability.installable) {
+    for (const filename of packagedFiles) {
+      if (hasUnsafePackagePathCharacter(filename)) {
+        failures.push(
+          `Unsafe package-visible path for ${skillDir}: control characters are not allowed.`,
+        );
+        continue;
+      }
+      if (/\.mdx$/i.test(filename)) {
+        failures.push(
+          `Unsupported package-visible MDX path for non-installable skill ${skillDir}: ${filename}.`,
+        );
+        continue;
+      }
+      if (!/\.md$/i.test(filename) || DOC_FILENAMES.includes(filename)) {
+        continue;
+      }
+
+      const docPath = path.resolve(skillRoot, filename.split("/").join(path.sep));
+      const skillPrefix = `${path.resolve(skillRoot)}${path.sep}`;
+      const displayPath = `${skillDir}/${filename}`;
+      if (!docPath.startsWith(skillPrefix)) {
+        failures.push(`Unsafe package-visible Markdown path for ${skillDir}: ${filename}.`);
+        continue;
+      }
+
+      let docStat;
+      try {
+        docStat = lstatSync(docPath);
+      } catch (error) {
+        if (error?.code === "ENOENT") {
+          continue;
+        }
+        failures.push(`Unable to inspect package-visible Markdown file: ${displayPath}`);
+        continue;
+      }
+      if (!docStat.isFile()) {
+        failures.push(`Package-visible Markdown path is not a regular file: ${displayPath}`);
+        continue;
+      }
+
+      failures.push(...await validateNonInstallableMarkdown({
+        docPath,
+        displayPath,
+        requirePrologue: false,
+      }));
     }
   }
 

--- a/scripts/test-noninstallable-public-installer-policy.mjs
+++ b/scripts/test-noninstallable-public-installer-policy.mjs
@@ -1,0 +1,671 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import { inspectNonInstallableMarkdown } from "./ci/noninstallable_public_installer_policy.mjs";
+
+for (const [label, markdown, expectedIssue] of [
+  ["canonical skills add", "npx skills add prompt-security/clawsec", "skills add"],
+  ["quoted versioned command", `"npx@10" 'skills@latest' "add" target`, "skills add"],
+  ["npm exec update", "npm exec -- skills update target", "skills update"],
+  ["pnpm clawhub", "pnpm dlx clawhub@latest install target", "clawhub install"],
+  ["direct clawhub", "clawhub install target", "clawhub install"],
+  ["Hermes installer", "hermes skills install target", "skills install"],
+  ["Pico installer", "install_skill(target)", "install_skill"],
+  ["shell escaped", "s\\kills a\\d\\d target", "skills add"],
+  ["two-layer shell escaped", "s\\\\kills add target", "skills add"],
+  [
+    "Markdown-unescaped expansion introducers",
+    "$\\{x:-skills} $\\{y:-add}",
+    "ambiguous dynamic public installer authority and action",
+  ],
+  [
+    "command substitution policy",
+    '$(printf "sk%slls add" i) target',
+    "command substitution",
+  ],
+  [
+    "legacy backtick substitution policy",
+    "`printf 'sk%slls add' i` target",
+    "non-fence backticks",
+  ],
+  [
+    "invalid closing fence content",
+    "```text\nsafe\n``` skills add target\n```",
+    "non-fence backticks",
+  ],
+  [
+    "shorter backticks inside longer fence",
+    "````text\n```skills add target\n````",
+    "non-fence backticks",
+  ],
+  [
+    "backtick content inside tilde fence",
+    "~~~text\n``` literal content\n~~~",
+    "non-fence backticks",
+  ],
+  [
+    "installer tail in fence info string",
+    "```skills add target\nsafe\n```",
+    "skills add",
+  ],
+  [
+    "ClawHub tail in longer fence info string",
+    "````clawhub install target\nsafe\n````",
+    "clawhub install",
+  ],
+  [
+    "installer tail in tilde fence info string",
+    "~~~skills add target\nsafe\n~~~",
+    "skills add",
+  ],
+  [
+    "invalid tilde closing fence content",
+    "~~~text\nsafe\n~~~ skills add target\n~~~",
+    "skills add",
+  ],
+  ["quote fragmented", `s'k'ills a"d"d target`, "skills add"],
+  ["line continuation", "skills \\\nadd target", "skills add"],
+  ["arbitrary gap", `skills${" -".repeat(400)} add target`, "skills add"],
+  ["hidden comment", "<!-- npx skills add target -->", "skills add"],
+  ["comment split", "sk<!-- noise -->ills add target", "skills add"],
+  ["tag wrapped", "<code>skills</code><span>add</span>", "skills add"],
+  [
+    "tag obfuscation after prose apostrophe",
+    "Don't allow this: sk<x>ill</x>s add target",
+    "skills add",
+  ],
+  [
+    "tag obfuscation after prior-line prose apostrophe",
+    "Ordinary user's note\nsk<x>ill</x>s add target",
+    "skills add",
+  ],
+  [
+    "tag obfuscation after unmatched prose quote",
+    'Prose says "warning: skills a<span>d</span>d target',
+    "skills add",
+  ],
+  [
+    "unterminated tag after prose apostrophe",
+    "Don't allow this: sk<x",
+    "unterminated HTML tag",
+  ],
+  ["numeric entities", "sk&#105;lls&#x20;add target", "skills add"],
+  ["double entities", "sk&amp;#105;lls&amp;#x20;add target", "skills add"],
+  ["full-width", "ｓｋｉｌｌｓ ａｄｄ target", "skills add"],
+  ["ASCII hex escape", "sk\\x69lls add target", "skills add"],
+  ["ASCII Unicode escape", "sk\\u0069lls add target", "skills add"],
+  ["empty expansion", "sk${EMPTY}ills add target", "skills add"],
+  ["spacing expansion", "skills${SPACE}add target", "skills add"],
+  [
+    "ANSI-C octal fragment",
+    "$'\\163\\153\\151'lls add target",
+    "skills add",
+  ],
+  [
+    "ANSI-C long Unicode fragment",
+    "claw$'\\U00000068\\U00000075\\U00000062' install target",
+    "clawhub install",
+  ],
+  [
+    "ANSI-C zero-prefixed octal control",
+    "echo $'\\0163'",
+    "control",
+  ],
+  ["ANSI-C fragment", "sk$'i'lls add target", "skills add"],
+  ["ANSI-C boundary fragment", "skill$'s' add target", "skills add"],
+  ["fully quoted ANSI-C authority", "$'skills' add target", "skills add"],
+  [
+    "fully dynamic authority and action",
+    "${tool:-skills} ${action:-add} target",
+    "ambiguous dynamic public installer authority",
+  ],
+  [
+    "fully dynamic authority and action through IFS",
+    "${tool:-skills}${IFS}${action:-add} target",
+    "ambiguous dynamic public installer authority",
+  ],
+  [
+    "dynamic authority through IFS with literal action",
+    "$tool${IFS}add target",
+    "ambiguous dynamic public installer authority",
+  ],
+  [
+    "fragmented authority before IFS",
+    "sk${mid:-i}lls${IFS}add target",
+    "ambiguous dynamic public installer authority and action",
+  ],
+  [
+    "nested fragmented authority before IFS",
+    "${cmd:-sk${mid:-i}lls${IFS}add} target",
+    "ambiguous dynamic public installer authority and action",
+  ],
+  [
+    "installer tail inside a parameter default",
+    "${cmd:-skills${IFS}add} target",
+    "ambiguous dynamic public installer authority and action",
+  ],
+  [
+    "installer tail inside ANSI-C quoting",
+    "$'skills add' target",
+    "skills add",
+  ],
+  ["parameter default fragment", "sk${value:-i}lls add target", "ambiguous public installer authority"],
+  [
+    "nested parameter fragment",
+    "sk${outer:-${inner:-i}}lls add target",
+    "ambiguous public installer authority",
+  ],
+  [
+    "near-complete Skills authority fragment",
+    "skil${suffix} add target",
+    "ambiguous public installer authority",
+  ],
+  [
+    "near-complete ClawHub authority fragment",
+    "clawh${suffix} install target",
+    "ambiguous public installer authority",
+  ],
+  [
+    "near-complete Pico authority fragment",
+    "install_ski${suffix} target",
+    "ambiguous public installer authority",
+  ],
+  [
+    "known parameter default completes Skills authority",
+    "s${value:-kills} add target",
+    "skills add",
+  ],
+  [
+    "known parameter default completes ClawHub authority",
+    "c${value:-lawhub} install target",
+    "clawhub install",
+  ],
+  [
+    "known parameter default completes Pico authority",
+    "i${value:-nstall_skill} target",
+    "install_skill",
+  ],
+  [
+    "known ANSI-C string completes Skills authority",
+    "s$'kills' add target",
+    "skills add",
+  ],
+  [
+    "known localized string completes Skills authority",
+    's$"kills" add target',
+    "skills add",
+  ],
+  [
+    "nested known defaults complete Skills authority",
+    "s${value:-k${tail:-ills}} add target",
+    "skills add",
+  ],
+  [
+    "known expansion subset omits conditional noise",
+    "${noise:+x}${tool:-skills} ${action:-add} target",
+    "skills add",
+  ],
+  [
+    "known expansions compose through unknown separator",
+    "${tool:-skills}${IFS}${action:-add} target",
+    "skills add",
+  ],
+  ["positional parameter fragment", "sk$1ills add target", "ambiguous public installer authority"],
+  ["command substitution fragment", "sk$(printf i)lls add target", "ambiguous public installer authority"],
+  ["action substitution", "skills $(printf add) target", "ambiguous public installer action"],
+  ["parameter action", "skills ${verb:-add} target", "ambiguous public installer action"],
+  [
+    "nested parameter action",
+    "skills ${outer:-${verb:-add}} target",
+    "ambiguous public installer action",
+  ],
+  ["positional action", "skills $1 target", "ambiguous public installer action"],
+  ["hash version package", "skills#v1 add target", "skills add"],
+  [
+    "Git HTTPS fragment package",
+    "https://github.com/vercel-labs/skills.git#v1 add target",
+    "skills add",
+  ],
+  [
+    "bare Git HTTPS package",
+    "npx https://github.com/vercel-labs/skills.git add target",
+    "skills add",
+  ],
+  ["percent-encoded package", "npx https://example.test/%73kills.git#v1 add target", "skills add"],
+  [
+    "registry tarball package",
+    "npx https://registry.example.test/skills/-/skills-1.2.3.tgz add target",
+    "skills add",
+  ],
+  [
+    "percent-encoded registry tarball package",
+    "npx https://registry.example.test/%73kills/-/%73kills-1.2.3.tgz add target",
+    "skills add",
+  ],
+  [
+    "registry tarball package with query",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=1' add target",
+    "skills add",
+  ],
+  [
+    "registry tarball package with query and fragment",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=1#v1' add target",
+    "skills add",
+  ],
+  [
+    "registry tarball package with arbitrary path suffix",
+    "npx --yes http://example.test/skills/-/skills-1.2.3.tgz/extra add target",
+    "remote package executor",
+  ],
+  [
+    "registry tarball package with encoded path suffix",
+    "npx --yes http://example.test/skills/-/skills-1.2.3.tgz%2Fextra add target",
+    "remote package executor",
+  ],
+  [
+    "registry tarball package with semicolon suffix",
+    "npx --yes 'http://example.test/skills/-/skills-1.2.3.tgz;extra' add target",
+    "remote package executor",
+  ],
+  [
+    "registry tarball package with repeated slash suffix",
+    "npx --yes http://example.test/skills/-/skills-1.2.3.tgz//extra add target",
+    "remote package executor",
+  ],
+  [
+    "registry tarball package with comma suffix",
+    "npx --yes http://example.test/skills/-/skills-1.2.3.tgz,extra add target",
+    "remote package executor",
+  ],
+  [
+    "opaque Git URL through npx",
+    "npx --yes 'git+https://example.test/widget A.git#v1' add target",
+    "remote package executor",
+  ],
+  [
+    "opaque URL through bunx",
+    "bunx https://example.test/widget.tgz install target",
+    "remote package executor",
+  ],
+  [
+    "opaque URL through npm exec",
+    "npm exec -- https://example.test/widget.tgz -- update target",
+    "remote package executor",
+  ],
+  [
+    "opaque URL through pnpm dlx",
+    "pnpm dlx https://example.test/widget.tgz add target",
+    "remote package executor",
+  ],
+  [
+    "opaque URL through yarn dlx",
+    "yarn dlx https://example.test/widget.tgz install target",
+    "remote package executor",
+  ],
+  [
+    "opaque URL after many executor flags",
+    `npx ${"--yes ".repeat(20)}https://example.test/widget.tgz add target`,
+    "remote package executor",
+  ],
+  [
+    "opaque quoted URL with literal semicolon",
+    "npx 'https://example.test/widget;extra' add target",
+    "remote package executor",
+  ],
+  [
+    "opaque URL with shell-escaped semicolon",
+    "npx https://example.test/widget\\;extra add target",
+    "remote package executor",
+  ],
+  [
+    "opaque URL after line continuation",
+    "npx --yes \\\nhttps://example.test/widget.tgz update target",
+    "remote package executor",
+  ],
+  [
+    "registry tarball package with semicolon query",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=1;foo=2' add target",
+    "skills add",
+  ],
+  [
+    "registry tarball package with legal query punctuation",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=1?more=2,@!()' add target",
+    "skills add",
+  ],
+  [
+    "registry tarball package with encoded semicolon query",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=1%3Bfoo=2' add target",
+    "skills add",
+  ],
+  [
+    "registry tarball package with fragment punctuation",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz#a!z' add target",
+    "skills add",
+  ],
+  [
+    "registry tarball package with encoded fragment punctuation",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz%23%61%21%7A' add target",
+    "skills add",
+  ],
+  [
+    "registry tarball package with double-encoded fragment punctuation",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz%2523%2561%2521%257A' add target",
+    "skills add",
+  ],
+  [
+    "Git package with fragment punctuation",
+    "npx https://github.com/vercel-labs/skills.git#a!z add target",
+    "skills add",
+  ],
+  [
+    "registry tarball package with encoded space",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=1%20foo=2' add target",
+    "percent-encoded syntax delimiter",
+  ],
+  [
+    "registry tarball package with double-encoded space",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=1%2520foo=2' add target",
+    "percent-encoded syntax delimiter",
+  ],
+  [
+    "registry tarball package with encoded angle delimiter",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=1%3Efoo=2' add target",
+    "percent-encoded syntax delimiter",
+  ],
+  [
+    "registry tarball package with numeric entity space",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=1&#32;foo=2' add target",
+    "HTML-encoded syntax delimiter",
+  ],
+  [
+    "registry tarball package with hexadecimal entity space",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=1&#x20;foo=2' add target",
+    "HTML-encoded syntax delimiter",
+  ],
+  [
+    "registry tarball package with nested entity space",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=1&amp;#32;foo=2' add target",
+    "HTML-encoded syntax delimiter",
+  ],
+  [
+    "registry tarball package with compatibility angle delimiter",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=1＜foo=2' add target",
+    "compatibility character",
+  ],
+  [
+    "registry tarball package with encoded compatibility angle delimiter",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=1%EF%BC%9Cfoo=2' add target",
+    "compatibility character",
+  ],
+  [
+    "registry tarball package with safe dollar query still installs",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=A%24B' add target",
+    "skills add",
+  ],
+  [
+    "quoted registry tarball package with raw space",
+    'npx --yes "https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=A B" add target',
+    "skills add",
+  ],
+  [
+    "quoted registry tarball package with raw angle delimiter",
+    'npx --yes "https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=A>B" add target',
+    "skills add",
+  ],
+  [
+    "single-quoted registry tarball with raw double quote",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=A\"B' add target",
+    "skills add",
+  ],
+  [
+    "registry tarball with shell-escaped space",
+    "npx --yes https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=A\\ B add target",
+    "skills add",
+  ],
+  [
+    "registry tarball with shell-escaped angle",
+    "npx --yes https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=A\\>B add target",
+    "skills add",
+  ],
+  [
+    "registry tarball with line continuation",
+    "npx --yes https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=A\\\nB add target",
+    "skills add",
+  ],
+  [
+    "Git package with shell-escaped space",
+    "npx https://github.com/vercel-labs/skills.git?q=A\\ B add target",
+    "skills add",
+  ],
+  [
+    "registry tarball package with encoded fragment",
+    "npx --yes 'https://registry.npmjs.org/skills/-/skills-1.5.20.tgz?cache=1%23v1' add target",
+    "skills add",
+  ],
+  ["Windows cmd executable", "skills.cmd add target", "skills add"],
+  ["Windows exe executable", "skills.exe update target", "skills update"],
+  ["PowerShell executable", "skills.ps1 install target", "skills install"],
+  ["JavaScript executable", "./skills.js add target", "skills add"],
+  ["ES module executable", "./skills.mjs add target", "skills add"],
+  ["Python executable", "./skills.py install target", "skills install"],
+  ["shell executable", "./skills.sh update target", "skills update"],
+  ["DOS executable", "./skills.com add target", "skills add"],
+  ["ClawHub executable", "clawhub.cmd install target", "clawhub install"],
+  [
+    "Markdown links",
+    "[skills](https://example.test/a) [add](https://example.test/b)",
+    "Markdown links and images",
+  ],
+  [
+    "deeply nested Markdown links",
+    "[skills](https://x/(a(b))) [add](https://x/) target",
+    "Markdown links and images",
+  ],
+  [
+    "angle-bracket Markdown destination",
+    "[skills](<(noise>) [add](x)",
+    "Markdown links and images",
+  ],
+  [
+    "multiline angle-bracket Markdown destination",
+    "[skills](<(a>\n) [add](x)",
+    "Markdown links and images",
+  ],
+  [
+    "angle-bracket Markdown destination after newline",
+    "[skills](\n<(a>) [add](x)",
+    "Markdown links and images",
+  ],
+  ["quote inside Markdown label", '[sk"]()ills" add', "Markdown links and images"],
+  [
+    "quote inside Markdown reference label",
+    '[skills][a"] [add][b]\n\n[a"]: /x\n[b]: /y',
+    "Markdown links and images",
+  ],
+  [
+    "entity in Markdown destination",
+    "[skills](https://x/&#41;noise) [add](https://x/)",
+    "Markdown links and images",
+  ],
+  [
+    "double entity in Markdown destination",
+    "[skills](https://x/&amp;#41;noise) [add](https://x/)",
+    "Markdown links and images",
+  ],
+  [
+    "nested Markdown image",
+    "[skills![](x)]() add",
+    "Markdown links and images",
+  ],
+  [
+    "blockquote reference definition",
+    "skills\n> [a]: x\nadd",
+    "Markdown links and images",
+  ],
+  [
+    "nested blockquote reference definition",
+    "skills\n>> [a]: x\nadd",
+    "Markdown links and images",
+  ],
+  [
+    "list reference definition",
+    "skills\n- [a]: x\nadd",
+    "Markdown links and images",
+  ],
+  [
+    "blockquote shortcut reference",
+    '> [sk"]ills" add\n>\n> [sk"]: /x',
+    "Markdown links and images",
+  ],
+  ["Markdown URI autolink", "<https://example.test/docs>", "Markdown links and images"],
+  ["Markdown email autolink", "<security@example.test>", "Markdown links and images"],
+  ["HTML anchor", '<a href="https://example.test">docs</a>', "Markdown links and images"],
+  ["HTML image", '<img src="https://example.test/x.png">', "Markdown links and images"],
+  ["HTML image alias", '<image src="https://example.test/x.png">', "Markdown links and images"],
+  [
+    "escaped-bracket reference definition",
+    "[\\]]:a\n[\\]]",
+    "Markdown links and images",
+  ],
+  ["entity inside HTML comment", "sk<!-- --&gt; -->ills add", "skills add"],
+  ["entity inside HTML tag", "sk<x a=&gt;>ills add", "skills add"],
+  ["zero-width split", "sk\u200bills add target", "formatting character"],
+  ["variation selector split", "sk\uFE0Fills add target", "default-ignorable"],
+  ["combining grapheme joiner split", "sk\u034Fills add target", "default-ignorable"],
+  ["bidirectional control", "skills\u202e add target", "formatting character"],
+  ["non-ASCII whitespace", "skills\u00a0add target", "non-ASCII whitespace"],
+  ["unknown entity", "safe &unknown; prose", "unsupported"],
+  ["unterminated comment", "safe <!-- comment", "unterminated HTML comment"],
+]) {
+  const result = inspectNonInstallableMarkdown(markdown);
+  assert.ok(result.issues.length > 0, `${label} must be rejected`);
+  assert.match(
+    result.issues.join("\n"),
+    new RegExp(expectedIssue, "i"),
+    `${label} must report ${expectedIssue}`,
+  );
+}
+
+const invalidUtf8 = inspectNonInstallableMarkdown(Buffer.from([0xc3, 0x28]));
+assert.equal(invalidUtf8.markdown, null);
+assert.match(invalidUtf8.issues.join("\n"), /not valid UTF-8/);
+
+for (const [label, markdown] of [
+  ["internal release helper", "./scripts/release-skill.sh <name> 1.2.0-rc1"],
+  ["Git operations", "git status\ngit add path\ngit push origin branch"],
+  ["GitHub release inspection", "gh release view tag"],
+  ["verification tools", "curl URL -o file\nopenssl version\njq --version\nshasum -a 256 file"],
+  ["development tools", "npm ci\nnpx eslint .\nnpx tsc --noEmit\npipx run ruff check"],
+  ["ClawHub release operations", "clawhub inspect\nclawhub login\nclawhub publish"],
+  ["read-only skill operations", "skills list\nhermes skills list\nfind_skills(query)"],
+  ["read-only dynamic filter", "skills list ${FILTER}"],
+  ["read-only dynamic command", "$tool list"],
+  ["OpenClaw cron", "openclaw cron add --name advisory-check"],
+  ["denial prose", "Installation is unavailable through public skill channels."],
+  ["unrelated words", "Skills are safe to add only after independent review."],
+  ["non-authority identifier", "install_skillful is not the Pico installer function."],
+  ["core entity", "\uFEFFUse A &amp; B.\r\n"],
+  ["plain URL", "See https://example.test/docs for details."],
+  ["plain IPv6 URL", "See http://[::1]:8080/docs for details."],
+  ["plain expanded IPv6 URL", "See https://[2001:db8::1]:443/path for details."],
+  ["plain IPv6 curl command", "curl http://[::1]:3000/feed.json -o feed.json"],
+  ["safe fenced code", "```bash\ngit status\n```"],
+  ["safe fenced variable", '```bash\nprintf "%s\\n" "${HOME}"\n```'],
+  ["safe four-backtick fence", "````bash\ngit status\n````"],
+  ["safe four-backtick variable", '````bash\nprintf "%s\\n" "${HOME}"\n````'],
+  ["safe tilde fence", "~~~bash\ngit status\n~~~"],
+  ["safe tilde variable", '~~~bash\nprintf "%s\\n" "${HOME}"\n~~~'],
+  ["safe percent-encoded URL path", "See https://example.test/a%2Fb for details."],
+  ["safe numeric-entity URL path", "See https://example.test/a&#47;b for details."],
+  ["safe raw dollar URL query", "See https://example.test/archive.tgz?x=A$B for details."],
+  ["safe encoded dollar URL query", "See https://example.test/archive.tgz?x=A%24B for details."],
+  ["safe double-encoded dollar URL query", "See https://example.test/archive.tgz?x=A%2524B for details."],
+  ["safe entity dollar URL path", "See https://example.test/a&#36;b for details."],
+  ["safe compatibility dollar URL path", "See https://example.test/a＄b for details."],
+  ["safe short authority subsequence URL", "See https://example.test/in$B for details."],
+  [
+    "safe quoted curl dollar URL",
+    "```bash\ncurl 'https://example.test/archive.tgz?x=A%24B' -o package.tgz\n```",
+  ],
+  [
+    "safe quoted curl URL with raw space",
+    "```bash\ncurl 'https://example.test/archive.tgz?x=A B' -o package.tgz\n```",
+  ],
+  [
+    "safe curl URL with shell-escaped space",
+    "```bash\ncurl https://example.test/archive.tgz?x=A\\ B -o package.tgz\n```",
+  ],
+  [
+    "safe curl URL with line continuation",
+    "```bash\ncurl https://example.test/archive.tgz?x=A\\\nB -o package.tgz\n```",
+  ],
+  [
+    "safe quoted curl URL with literal less-than",
+    "```bash\ncurl 'https://example.test/archive.tgz?q=A<B' -o package.tgz\n```",
+  ],
+  [
+    "safe curl URL with shell-escaped less-than",
+    "```bash\ncurl https://example.test/archive.tgz?q=A\\<B -o package.tgz\n```",
+  ],
+  ["safe exact conditional expansions", "echo ${a:+one}${b:+two}"],
+  ["safe exact non-colon conditional expansions", "echo ${a+one}${b+two}"],
+  [
+    "safe four exact conditional expansions",
+    "echo ${a:+one}${b:+two}${c:+three}${d:+four}",
+  ],
+  ["safe adjacent ANSI-C strings", "echo $'one'$'two'"],
+  [
+    "safe mixed exact shell expansions",
+    "echo ${a:+one}$'two'${b:+three}",
+  ],
+  ["safe literal octal outside ANSI-C quoting", "printf '%s\\n' '\\163\\153\\151'"],
+  ["safe literal U8 outside ANSI-C quoting", "printf '%s\\n' '\\U00000073'"],
+  ["safe three-digit zero-prefixed ANSI octal", "echo $'\\060123'"],
+  ["safe longer identifier", "skillsful add target"],
+  [
+    "safe URL executor with non-sensitive action",
+    "npx https://example.test/widget.tgz status",
+  ],
+  [
+    "safe URL executor with many flags and non-sensitive action",
+    `npx ${"--yes ".repeat(20)}https://example.test/widget.tgz status`,
+  ],
+  [
+    "safe attached semicolon command boundary",
+    "npx --yes; curl https://example.test/widget.bin add target",
+  ],
+  [
+    "safe attached AND command boundary",
+    "npx --yes&& curl https://example.test/widget.bin add target",
+  ],
+  [
+    "safe attached OR command boundary",
+    "npx --yes|| curl https://example.test/widget.bin add target",
+  ],
+  [
+    "safe attached pipe command boundary",
+    "npx --yes| curl https://example.test/widget.bin add target",
+  ],
+  [
+    "safe newline command boundary",
+    "npx --yes\ncurl https://example.test/widget.bin add target",
+  ],
+  [
+    "safe URL-attached semicolon command boundary",
+    "npx --yes https://example.test/widget.bin; add target",
+  ],
+  [
+    "safe URL-attached AND command boundary",
+    "npx --yes https://example.test/widget.bin&& add target",
+  ],
+  [
+    "safe shell comment after executor",
+    "npx --yes # https://example.test/widget.tgz add target",
+  ],
+  [
+    "safe shell comment before later curl command",
+    "npx --yes # ignored URL and action\ncurl https://example.test/widget.bin add target",
+  ],
+]) {
+  const result = inspectNonInstallableMarkdown(markdown);
+  assert.deepEqual(result.issues, [], `${label} must remain allowed: ${result.issues.join("; ")}`);
+}

--- a/scripts/test-skill-install-docs.mjs
+++ b/scripts/test-skill-install-docs.mjs
@@ -88,6 +88,103 @@ try {
     /Public install docs not applicable for non-installable-example: skill\.json declares "installable": false/,
   );
 
+  await writeSkill({
+    name: "non-installable-public-command",
+    metadata: { installable: false },
+    readme:
+      `${nonInstallableDocPrologue}\n\n` +
+      "```bash\nnpx skills add prompt-security/clawsec --skill non-installable-public-command -a openclaw -y\n```\n",
+    skillMd:
+      `---\nname: non-installable-public-command\n---\n\n${nonInstallableDocPrologue}\n`,
+  });
+  const publicCommand = runValidator(
+    ["--skills", "skills/non-installable-public-command"],
+    { agentTypesFile: path.join(tempRoot, "missing-agent-types.ts") },
+  );
+  assert.equal(publicCommand.status, 1, "non-installable required docs must deny public installer authority");
+  assert.match(publicCommand.stderr, /forbidden public installer authority: skills add/);
+
+  await writeSkill({
+    name: "non-installable-packaged-command",
+    metadata: { installable: false },
+    readme: `${nonInstallableDocPrologue}\n`,
+    skillMd:
+      `---\nname: non-installable-packaged-command\n---\n\n${nonInstallableDocPrologue}\n`,
+    installMd: "# Unsupported installer\n\npnpm dlx clawhub@latest install target\n",
+  });
+  const packagedCommand = runValidator(
+    ["--skills", "skills/non-installable-packaged-command"],
+    { agentTypesFile: path.join(tempRoot, "missing-agent-types.ts") },
+  );
+  assert.equal(packagedCommand.status, 1, "package-visible Markdown must deny public installer authority");
+  assert.match(
+    packagedCommand.stderr,
+    /skills\/non-installable-packaged-command\/INSTALL\.md[\s\S]*clawhub install/,
+  );
+
+  await writeSkill({
+    name: "non-installable-sbom-newline",
+    metadata: {
+      installable: false,
+      sbom: {
+        files: [{
+          path: "SAFE.md\nEVIL.md",
+          required: true,
+          description: "Ambiguous package-visible path",
+        }],
+      },
+    },
+    readme: `${nonInstallableDocPrologue}\n`,
+    skillMd:
+      `---\nname: non-installable-sbom-newline\n---\n\n${nonInstallableDocPrologue}\n`,
+  });
+  const newlineSkillRoot = path.join(tempRoot, "skills", "non-installable-sbom-newline");
+  await writeFile(path.join(newlineSkillRoot, "SAFE.md\nEVIL.md"), "# Safe combined filename\n");
+  await writeFile(path.join(newlineSkillRoot, "EVIL.md"), "npx skills add target\n");
+  const newlinePath = runValidator(
+    ["--skills", "skills/non-installable-sbom-newline"],
+    { agentTypesFile: path.join(tempRoot, "missing-agent-types.ts") },
+  );
+  assert.equal(newlinePath.status, 1, "SBOM paths must not split into extra release files");
+  assert.match(
+    newlinePath.stderr,
+    /Unsafe package-visible path for skills\/non-installable-sbom-newline: control characters are not allowed/,
+  );
+  assert.doesNotMatch(
+    newlinePath.stderr,
+    /SAFE\.md\s+EVIL\.md/,
+    "unsafe path diagnostics must not reproduce control-character filenames",
+  );
+
+  await writeSkill({
+    name: "non-installable-mdx",
+    metadata: {
+      installable: false,
+      sbom: {
+        files: [{
+          path: "INSTALL.mdx",
+          required: true,
+          description: "Executable installation documentation",
+        }],
+      },
+    },
+    readme: `${nonInstallableDocPrologue}\n`,
+    skillMd: `---\nname: non-installable-mdx\n---\n\n${nonInstallableDocPrologue}\n`,
+  });
+  await writeFile(
+    path.join(tempRoot, "skills", "non-installable-mdx", "INSTALL.mdx"),
+    '# Unsupported installer\n\nsk{"i"}lls add target\n',
+  );
+  const packagedMdx = runValidator(
+    ["--skills", "skills/non-installable-mdx"],
+    { agentTypesFile: path.join(tempRoot, "missing-agent-types.ts") },
+  );
+  assert.equal(packagedMdx.status, 1, "executable MDX must be denied for non-installable skills");
+  assert.match(
+    packagedMdx.stderr,
+    /Unsupported package-visible MDX path for non-installable skill skills\/non-installable-mdx: INSTALL\.mdx/,
+  );
+
   for (const [name, readme, skillMd] of [
     [
       "non-installable-missing-prologue",


### PR DESCRIPTION
# User description
## Summary

- add a dedicated fail-closed policy scanner for documentation attached to non-installable skills
- apply the policy to required documentation and SBOM-declared Markdown files
- reject public installer instructions hidden through Markdown/HTML, encoding, shell quoting and expansion, package suffixes, or opaque remote package executors
- preserve current repository-wide validator output while adding focused adversarial and regression coverage

## Why

PR #318 defines the non-installable documentation contract, but the existing validator could still allow public install commands to survive in documentation through alternate syntax or obfuscation. That would make a source template resolver-complete in practice even when its metadata says it is not installable.

This enforcement is required before canonical package sources can remain non-installable on public branches while beta, RC, and stable-intent artifacts stay confined to authenticated lab distribution.

## Impact and security boundary

The validator now fails closed when non-installable documentation contains `skills add/install/update`, `clawhub install`, `install_skill`, or an opaque remote package executor followed by a sensitive installer action. Ordinary read-only commands, development tools, plain URLs, safe shell boundaries, and non-sensitive remote-executor actions remain allowed.

This PR changes release-policy tooling only. It does not create, tag, publish, authorize, install, or activate any skill release.

## Validation

All execution was performed on the explicitly approved remote test machine from exact base commit `99680f13c75f827f4165fbff28db5593aadb2ed6`.

- two independent hash-bound adversarial audits accepted the exact scanner freeze
- focused scanner and install-documentation tests passed
- every `scripts/test-skill-*.mjs` test passed
- repository-wide ESLint passed
- `npx tsc --noEmit` passed
- `npm run build` passed
- clean fresh checkout replay passed after `npm ci`
- baseline and candidate `validate_skill_install_docs.mjs --all` both exited `1` with byte-identical stdout and stderr
- final fresh proof retained at `/tmp/clawsec-noninstall-final.AsTtYO` on the approved test host

The remote host lacks a system `zip`, so tag-release simulations used the existing verified wrapper with SHA-256 `472456191504d886c5871da3e900797512ab9266b8426d736c6a0f48248046b0`.

## Stack

- depends on draft PR #318
- implementation branch: `davida-ps/noninstallable-public-installer-policy-v1`
- commit: `44c3b1f620256973dae6131be5b533ba8deca0c8`

No merge, tag, release, store publication, or catalog activation is part of this PR.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implement a fail-closed Markdown inspector that normalizes obfuscation layers to block hidden public installer commands in non-installable documentation. Extend <code>validateSkill</code> and <code>validate_skill_install_docs.mjs</code> to apply that policy to required docs and SBOM-listed Markdown while preserving existing installable-skill checks.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/319?tool=ast&topic=Validator+Policy>Validator Policy</a>
        </td><td>Apply the scanner to required and package-visible Markdown for non-installable skills, and reject unsafe SBOM paths, MDX docs, and control-character filenames.<details><summary>Modified files (2)</summary><ul><li>scripts/ci/validate_skill_install_docs.mjs</li>
<li>scripts/test-skill-install-docs.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(release): enforce ...</td><td>July 23, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(advisories): align...</td><td>July 13, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/319?tool=ast&topic=Doc+Scanner>Doc Scanner</a>
        </td><td>Implement a fail-closed scanner that decodes HTML, percent escapes, shell quoting, markup, and expansion fragments to catch hidden installer authority and remote executor chains.<details><summary>Modified files (2)</summary><ul><li>scripts/ci/noninstallable_public_installer_policy.mjs</li>
<li>scripts/test-noninstallable-public-installer-policy.mjs</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(release): enforce ...</td><td>July 23, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/319?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>