### PR TITLE
feat(contracts): define non-authorizing install plans

### DIFF
--- a/contracts/fixtures/install-plan-v1/valid/nanoclaw-v2-blocked-unowned-path.json
+++ b/contracts/fixtures/install-plan-v1/valid/nanoclaw-v2-blocked-unowned-path.json
@@ -1,0 +1,152 @@
+{
+  "schema": "clawsec.install-plan/v1",
+  "path_flavor": "posix",
+  "result": {
+    "schema": "clawsec.result/v1",
+    "executor": {
+      "schema": "clawsec.component-ref/v1",
+      "name": "clawsec-core-nanoclaw",
+      "version": "0.1.0-rc.1",
+      "harness": "nanoclaw",
+      "role": "core",
+      "metadata_digest": "sha256:765f343f11e9367051b5ed95daed35ff318945c672df0f5509c0dbcd1276eea5"
+    },
+    "subject": {
+      "kind": "component",
+      "component": {
+        "schema": "clawsec.component-ref/v1",
+        "name": "clawsec-suite-nanoclaw",
+        "version": "0.1.0-rc.1",
+        "harness": "nanoclaw",
+        "role": "suite",
+        "metadata_digest": "sha256:a123a4f4451018ebafee26cfc7674a24bf33b7903a60ff69d25eb9251577e83a"
+      }
+    },
+    "invocation": {
+      "id": "66666666-6666-4666-8666-666666666666",
+      "operation": "core.plan-release",
+      "harness": {
+        "name": "nanoclaw",
+        "version": "2.1.17"
+      },
+      "scope": {
+        "kind": "nanoclaw.checkout",
+        "ref": "nanoclaw-v2-lab-01"
+      }
+    },
+    "reported_at": "2026-07-24T09:10:00Z",
+    "outcome": "blocked",
+    "reason_code": "prerequisite_missing",
+    "summary": "Synthetic contract fixture: an unowned target path prevents installation planning.",
+    "effects": []
+  },
+  "plan_id": "77777777-7777-4777-8777-777777777777",
+  "disposition": "blocked",
+  "expires_at": "2026-07-24T09:15:00Z",
+  "artifact": {
+    "channel": "private_lab",
+    "component": {
+      "schema": "clawsec.component-ref/v1",
+      "name": "clawsec-suite-nanoclaw",
+      "version": "0.1.0-rc.1",
+      "harness": "nanoclaw",
+      "role": "suite",
+      "metadata_digest": "sha256:a123a4f4451018ebafee26cfc7674a24bf33b7903a60ff69d25eb9251577e83a"
+    },
+    "authority": {
+      "kind": "private_candidate",
+      "contract": "clawsec.private-candidate/v1",
+      "document_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "signature_digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "root_fingerprint": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "expires_at": "2026-07-24T09:30:00Z"
+    },
+    "trust_policy_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "signed_checksum_manifest_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "detached_signature_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "archive_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "archive_byte_length": 2048,
+    "install_tree_manifest_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    "install_tree_entry_count": 2,
+    "install_tree_total_bytes": 1024,
+    "release_manifest_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+  },
+  "verification_refs": {
+    "release_verification_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+    "advisory_state_digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+    "install_policy_digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "decision": "reported_allow"
+  },
+  "staged_input": {
+    "kind": "quarantine_snapshot",
+    "snapshot_digest": "sha256:9191919191919191919191919191919191919191919191919191919191919191",
+    "archive_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "install_tree_manifest_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+  },
+  "target_state": {
+    "target_instance_id": "nanoclaw-v2-lab-01",
+    "scope_root_identity_digest": "sha256:7676767676767676767676767676767676767676767676767676767676767676",
+    "ancestor_chain_digest": "sha256:7878787878787878787878787878787878787878787878787878787878787878",
+    "action_set_digest": "sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+    "touched_prestate_digest": "sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+    "touched_expected_poststate_digest": "sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+  },
+  "confirmation_requirements": null,
+  "adapter": {
+    "contract": "clawsec.nanoclaw-install-adapter/v1",
+    "implementation_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "configuration_digest": "sha256:abababababababababababababababababababababababababababababababab",
+    "profile": {
+      "kind": "nanoclaw_v2_host",
+      "upstream_baseline": {
+        "version": "2.1.17",
+        "commit": "ee7f891698760f21b9e79a850d64c7f633cd95ef"
+      },
+      "checkout_revision": "1234567890abcdef1234567890abcdef12345678",
+      "checkout_status": "dirty",
+      "checkout_identity_digest": "sha256:7676767676767676767676767676767676767676767676767676767676767676",
+      "ancestor_chain_digest": "sha256:7878787878787878787878787878787878787878787878787878787878787878",
+      "skill_root_identity_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+      "skill_root_path": ".claude/skills",
+      "dependency_lock_digest": "sha256:7474747474747474747474747474747474747474747474747474747474747474",
+      "validation_plan_digest": "sha256:7373737373737373737373737373737373737373737373737373737373737373",
+      "validation_steps": [
+        "postimage_manifest",
+        "host_build",
+        "host_tests",
+        "skill_tests"
+      ],
+      "coding_harness": null,
+      "reload_behavior": "none",
+      "host_authority": true,
+      "ipc_model": "sqlite_session_databases",
+      "legacy_v1_compatibility": false
+    }
+  },
+  "apply_context": null,
+  "actions": [],
+  "rollback_order": [],
+  "blockers": [
+    {
+      "blocker_id": "unowned-suite-path",
+      "code": "unowned_state",
+      "target": {
+        "anchor": "scope_root",
+        "path": ".claude/skills/clawsec-suite-nanoclaw"
+      },
+      "summary": "The target package path exists but is not owned by a verifiable ClawSec installation receipt."
+    }
+  ],
+  "assurance": {
+    "provenance": "unverified",
+    "catalog_authorization": "unverified",
+    "release_signature_authorization": "unverified",
+    "advisory_verification": "unverified",
+    "operator_authorization": "unverified",
+    "artifact_source_membership": "unverified",
+    "action_state_derivation": "verified_when_bound",
+    "installation_authorization": "not_granted",
+    "execution": "not_executed",
+    "preconditions_at_apply_time": "unverified"
+  }
+}

--- a/contracts/fixtures/install-plan-v1/valid/nanoclaw-v2-ready.json
+++ b/contracts/fixtures/install-plan-v1/valid/nanoclaw-v2-ready.json
@@ -1,0 +1,259 @@
+{
+  "schema": "clawsec.install-plan/v1",
+  "path_flavor": "posix",
+  "result": {
+    "schema": "clawsec.result/v1",
+    "executor": {
+      "schema": "clawsec.component-ref/v1",
+      "name": "clawsec-core-nanoclaw",
+      "version": "0.1.0-rc.1",
+      "harness": "nanoclaw",
+      "role": "core",
+      "metadata_digest": "sha256:765f343f11e9367051b5ed95daed35ff318945c672df0f5509c0dbcd1276eea5"
+    },
+    "subject": {
+      "kind": "component",
+      "component": {
+        "schema": "clawsec.component-ref/v1",
+        "name": "clawsec-suite-nanoclaw",
+        "version": "0.1.0-rc.1",
+        "harness": "nanoclaw",
+        "role": "suite",
+        "metadata_digest": "sha256:a123a4f4451018ebafee26cfc7674a24bf33b7903a60ff69d25eb9251577e83a"
+      }
+    },
+    "invocation": {
+      "id": "33333333-3333-4333-8333-333333333333",
+      "operation": "core.plan-release",
+      "harness": {
+        "name": "nanoclaw",
+        "version": "2.1.17"
+      },
+      "scope": {
+        "kind": "nanoclaw.checkout",
+        "ref": "nanoclaw-v2-lab-01"
+      }
+    },
+    "reported_at": "2026-07-24T09:00:00Z",
+    "outcome": "pass",
+    "reason_code": "operation_completed",
+    "summary": "Synthetic contract fixture: the core reports a ready NanoClaw v2 suite installation plan.",
+    "effects": [
+      {
+        "effect_id": "create-package-directory",
+        "state": "proposed",
+        "target": {
+          "kind": "relative_path",
+          "value": ".claude/skills/clawsec-suite-nanoclaw"
+        },
+        "summary": "Create the suite package directory in the selected NanoClaw checkout."
+      },
+      {
+        "effect_id": "write-skill-document",
+        "state": "proposed",
+        "target": {
+          "kind": "relative_path",
+          "value": ".claude/skills/clawsec-suite-nanoclaw/SKILL.md"
+        },
+        "summary": "Write the staged suite skill document into the selected NanoClaw checkout."
+      }
+    ]
+  },
+  "plan_id": "44444444-4444-4444-8444-444444444444",
+  "disposition": "ready",
+  "expires_at": "2026-07-24T09:05:00Z",
+  "artifact": {
+    "channel": "private_lab",
+    "component": {
+      "schema": "clawsec.component-ref/v1",
+      "name": "clawsec-suite-nanoclaw",
+      "version": "0.1.0-rc.1",
+      "harness": "nanoclaw",
+      "role": "suite",
+      "metadata_digest": "sha256:a123a4f4451018ebafee26cfc7674a24bf33b7903a60ff69d25eb9251577e83a"
+    },
+    "authority": {
+      "kind": "private_candidate",
+      "contract": "clawsec.private-candidate/v1",
+      "document_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "signature_digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "root_fingerprint": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "expires_at": "2026-07-24T09:30:00Z"
+    },
+    "trust_policy_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "signed_checksum_manifest_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "detached_signature_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "archive_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "archive_byte_length": 2048,
+    "install_tree_manifest_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    "install_tree_entry_count": 2,
+    "install_tree_total_bytes": 1024,
+    "release_manifest_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+  },
+  "verification_refs": {
+    "release_verification_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+    "advisory_state_digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+    "install_policy_digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "decision": "reported_allow"
+  },
+  "staged_input": {
+    "kind": "quarantine_snapshot",
+    "snapshot_digest": "sha256:9090909090909090909090909090909090909090909090909090909090909090",
+    "archive_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "install_tree_manifest_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+  },
+  "target_state": {
+    "target_instance_id": "nanoclaw-v2-lab-01",
+    "scope_root_identity_digest": "sha256:7676767676767676767676767676767676767676767676767676767676767676",
+    "ancestor_chain_digest": "sha256:7878787878787878787878787878787878787878787878787878787878787878",
+    "action_set_digest": "sha256:5f526ab27ea59ec8406600d680df90ccb51c746173f4a4626e7828928d29f24a",
+    "touched_prestate_digest": "sha256:3e76ce75c0f90c21a84990ff6a71c511410939e8eb2995d55498215e5a44f803",
+    "touched_expected_poststate_digest": "sha256:1e5da7e8b5a1c361a4ab8bf407d65d2922d316bac3dfb038fb0453cd7ab282af"
+  },
+  "confirmation_requirements": {
+    "binding": "sha256_exact_plan_bytes",
+    "disclosure_source": "install_plan_actions",
+    "external_nonce": "required",
+    "authenticated_principal": "required",
+    "target_instance_binding": "required",
+    "one_time_ledger": "required",
+    "expires_with_plan": true
+  },
+  "adapter": {
+    "contract": "clawsec.nanoclaw-install-adapter/v1",
+    "implementation_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "configuration_digest": "sha256:abababababababababababababababababababababababababababababababab",
+    "profile": {
+      "kind": "nanoclaw_v2_host",
+      "upstream_baseline": {
+        "version": "2.1.17",
+        "commit": "ee7f891698760f21b9e79a850d64c7f633cd95ef"
+      },
+      "checkout_revision": "1234567890abcdef1234567890abcdef12345678",
+      "checkout_status": "dirty",
+      "checkout_identity_digest": "sha256:7676767676767676767676767676767676767676767676767676767676767676",
+      "ancestor_chain_digest": "sha256:7878787878787878787878787878787878787878787878787878787878787878",
+      "skill_root_identity_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+      "skill_root_path": ".claude/skills",
+      "dependency_lock_digest": "sha256:7474747474747474747474747474747474747474747474747474747474747474",
+      "validation_plan_digest": "sha256:7373737373737373737373737373737373737373737373737373737373737373",
+      "validation_steps": [
+        "postimage_manifest",
+        "host_build",
+        "host_tests",
+        "skill_tests"
+      ],
+      "coding_harness": null,
+      "reload_behavior": "none",
+      "host_authority": true,
+      "ipc_model": "sqlite_session_databases",
+      "legacy_v1_compatibility": false
+    }
+  },
+  "apply_context": {
+    "executor": {
+      "schema": "clawsec.component-ref/v1",
+      "name": "clawsec-core-nanoclaw",
+      "version": "0.1.0-rc.1",
+      "harness": "nanoclaw",
+      "role": "core",
+      "metadata_digest": "sha256:765f343f11e9367051b5ed95daed35ff318945c672df0f5509c0dbcd1276eea5"
+    },
+    "subject": {
+      "kind": "component",
+      "component": {
+        "schema": "clawsec.component-ref/v1",
+        "name": "clawsec-suite-nanoclaw",
+        "version": "0.1.0-rc.1",
+        "harness": "nanoclaw",
+        "role": "suite",
+        "metadata_digest": "sha256:a123a4f4451018ebafee26cfc7674a24bf33b7903a60ff69d25eb9251577e83a"
+      }
+    },
+    "invocation": {
+      "id": "88888888-8888-4888-8888-888888888888",
+      "operation": "core.install-release",
+      "harness": {
+        "name": "nanoclaw",
+        "version": "2.1.17"
+      },
+      "scope": {
+        "kind": "nanoclaw.checkout",
+        "ref": "nanoclaw-v2-lab-01"
+      }
+    }
+  },
+  "actions": [
+    {
+      "action_id": "create-package-directory",
+      "kind": "managed_entry",
+      "operation": "create",
+      "target": {
+        "anchor": "scope_root",
+        "path": ".claude/skills/clawsec-suite-nanoclaw"
+      },
+      "before": {
+        "kind": "absent"
+      },
+      "after": {
+        "kind": "directory",
+        "mode": "0755",
+        "owner_identity_digest": "sha256:7171717171717171717171717171717171717171717171717171717171717171",
+        "group_identity_digest": "sha256:7272727272727272727272727272727272727272727272727272727272727272"
+      },
+      "tree_entry": {
+        "kind": "directory",
+        "path": ".",
+        "manifest_entry_digest": "sha256:1010101010101010101010101010101010101010101010101010101010101010",
+        "mode": "0755"
+      },
+      "rollback_source": null
+    },
+    {
+      "action_id": "write-skill-document",
+      "kind": "managed_entry",
+      "operation": "create",
+      "target": {
+        "anchor": "scope_root",
+        "path": ".claude/skills/clawsec-suite-nanoclaw/SKILL.md"
+      },
+      "before": {
+        "kind": "absent"
+      },
+      "after": {
+        "kind": "file",
+        "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+        "byte_length": 1024,
+        "mode": "0644",
+        "owner_identity_digest": "sha256:7171717171717171717171717171717171717171717171717171717171717171",
+        "group_identity_digest": "sha256:7272727272727272727272727272727272727272727272727272727272727272"
+      },
+      "tree_entry": {
+        "kind": "file",
+        "path": "SKILL.md",
+        "manifest_entry_digest": "sha256:1212121212121212121212121212121212121212121212121212121212121212",
+        "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+        "byte_length": 1024,
+        "mode": "0644"
+      },
+      "rollback_source": null
+    }
+  ],
+  "rollback_order": [
+    "write-skill-document",
+    "create-package-directory"
+  ],
+  "blockers": [],
+  "assurance": {
+    "provenance": "unverified",
+    "catalog_authorization": "unverified",
+    "release_signature_authorization": "unverified",
+    "advisory_verification": "unverified",
+    "operator_authorization": "unverified",
+    "artifact_source_membership": "unverified",
+    "action_state_derivation": "verified_when_bound",
+    "installation_authorization": "not_granted",
+    "execution": "not_executed",
+    "preconditions_at_apply_time": "unverified"
+  }
+}

--- a/contracts/install-plan-policy.json
+++ b/contracts/install-plan-policy.json
@@ -1,0 +1,88 @@
+{
+  "contract": "clawsec.install-plan-policy/v1",
+  "contract_version": "1",
+  "maximum_plan_bytes": 1048576,
+  "maximum_validity_seconds": 900,
+  "maximum_actions": 64,
+  "maximum_blockers": 64,
+  "maximum_document_nodes": 4096,
+  "maximum_object_keys": 64,
+  "maximum_array_items": 64,
+  "maximum_install_tree_entries": 4096,
+  "maximum_archive_bytes": 134217728,
+  "maximum_installed_file_bytes": 67108864,
+  "maximum_install_tree_bytes": 268435456,
+  "maximum_planned_output_bytes": 268435456,
+  "maximum_planned_output_entries": 64,
+  "maximum_captured_preimage_bytes": 268435456,
+  "maximum_captured_preimage_entries": 64,
+  "maximum_expansion_ratio": 100,
+  "dispositions": {
+    "blocked": {
+      "result_outcome": "blocked",
+      "eligible_for_confirmation": false,
+      "authorizes_installation": false,
+      "minimum_actions": 0,
+      "maximum_actions": 0,
+      "minimum_blockers": 1,
+      "maximum_blockers": 64
+    },
+    "ready": {
+      "result_outcome": "pass",
+      "eligible_for_confirmation": true,
+      "authorizes_installation": false,
+      "minimum_actions": 1,
+      "maximum_actions": 64,
+      "minimum_blockers": 0,
+      "maximum_blockers": 0
+    }
+  },
+  "confirmation": {
+    "binding": "sha256_exact_plan_bytes",
+    "disclosure_source": "install_plan_actions",
+    "external_nonce_required": true,
+    "authenticated_principal_required": true,
+    "target_instance_binding_required": true,
+    "one_time_ledger_required": true,
+    "expires_with_plan": true,
+    "confirmation_authorizes_installation": false,
+    "apply_reverification_required": true
+  },
+  "filesystem": {
+    "path_flavor": "posix",
+    "target_anchor": "scope_root",
+    "paths_are_scope_relative": true,
+    "trailing_dot_segments_allowed": false,
+    "windows_device_basenames_allowed": false,
+    "symlinks_allowed": false,
+    "special_files_allowed": false,
+    "group_or_other_write_allowed": false,
+    "managed_entries_are_fresh_create_only": true,
+    "managed_entries_require_absent_prestate": true,
+    "existing_target_entries_are_blockers": true,
+    "install_tree_entries_require_manifest_entry_digest": true
+  },
+  "rollback": {
+    "state_mutating_actions_require_rollback": true,
+    "managed_create_rolls_back_by_removal": true,
+    "declared_transformation_requires_captured_preimage": true,
+    "non_state_mutating_actions_have_null_rollback": true,
+    "non_state_mutating_actions_excluded_from_rollback_order": true
+  },
+  "assurance": {
+    "exact_plan_bytes": "verified",
+    "exact_component_metadata": "verified_when_bound",
+    "caller_expected_artifact": "verified_when_bound",
+    "future_install_context": "verified_when_ready",
+    "provenance": "unverified",
+    "catalog_authorization": "unverified",
+    "release_signature_authorization": "unverified",
+    "advisory_verification": "unverified",
+    "operator_authorization": "unverified",
+    "artifact_source_membership": "unverified",
+    "action_state_derivation": "verified_when_bound",
+    "installation_authorization": "not_granted",
+    "execution": "not_executed",
+    "preconditions_at_apply_time": "unverified"
+  }
+}

--- a/contracts/schemas/install/adapters/hermes-v1.schema.json
+++ b/contracts/schemas/install/adapters/hermes-v1.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawsec.prompt.security/contracts/schemas/install/adapters/hermes-v1.schema.json",
+  "title": "ClawSec Hermes install adapter profile v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "profile_identity_digest",
+    "profile_config_digest",
+    "skill_root_identity_digest",
+    "native_install_status",
+    "reload_behavior"
+  ],
+  "properties": {
+    "kind": {
+      "const": "hermes"
+    },
+    "profile_identity_digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "profile_config_digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "skill_root_identity_digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "native_install_status": {
+      "const": "prototype_pending"
+    },
+    "reload_behavior": {
+      "$ref": "#/definitions/reloadBehavior"
+    }
+  },
+  "definitions": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "reloadBehavior": {
+      "const": "none"
+    }
+  }
+}

--- a/contracts/schemas/install/adapters/nanoclaw-v2.schema.json
+++ b/contracts/schemas/install/adapters/nanoclaw-v2.schema.json
@@ -1,0 +1,237 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawsec.prompt.security/contracts/schemas/install/adapters/nanoclaw-v2.schema.json",
+  "title": "ClawSec NanoClaw v2 host install adapter profile",
+  "description": "Closed host-authoritative profile for a specific NanoClaw v2 checkout and its required validation work.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "upstream_baseline",
+    "checkout_revision",
+    "checkout_status",
+    "checkout_identity_digest",
+    "ancestor_chain_digest",
+    "skill_root_identity_digest",
+    "skill_root_path",
+    "dependency_lock_digest",
+    "validation_plan_digest",
+    "validation_steps",
+    "coding_harness",
+    "reload_behavior",
+    "host_authority",
+    "ipc_model",
+    "legacy_v1_compatibility"
+  ],
+  "properties": {
+    "kind": {
+      "const": "nanoclaw_v2_host"
+    },
+    "upstream_baseline": {
+      "$ref": "#/definitions/upstreamBaseline"
+    },
+    "checkout_revision": {
+      "$ref": "#/definitions/sha40"
+    },
+    "checkout_status": {
+      "enum": [
+        "clean",
+        "dirty",
+        "conflicted"
+      ]
+    },
+    "checkout_identity_digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "ancestor_chain_digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "skill_root_identity_digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "skill_root_path": {
+      "const": ".claude/skills"
+    },
+    "dependency_lock_digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "validation_plan_digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "validation_steps": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 7,
+      "uniqueItems": true,
+      "contains": {
+        "const": "postimage_manifest"
+      },
+      "items": {
+        "enum": [
+          "postimage_manifest",
+          "host_build",
+          "host_tests",
+          "skill_tests",
+          "container_typecheck",
+          "container_build",
+          "container_tests"
+        ]
+      }
+    },
+    "coding_harness": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/definitions/codingHarness"
+        }
+      ]
+    },
+    "reload_behavior": {
+      "$ref": "#/definitions/reloadBehavior"
+    },
+    "host_authority": {
+      "const": true
+    },
+    "ipc_model": {
+      "const": "sqlite_session_databases"
+    },
+    "legacy_v1_compatibility": {
+      "const": false
+    }
+  },
+  "definitions": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "sha40": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "finalSemVer": {
+      "type": "string",
+      "pattern": "^(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)$"
+    },
+    "exactSemVer": {
+      "type": "string",
+      "pattern": "^(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$"
+    },
+    "reloadBehavior": {
+      "enum": [
+        "none",
+        "reload_harness",
+        "restart_harness"
+      ]
+    },
+    "upstreamBaseline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "commit"
+      ],
+      "properties": {
+        "version": {
+          "$ref": "#/definitions/finalSemVer"
+        },
+        "commit": {
+          "$ref": "#/definitions/sha40"
+        }
+      }
+    },
+    "exactVersionReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "value"
+      ],
+      "properties": {
+        "kind": {
+          "const": "exact_version"
+        },
+        "value": {
+          "$ref": "#/definitions/exactSemVer"
+        }
+      }
+    },
+    "commitReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "value"
+      ],
+      "properties": {
+        "kind": {
+          "const": "commit"
+        },
+        "value": {
+          "$ref": "#/definitions/sha40"
+        }
+      }
+    },
+    "contentDigestReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "value"
+      ],
+      "properties": {
+        "kind": {
+          "const": "content_digest"
+        },
+        "value": {
+          "$ref": "#/definitions/digest"
+        }
+      }
+    },
+    "immutableReference": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/exactVersionReference"
+        },
+        {
+          "$ref": "#/definitions/commitReference"
+        },
+        {
+          "$ref": "#/definitions/contentDigestReference"
+        }
+      ]
+    },
+    "codingHarness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "immutable_reference",
+        "implementation_digest",
+        "toolchain_digest",
+        "configuration_digest"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]*$"
+        },
+        "immutable_reference": {
+          "$ref": "#/definitions/immutableReference"
+        },
+        "implementation_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "toolchain_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "configuration_digest": {
+          "$ref": "#/definitions/digest"
+        }
+      }
+    }
+  }
+}

--- a/contracts/schemas/install/adapters/openclaw-v1.schema.json
+++ b/contracts/schemas/install/adapters/openclaw-v1.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawsec.prompt.security/contracts/schemas/install/adapters/openclaw-v1.schema.json",
+  "title": "ClawSec OpenClaw install adapter profile v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "scope_identity_digest",
+    "skill_root_identity_digest",
+    "skill_root_path",
+    "reload_behavior"
+  ],
+  "properties": {
+    "kind": {
+      "const": "openclaw"
+    },
+    "scope_identity_digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "skill_root_identity_digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "skill_root_path": {
+      "$ref": "#/definitions/portableRelativePath"
+    },
+    "reload_behavior": {
+      "$ref": "#/definitions/reloadBehavior"
+    }
+  },
+  "definitions": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "portableRelativePath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*(?:^|/)[^/]*\\.(?:/|$))(?!.*(?:^|/)(?:[Cc][Oo][Nn]|[Pp][Rr][Nn]|[Aa][Uu][Xx]|[Nn][Uu][Ll]|[Cc][Oo][Mm][1-9]|[Ll][Pp][Tt][1-9])(?:\\.[^/]*)?(?:/|$))[A-Za-z0-9._@+-]+(?:/[A-Za-z0-9._@+-]+)*$"
+    },
+    "reloadBehavior": {
+      "enum": [
+        "none",
+        "reload_harness",
+        "restart_harness"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/install/adapters/picoclaw-v1.schema.json
+++ b/contracts/schemas/install/adapters/picoclaw-v1.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawsec.prompt.security/contracts/schemas/install/adapters/picoclaw-v1.schema.json",
+  "title": "ClawSec PicoClaw install adapter profile v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "home_identity_digest",
+    "config_schema_version",
+    "config_digest",
+    "skill_root_identity_digest",
+    "native_install_status",
+    "reload_behavior"
+  ],
+  "properties": {
+    "kind": {
+      "const": "picoclaw"
+    },
+    "home_identity_digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "config_schema_version": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]*$"
+    },
+    "config_digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "skill_root_identity_digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "native_install_status": {
+      "const": "prototype_pending"
+    },
+    "reload_behavior": {
+      "$ref": "#/definitions/reloadBehavior"
+    }
+  },
+  "definitions": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "reloadBehavior": {
+      "const": "none"
+    }
+  }
+}

--- a/contracts/schemas/install/install-plan-v1.schema.json
+++ b/contracts/schemas/install/install-plan-v1.schema.json
@@ -1,0 +1,1259 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawsec.prompt.security/contracts/schemas/install/install-plan-v1.schema.json",
+  "title": "ClawSec install plan v1",
+  "description": "A bounded, non-authorizing proposal for installing one exact ClawSec artifact into one explicit harness scope. Every managed create binds one exact digest-referenced install-tree entry claim; membership is unverified here. Exact signature, advisory, operator-authorization, and apply-time precondition proof live outside this document.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "result",
+    "plan_id",
+    "disposition",
+    "path_flavor",
+    "expires_at",
+    "artifact",
+    "verification_refs",
+    "staged_input",
+    "target_state",
+    "confirmation_requirements",
+    "adapter",
+    "apply_context",
+    "actions",
+    "rollback_order",
+    "blockers",
+    "assurance"
+  ],
+  "properties": {
+    "schema": {
+      "const": "clawsec.install-plan/v1"
+    },
+    "result": {
+      "$ref": "https://clawsec.prompt.security/contracts/schemas/result/result-v1.schema.json"
+    },
+    "plan_id": {
+      "$ref": "#/definitions/uuidV4"
+    },
+    "disposition": {
+      "enum": [
+        "blocked",
+        "ready"
+      ]
+    },
+    "path_flavor": {
+      "const": "posix"
+    },
+    "expires_at": {
+      "$ref": "#/definitions/timestamp"
+    },
+    "artifact": {
+      "$ref": "#/definitions/artifact"
+    },
+    "verification_refs": {
+      "$ref": "#/definitions/verificationRefs"
+    },
+    "staged_input": {
+      "$ref": "#/definitions/stagedInput"
+    },
+    "target_state": {
+      "$ref": "#/definitions/targetState"
+    },
+    "confirmation_requirements": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/definitions/confirmationRequirements"
+        }
+      ]
+    },
+    "adapter": {
+      "$ref": "#/definitions/adapter"
+    },
+    "apply_context": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/definitions/expectedContext"
+        }
+      ]
+    },
+    "actions": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/managedEntryAction"
+          },
+          {
+            "$ref": "#/definitions/declaredTransformationAction"
+          },
+          {
+            "$ref": "#/definitions/nativeOperationAction"
+          }
+        ]
+      }
+    },
+    "rollback_order": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "$ref": "#/definitions/actionId"
+      }
+    },
+    "blockers": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "$ref": "#/definitions/blocker"
+      }
+    },
+    "assurance": {
+      "$ref": "#/definitions/assurance"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "disposition": {
+            "const": "blocked"
+          }
+        },
+        "required": [
+          "disposition"
+        ]
+      },
+      "then": {
+        "properties": {
+          "actions": {
+            "maxItems": 0
+          },
+          "rollback_order": {
+            "maxItems": 0
+          },
+          "blockers": {
+            "minItems": 1,
+            "maxItems": 64
+          },
+          "confirmation_requirements": {
+            "type": "null"
+          },
+          "apply_context": {
+            "type": "null"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "disposition": {
+            "const": "ready"
+          }
+        },
+        "required": [
+          "disposition"
+        ]
+      },
+      "then": {
+        "properties": {
+          "actions": {
+            "minItems": 1,
+            "maxItems": 64
+          },
+          "blockers": {
+            "maxItems": 0
+          },
+          "confirmation_requirements": {
+            "$ref": "#/definitions/confirmationRequirements"
+          },
+          "apply_context": {
+            "$ref": "#/definitions/expectedContext"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "adapter": {
+            "properties": {
+              "profile": {
+                "properties": {
+                  "native_install_status": {
+                    "const": "prototype_pending"
+                  }
+                },
+                "required": [
+                  "native_install_status"
+                ]
+              }
+            },
+            "required": [
+              "profile"
+            ]
+          }
+        },
+        "required": [
+          "adapter"
+        ]
+      },
+      "then": {
+        "properties": {
+          "disposition": {
+            "const": "blocked"
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "sha40": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "exactSemVer": {
+      "type": "string",
+      "pattern": "^(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$"
+    },
+    "boundedIdentifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:@+-]*$"
+    },
+    "uuidV4": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^[^\\u0000-\\u001f\\u007f]+$"
+    },
+    "actionId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[a-z0-9][a-z0-9._-]*$"
+    },
+    "mode": {
+      "type": "string",
+      "description": "Four-digit octal mode with group and other write bits forbidden.",
+      "pattern": "^0[0-7][0145][0145]$"
+    },
+    "relativePath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*(?:^|/)[^/]*\\.(?:/|$))(?!.*(?:^|/)(?:[Cc][Oo][Nn]|[Pp][Rr][Nn]|[Aa][Uu][Xx]|[Nn][Uu][Ll]|[Cc][Oo][Mm][1-9]|[Ll][Pp][Tt][1-9])(?:\\.[^/]*)?(?:/|$))[A-Za-z0-9._@+-]+(?:/[A-Za-z0-9._@+-]+)*$"
+    },
+    "anchoredPath": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "anchor",
+        "path"
+      ],
+      "properties": {
+        "anchor": {
+          "const": "scope_root"
+        },
+        "path": {
+          "$ref": "#/definitions/relativePath"
+        }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "channel",
+        "component",
+        "authority",
+        "trust_policy_digest",
+        "signed_checksum_manifest_digest",
+        "detached_signature_digest",
+        "archive_digest",
+        "archive_byte_length",
+        "install_tree_manifest_digest",
+        "install_tree_entry_count",
+        "install_tree_total_bytes",
+        "release_manifest_digest"
+      ],
+      "properties": {
+        "channel": {
+          "enum": [
+            "private_lab",
+            "public_stable"
+          ]
+        },
+        "component": {
+          "$ref": "https://clawsec.prompt.security/contracts/schemas/component/component-ref-v1.schema.json"
+        },
+        "authority": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/privateCandidateAuthority"
+            },
+            {
+              "$ref": "#/definitions/activeCatalogEntryAuthority"
+            }
+          ]
+        },
+        "trust_policy_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "signed_checksum_manifest_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "detached_signature_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "archive_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "archive_byte_length": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 134217728
+        },
+        "install_tree_manifest_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "install_tree_entry_count": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 4096
+        },
+        "install_tree_total_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 268435456
+        },
+        "release_manifest_digest": {
+          "$ref": "#/definitions/digest"
+        }
+      }
+    },
+    "privateCandidateAuthority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "contract",
+        "document_digest",
+        "signature_digest",
+        "root_fingerprint",
+        "expires_at"
+      ],
+      "properties": {
+        "kind": {
+          "const": "private_candidate"
+        },
+        "contract": {
+          "const": "clawsec.private-candidate/v1"
+        },
+        "document_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "signature_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "root_fingerprint": {
+          "$ref": "#/definitions/digest"
+        },
+        "expires_at": {
+          "$ref": "#/definitions/timestamp"
+        }
+      }
+    },
+    "activeCatalogEntryAuthority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "contract",
+        "document_digest",
+        "signature_digest",
+        "root_fingerprint",
+        "expires_at"
+      ],
+      "properties": {
+        "kind": {
+          "const": "active_catalog_entry"
+        },
+        "contract": {
+          "const": "clawsec.catalog-entry/v1"
+        },
+        "document_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "signature_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "root_fingerprint": {
+          "$ref": "#/definitions/digest"
+        },
+        "expires_at": {
+          "$ref": "#/definitions/timestamp"
+        }
+      }
+    },
+    "verificationRefs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "release_verification_digest",
+        "advisory_state_digest",
+        "install_policy_digest",
+        "decision"
+      ],
+      "properties": {
+        "release_verification_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "advisory_state_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "install_policy_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "decision": {
+          "const": "reported_allow"
+        }
+      }
+    },
+    "adapter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract",
+        "implementation_digest",
+        "configuration_digest",
+        "profile"
+      ],
+      "properties": {
+        "contract": {
+          "type": "string",
+          "pattern": "^clawsec\\.(?:openclaw|hermes|nanoclaw|picoclaw)-install-adapter/v1$"
+        },
+        "implementation_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "configuration_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "profile": {
+          "oneOf": [
+            {
+              "$ref": "https://clawsec.prompt.security/contracts/schemas/install/adapters/openclaw-v1.schema.json"
+            },
+            {
+              "$ref": "https://clawsec.prompt.security/contracts/schemas/install/adapters/hermes-v1.schema.json"
+            },
+            {
+              "$ref": "https://clawsec.prompt.security/contracts/schemas/install/adapters/nanoclaw-v2.schema.json"
+            },
+            {
+              "$ref": "https://clawsec.prompt.security/contracts/schemas/install/adapters/picoclaw-v1.schema.json"
+            }
+          ]
+        }
+      }
+    },
+    "stagedInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "snapshot_digest",
+        "archive_digest",
+        "install_tree_manifest_digest"
+      ],
+      "properties": {
+        "kind": {
+          "const": "quarantine_snapshot"
+        },
+        "snapshot_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "archive_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "install_tree_manifest_digest": {
+          "$ref": "#/definitions/digest"
+        }
+      }
+    },
+    "targetState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target_instance_id",
+        "scope_root_identity_digest",
+        "ancestor_chain_digest",
+        "action_set_digest",
+        "touched_prestate_digest",
+        "touched_expected_poststate_digest"
+      ],
+      "properties": {
+        "target_instance_id": {
+          "$ref": "#/definitions/boundedIdentifier"
+        },
+        "scope_root_identity_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "ancestor_chain_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "action_set_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "touched_prestate_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "touched_expected_poststate_digest": {
+          "$ref": "#/definitions/digest"
+        }
+      }
+    },
+    "confirmationRequirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "binding",
+        "disclosure_source",
+        "external_nonce",
+        "authenticated_principal",
+        "target_instance_binding",
+        "one_time_ledger",
+        "expires_with_plan"
+      ],
+      "properties": {
+        "binding": {
+          "const": "sha256_exact_plan_bytes"
+        },
+        "disclosure_source": {
+          "const": "install_plan_actions"
+        },
+        "external_nonce": {
+          "const": "required"
+        },
+        "authenticated_principal": {
+          "const": "required"
+        },
+        "target_instance_binding": {
+          "const": "required"
+        },
+        "one_time_ledger": {
+          "const": "required"
+        },
+        "expires_with_plan": {
+          "const": true
+        }
+      }
+    },
+    "expectedContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "executor",
+        "subject",
+        "invocation"
+      ],
+      "properties": {
+        "executor": {
+          "$ref": "https://clawsec.prompt.security/contracts/schemas/component/component-ref-v1.schema.json"
+        },
+        "subject": {
+          "$ref": "https://clawsec.prompt.security/contracts/schemas/result/result-v1.schema.json#/definitions/subject"
+        },
+        "invocation": {
+          "$ref": "https://clawsec.prompt.security/contracts/schemas/result/result-v1.schema.json#/definitions/invocation"
+        }
+      }
+    },
+    "assurance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provenance",
+        "catalog_authorization",
+        "release_signature_authorization",
+        "advisory_verification",
+        "operator_authorization",
+        "artifact_source_membership",
+        "action_state_derivation",
+        "installation_authorization",
+        "execution",
+        "preconditions_at_apply_time"
+      ],
+      "properties": {
+        "provenance": {
+          "const": "unverified"
+        },
+        "catalog_authorization": {
+          "const": "unverified"
+        },
+        "release_signature_authorization": {
+          "const": "unverified"
+        },
+        "advisory_verification": {
+          "const": "unverified"
+        },
+        "operator_authorization": {
+          "const": "unverified"
+        },
+        "artifact_source_membership": {
+          "const": "unverified"
+        },
+        "action_state_derivation": {
+          "const": "verified_when_bound"
+        },
+        "installation_authorization": {
+          "const": "not_granted"
+        },
+        "execution": {
+          "const": "not_executed"
+        },
+        "preconditions_at_apply_time": {
+          "const": "unverified"
+        }
+      }
+    },
+    "absentState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "const": "absent"
+        }
+      }
+    },
+    "directoryState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "mode",
+        "owner_identity_digest",
+        "group_identity_digest"
+      ],
+      "properties": {
+        "kind": {
+          "const": "directory"
+        },
+        "mode": {
+          "$ref": "#/definitions/mode"
+        },
+        "owner_identity_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "group_identity_digest": {
+          "$ref": "#/definitions/digest"
+        }
+      }
+    },
+    "fileState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "digest",
+        "byte_length",
+        "mode",
+        "owner_identity_digest",
+        "group_identity_digest"
+      ],
+      "properties": {
+        "kind": {
+          "const": "file"
+        },
+        "digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "byte_length": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 67108864
+        },
+        "mode": {
+          "$ref": "#/definitions/mode"
+        },
+        "owner_identity_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "group_identity_digest": {
+          "$ref": "#/definitions/digest"
+        }
+      }
+    },
+    "entryState": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/absentState"
+        },
+        {
+          "$ref": "#/definitions/directoryState"
+        },
+        {
+          "$ref": "#/definitions/fileState"
+        }
+      ]
+    },
+    "installTreeEntryPath": {
+      "description": "POSIX path claimed inside the digest-referenced package install tree. A single dot identifies the package root; membership is unverified here.",
+      "oneOf": [
+        {
+          "const": "."
+        },
+        {
+          "$ref": "#/definitions/relativePath"
+        }
+      ]
+    },
+    "installTreeDirectoryEntry": {
+      "description": "One exact digest-referenced directory-entry claim, including empty directories and the package root; membership is unverified here.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "path",
+        "manifest_entry_digest",
+        "mode"
+      ],
+      "properties": {
+        "kind": {
+          "const": "directory"
+        },
+        "path": {
+          "$ref": "#/definitions/installTreeEntryPath"
+        },
+        "manifest_entry_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "mode": {
+          "$ref": "#/definitions/mode"
+        }
+      }
+    },
+    "installTreeFileEntry": {
+      "description": "One exact digest-referenced file-entry claim, including its content digest and byte length; membership is unverified here.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "path",
+        "manifest_entry_digest",
+        "digest",
+        "byte_length",
+        "mode"
+      ],
+      "properties": {
+        "kind": {
+          "const": "file"
+        },
+        "path": {
+          "$ref": "#/definitions/relativePath"
+        },
+        "manifest_entry_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "byte_length": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 67108864
+        },
+        "mode": {
+          "$ref": "#/definitions/mode"
+        }
+      }
+    },
+    "installTreeEntry": {
+      "description": "One exact digest-referenced install-tree entry claim used by a fresh managed create; membership is unverified here.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/installTreeDirectoryEntry"
+        },
+        {
+          "$ref": "#/definitions/installTreeFileEntry"
+        }
+      ]
+    },
+    "capturedFileRollbackSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "digest",
+        "byte_length",
+        "mode",
+        "owner_identity_digest",
+        "group_identity_digest"
+      ],
+      "properties": {
+        "kind": {
+          "const": "captured_file"
+        },
+        "digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "byte_length": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 67108864
+        },
+        "mode": {
+          "$ref": "#/definitions/mode"
+        },
+        "owner_identity_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "group_identity_digest": {
+          "$ref": "#/definitions/digest"
+        }
+      }
+    },
+    "managedEntryAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action_id",
+        "kind",
+        "operation",
+        "target",
+        "before",
+        "after",
+        "tree_entry",
+        "rollback_source"
+      ],
+      "properties": {
+        "action_id": {
+          "$ref": "#/definitions/actionId"
+        },
+        "kind": {
+          "const": "managed_entry"
+        },
+        "operation": {
+          "const": "create"
+        },
+        "target": {
+          "$ref": "#/definitions/anchoredPath"
+        },
+        "before": {
+          "$ref": "#/definitions/absentState"
+        },
+        "after": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/directoryState"
+            },
+            {
+              "$ref": "#/definitions/fileState"
+            }
+          ]
+        },
+        "tree_entry": {
+          "description": "The exact digest-referenced install-tree entry claim created at target; membership is unverified here.",
+          "$ref": "#/definitions/installTreeEntry"
+        },
+        "rollback_source": {
+          "type": "null"
+        }
+      }
+    },
+    "exactVersionReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "value"
+      ],
+      "properties": {
+        "kind": {
+          "const": "exact_version"
+        },
+        "value": {
+          "$ref": "#/definitions/exactSemVer"
+        }
+      }
+    },
+    "commitReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "value"
+      ],
+      "properties": {
+        "kind": {
+          "const": "commit"
+        },
+        "value": {
+          "$ref": "#/definitions/sha40"
+        }
+      }
+    },
+    "contentDigestReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "value"
+      ],
+      "properties": {
+        "kind": {
+          "const": "content_digest"
+        },
+        "value": {
+          "$ref": "#/definitions/digest"
+        }
+      }
+    },
+    "immutableReference": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/exactVersionReference"
+        },
+        {
+          "$ref": "#/definitions/commitReference"
+        },
+        {
+          "$ref": "#/definitions/contentDigestReference"
+        }
+      ]
+    },
+    "codingHarness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "immutable_reference",
+        "implementation_digest",
+        "toolchain_digest",
+        "configuration_digest"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]*$"
+        },
+        "immutable_reference": {
+          "$ref": "#/definitions/immutableReference"
+        },
+        "implementation_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "toolchain_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "configuration_digest": {
+          "$ref": "#/definitions/digest"
+        }
+      }
+    },
+    "allowedTransformationOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target",
+        "before",
+        "after"
+      ],
+      "properties": {
+        "target": {
+          "$ref": "#/definitions/anchoredPath"
+        },
+        "before": {
+          "$ref": "#/definitions/fileState"
+        },
+        "after": {
+          "$ref": "#/definitions/fileState"
+        }
+      }
+    },
+    "managedFileTreeEntryReference": {
+      "description": "Reference to an earlier managed file action and its exact digest-referenced install-tree entry claim; membership is unverified here.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "managed_action_id",
+        "manifest_entry_digest"
+      ],
+      "properties": {
+        "managed_action_id": {
+          "$ref": "#/definitions/actionId"
+        },
+        "manifest_entry_digest": {
+          "$ref": "#/definitions/digest"
+        }
+      }
+    },
+    "transformationDeclaration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "release_manifest_digest",
+        "transformation_entry_digest",
+        "allowed_output",
+        "coding_harness"
+      ],
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/managedFileTreeEntryReference"
+        },
+        "release_manifest_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "transformation_entry_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "allowed_output": {
+          "$ref": "#/definitions/allowedTransformationOutput"
+        },
+        "coding_harness": {
+          "$ref": "#/definitions/codingHarness"
+        }
+      }
+    },
+    "declaredTransformationAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action_id",
+        "kind",
+        "target",
+        "declaration",
+        "before",
+        "after",
+        "rollback_source"
+      ],
+      "properties": {
+        "action_id": {
+          "$ref": "#/definitions/actionId"
+        },
+        "kind": {
+          "const": "declared_transformation"
+        },
+        "target": {
+          "$ref": "#/definitions/anchoredPath"
+        },
+        "declaration": {
+          "$ref": "#/definitions/transformationDeclaration"
+        },
+        "before": {
+          "$ref": "#/definitions/fileState"
+        },
+        "after": {
+          "$ref": "#/definitions/fileState"
+        },
+        "rollback_source": {
+          "$ref": "#/definitions/capturedFileRollbackSource"
+        }
+      }
+    },
+    "harnessResourceTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "value",
+        "identity_digest"
+      ],
+      "properties": {
+        "kind": {
+          "const": "harness_resource"
+        },
+        "value": {
+          "enum": [
+            "openclaw.runtime",
+            "hermes.runtime",
+            "nanoclaw.host",
+            "picoclaw.runtime"
+          ]
+        },
+        "identity_digest": {
+          "$ref": "#/definitions/digest"
+        }
+      }
+    },
+    "emptyArguments": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 0
+    },
+    "reloadHarnessAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action_id",
+        "kind",
+        "adapter_contract",
+        "operation",
+        "state_effect",
+        "target",
+        "arguments",
+        "precondition_digest",
+        "expected_postcondition_digest",
+        "rollback"
+      ],
+      "properties": {
+        "action_id": {
+          "$ref": "#/definitions/actionId"
+        },
+        "kind": {
+          "const": "native_operation"
+        },
+        "adapter_contract": {
+          "type": "string",
+          "pattern": "^clawsec\\.(?:openclaw|hermes|nanoclaw|picoclaw)-install-adapter/v1$"
+        },
+        "operation": {
+          "const": "reload_harness"
+        },
+        "state_effect": {
+          "const": "operational_non_mutating"
+        },
+        "target": {
+          "$ref": "#/definitions/harnessResourceTarget"
+        },
+        "arguments": {
+          "$ref": "#/definitions/emptyArguments"
+        },
+        "precondition_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "expected_postcondition_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "rollback": {
+          "type": "null"
+        }
+      }
+    },
+    "restartHarnessAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action_id",
+        "kind",
+        "adapter_contract",
+        "operation",
+        "state_effect",
+        "target",
+        "arguments",
+        "precondition_digest",
+        "expected_postcondition_digest",
+        "rollback"
+      ],
+      "properties": {
+        "action_id": {
+          "$ref": "#/definitions/actionId"
+        },
+        "kind": {
+          "const": "native_operation"
+        },
+        "adapter_contract": {
+          "type": "string",
+          "pattern": "^clawsec\\.(?:openclaw|hermes|nanoclaw|picoclaw)-install-adapter/v1$"
+        },
+        "operation": {
+          "const": "restart_harness"
+        },
+        "state_effect": {
+          "const": "operational_non_mutating"
+        },
+        "target": {
+          "$ref": "#/definitions/harnessResourceTarget"
+        },
+        "arguments": {
+          "$ref": "#/definitions/emptyArguments"
+        },
+        "precondition_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "expected_postcondition_digest": {
+          "$ref": "#/definitions/digest"
+        },
+        "rollback": {
+          "type": "null"
+        }
+      }
+    },
+    "nativeOperationAction": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/reloadHarnessAction"
+        },
+        {
+          "$ref": "#/definitions/restartHarnessAction"
+        }
+      ]
+    },
+    "blocker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "blocker_id",
+        "code",
+        "summary"
+      ],
+      "properties": {
+        "blocker_id": {
+          "$ref": "#/definitions/actionId"
+        },
+        "code": {
+          "enum": [
+            "path_conflict",
+            "permission_denied",
+            "precondition_unavailable",
+            "resource_limit",
+            "rollback_unavailable",
+            "scope_ambiguous",
+            "symlink_detected",
+            "unowned_state",
+            "unsupported_native_operation"
+          ]
+        },
+        "target": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/anchoredPath"
+            },
+            {
+              "$ref": "https://clawsec.prompt.security/contracts/schemas/result/result-v1.schema.json#/definitions/effectTarget"
+            }
+          ]
+        },
+        "summary": {
+          "$ref": "#/definitions/summary"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "gen:wiki-llms": "node scripts/generate-wiki-llms.mjs",
     "test:metadata-contracts": "node scripts/test-skill-component-metadata.mjs",
+    "test:install-plan-contract": "node scripts/test-skill-install-plan-contract.mjs",
     "test:result-envelope-contract": "node scripts/test-skill-result-envelope-contract.mjs",
     "populate-local-wiki": "./scripts/populate-local-wiki.sh",
     "predev": "npm run gen:wiki-llms",

--- a/scripts/ci/install-plan-adapters/hermes.mjs
+++ b/scripts/ci/install-plan-adapters/hermes.mjs
@@ -1,0 +1,16 @@
+export const hermesInstallPlanAdapter = Object.freeze({
+  profileKind: "hermes",
+  scopeIdentityField: "profile_identity_digest",
+
+  validateUnbound({ document, errors, addError, helpers }) {
+    const profile = document.adapter.profile;
+    helpers.validatePrototypePending({
+      document,
+      profile,
+      errors,
+      addError,
+    });
+  },
+
+  validateBound() {},
+});

--- a/scripts/ci/install-plan-adapters/nanoclaw-v2.mjs
+++ b/scripts/ci/install-plan-adapters/nanoclaw-v2.mjs
@@ -1,0 +1,298 @@
+import { isDeepStrictEqual } from "node:util";
+
+const REQUIRED_VALIDATION_STEPS = Object.freeze([
+  "postimage_manifest",
+  "host_build",
+  "host_tests",
+  "skill_tests",
+]);
+
+export const nanoclawV2InstallPlanAdapter = Object.freeze({
+  profileKind: "nanoclaw_v2_host",
+  scopeIdentityField: "checkout_identity_digest",
+
+  validateUnbound({ document, errors, addError, helpers }) {
+    const profile = document.adapter.profile;
+    if (
+      profile.upstream_baseline.version
+      !== document.result.invocation.harness.version
+    ) {
+      addError(
+        errors,
+        "INSTALL_PLAN_NANOCLAW_BASELINE_MISMATCH",
+        "/adapter/profile/upstream_baseline/version",
+        "NanoClaw v2 profile must bind the exact reported upstream version",
+      );
+    }
+    if (profile.checkout_status === "conflicted") {
+      addError(
+        errors,
+        "INSTALL_PLAN_NANOCLAW_CHECKOUT_CONFLICTED",
+        "/adapter/profile/checkout_status",
+        "NanoClaw v2 planning cannot target a conflicted checkout",
+      );
+    }
+    if (
+      profile.ancestor_chain_digest
+      !== document.target_state.ancestor_chain_digest
+    ) {
+      addError(
+        errors,
+        "INSTALL_PLAN_NANOCLAW_ANCESTOR_IDENTITY_MISMATCH",
+        "/target_state/ancestor_chain_digest",
+        "NanoClaw target-state ancestors must match the selected checkout profile",
+      );
+    }
+    for (const step of REQUIRED_VALIDATION_STEPS) {
+      requireValidationStep(profile, step, errors, addError);
+    }
+
+    const transformations = document.actions.filter((action) => (
+      action.kind === "declared_transformation"
+    ));
+    validateTransformations({
+      document,
+      profile,
+      transformations,
+      errors,
+      addError,
+    });
+    helpers.validateReloadBehavior({
+      document,
+      profile,
+      runtimeResource: "nanoclaw.host",
+      instanceIdentityDigest: profile.checkout_identity_digest,
+      errors,
+      addError,
+    });
+  },
+
+  validateBound({
+    document,
+    metadata,
+    errors,
+    addError,
+    helpers,
+    pathIsAtOrBelow,
+    validatePortablePosixPath,
+  }) {
+    const profile = document.adapter.profile;
+    const installLocation = metadata.clawsec?.native?.install_location;
+    if (typeof installLocation !== "string") {
+      addError(
+        errors,
+        "INSTALL_PLAN_NANOCLAW_INSTALL_LOCATION_REQUIRED",
+        "/result/subject/component",
+        "NanoClaw v2 metadata must declare the authoritative package install location",
+      );
+      return;
+    }
+    validatePortablePosixPath(
+      installLocation,
+      "/result/subject/component",
+      errors,
+    );
+    if (!pathIsAtOrBelow(installLocation, profile.skill_root_path)) {
+      addError(
+        errors,
+        "INSTALL_PLAN_NANOCLAW_INSTALL_LOCATION_INVALID",
+        "/result/subject/component",
+        "NanoClaw v2 metadata install location must remain under the adapter-selected skill root",
+      );
+      return;
+    }
+    helpers.validatePackageTargets({
+      document,
+      packageRoot: installLocation,
+      errors,
+      addError,
+      pathIsAtOrBelow,
+      validatePortablePosixPath,
+    });
+
+    if (
+      document.disposition === "ready"
+      && metadata.clawsec?.native?.remove_document_required === true
+    ) {
+      const removeDocumentPath = `${installLocation}/REMOVE.md`;
+      const carriesRemoveDocument = document.actions.some((action) => (
+        action.kind === "managed_entry"
+        && action.after.kind === "file"
+        && action.target.path === removeDocumentPath
+        && action.tree_entry?.kind === "file"
+        && action.tree_entry.path === "REMOVE.md"
+        && action.tree_entry.digest === action.after.digest
+      ));
+      if (!carriesRemoveDocument) {
+        addError(
+          errors,
+          "INSTALL_PLAN_NANOCLAW_REMOVE_DOCUMENT_REQUIRED",
+          "/actions",
+          "NanoClaw v2 stateful packages must install exact REMOVE.md bytes",
+        );
+      }
+    }
+  },
+});
+
+function validateTransformations({
+  document,
+  profile,
+  transformations,
+  errors,
+  addError,
+}) {
+  if (transformations.length === 0) {
+    if (profile.coding_harness !== null) {
+      addError(
+        errors,
+        "INSTALL_PLAN_NANOCLAW_UNUSED_CODING_HARNESS",
+        "/adapter/profile/coding_harness",
+        "NanoClaw plans without transformations cannot bind a coding harness",
+      );
+    }
+    return;
+  }
+  if (
+    profile.coding_harness === null
+    || typeof profile.coding_harness !== "object"
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_NANOCLAW_CODING_HARNESS_REQUIRED",
+      "/adapter/profile/coding_harness",
+      "NanoClaw transformations require one exact adapter-bound coding harness",
+    );
+    return;
+  }
+
+  for (const transformation of transformations) {
+    const index = document.actions.indexOf(transformation);
+    if (
+      transformation.target.anchor !== "scope_root"
+    ) {
+      addError(
+        errors,
+        "INSTALL_PLAN_NANOCLAW_TRANSFORMATION_ANCHOR_INVALID",
+        `/actions/${index}/target/anchor`,
+        "NanoClaw transformations must remain inside the selected checkout scope",
+      );
+    }
+    if (pathAtOrBelow(transformation.target.path, profile.skill_root_path)) {
+      addError(
+        errors,
+        "INSTALL_PLAN_NANOCLAW_TRANSFORMATION_PACKAGE_TREE_FORBIDDEN",
+        `/actions/${index}/target/path`,
+        "NanoClaw transformations cannot mutate the host skill tree; package files must be exact managed entries",
+      );
+    }
+    const forbiddenReason = forbiddenTransformationPath(
+      transformation.target.path,
+    );
+    if (forbiddenReason !== null) {
+      addError(
+        errors,
+        "INSTALL_PLAN_NANOCLAW_TRANSFORMATION_PATH_FORBIDDEN",
+        `/actions/${index}/target/path`,
+        forbiddenReason,
+      );
+    }
+    if (
+      !isDeepStrictEqual(
+        transformation.declaration.coding_harness,
+        profile.coding_harness,
+      )
+    ) {
+      addError(
+        errors,
+        "INSTALL_PLAN_NANOCLAW_CODING_HARNESS_MISMATCH",
+        `/actions/${index}/declaration/coding_harness`,
+        "NanoClaw transformation must use the exact adapter-bound coding harness",
+      );
+    }
+
+    if (touchesContainer(transformation)) {
+      requireValidationStep(profile, "container_build", errors, addError);
+    }
+    if (touchesAgentRunner(transformation)) {
+      requireValidationStep(profile, "container_typecheck", errors, addError);
+      requireValidationStep(profile, "container_tests", errors, addError);
+    }
+  }
+}
+
+function requireValidationStep(profile, step, errors, addError) {
+  if (!profile.validation_steps.includes(step)) {
+    addError(
+      errors,
+      "INSTALL_PLAN_NANOCLAW_VALIDATION_STEP_REQUIRED",
+      "/adapter/profile/validation_steps",
+      `NanoClaw v2 plan requires ${step}`,
+    );
+  }
+}
+
+function touchesContainer(transformation) {
+  const targetPath = transformation.target.path.toLowerCase();
+  return (
+    targetPath === "container"
+    || targetPath.startsWith("container/")
+  );
+}
+
+function touchesAgentRunner(transformation) {
+  const targetPath = transformation.target.path.toLowerCase();
+  return (
+    targetPath === "container/agent-runner"
+    || targetPath.startsWith("container/agent-runner/")
+  );
+}
+
+function pathAtOrBelow(candidate, root) {
+  const foldedCandidate = candidate.toLowerCase();
+  const foldedRoot = root.toLowerCase();
+  return (
+    foldedCandidate === foldedRoot
+    || foldedCandidate.startsWith(`${foldedRoot}/`)
+  );
+}
+
+function forbiddenTransformationPath(candidate) {
+  const normalized = candidate.toLowerCase();
+  const segments = normalized.split("/");
+  if (segments.includes(".git")) {
+    return "NanoClaw transformations cannot target Git control state";
+  }
+  if (["data", "groups", "logs"].includes(segments[0])) {
+    return "NanoClaw transformations cannot target live data, group, or log roots";
+  }
+  if (
+    normalized === "container/skills"
+    || normalized.startsWith("container/skills/")
+  ) {
+    return "NanoClaw transformations cannot target container skill state";
+  }
+
+  const basename = segments.at(-1);
+  if (
+    basename === ".env"
+    || basename.startsWith(".env.")
+    || basename === ".netrc"
+    || basename === ".npmrc"
+    || basename.startsWith("id_rsa")
+    || basename.startsWith("id_ed25519")
+    || /^(?:credentials|secrets|token)(?:\.(?:json|ya?ml|toml|ini|conf|txt|key|pem))?$/.test(
+      basename,
+    )
+  ) {
+    return "NanoClaw transformations cannot target secret-bearing files";
+  }
+  if (
+    basename.endsWith(".db")
+    || basename.endsWith(".sqlite")
+    || basename.endsWith(".sqlite3")
+  ) {
+    return "NanoClaw transformations cannot target live database files";
+  }
+  return null;
+}

--- a/scripts/ci/install-plan-adapters/openclaw.mjs
+++ b/scripts/ci/install-plan-adapters/openclaw.mjs
@@ -1,0 +1,36 @@
+export const openclawInstallPlanAdapter = Object.freeze({
+  profileKind: "openclaw",
+  scopeIdentityField: "scope_identity_digest",
+
+  validateUnbound({ document, errors, addError, helpers }) {
+    const profile = document.adapter.profile;
+    helpers.rejectTransformations({ document, errors, addError });
+    helpers.validateReloadBehavior({
+      document,
+      profile,
+      runtimeResource: "openclaw.runtime",
+      instanceIdentityDigest: profile.scope_identity_digest,
+      errors,
+      addError,
+    });
+  },
+
+  validateBound({
+    document,
+    errors,
+    addError,
+    helpers,
+    pathIsAtOrBelow,
+    validatePortablePosixPath,
+  }) {
+    const profile = document.adapter.profile;
+    helpers.validatePackageTargets({
+      document,
+      packageRoot: `${profile.skill_root_path}/${document.result.subject.component.name}`,
+      errors,
+      addError,
+      pathIsAtOrBelow,
+      validatePortablePosixPath,
+    });
+  },
+});

--- a/scripts/ci/install-plan-adapters/picoclaw.mjs
+++ b/scripts/ci/install-plan-adapters/picoclaw.mjs
@@ -1,0 +1,16 @@
+export const picoclawInstallPlanAdapter = Object.freeze({
+  profileKind: "picoclaw",
+  scopeIdentityField: "home_identity_digest",
+
+  validateUnbound({ document, errors, addError, helpers }) {
+    const profile = document.adapter.profile;
+    helpers.validatePrototypePending({
+      document,
+      profile,
+      errors,
+      addError,
+    });
+  },
+
+  validateBound() {},
+});

--- a/scripts/ci/install-plan-adapters/registry.mjs
+++ b/scripts/ci/install-plan-adapters/registry.mjs
@@ -1,0 +1,330 @@
+import { openclawInstallPlanAdapter } from "./openclaw.mjs";
+import { hermesInstallPlanAdapter } from "./hermes.mjs";
+import { nanoclawV2InstallPlanAdapter } from "./nanoclaw-v2.mjs";
+import { picoclawInstallPlanAdapter } from "./picoclaw.mjs";
+
+const adapterByHarness = new Map([
+  ["openclaw", openclawInstallPlanAdapter],
+  ["hermes", hermesInstallPlanAdapter],
+  ["nanoclaw", nanoclawV2InstallPlanAdapter],
+  ["picoclaw", picoclawInstallPlanAdapter],
+]);
+
+export function validateInstallPlanAdapter(document, errors, addError) {
+  const harness = document.result.invocation.harness.name;
+  const definition = adapterByHarness.get(harness);
+  if (definition === undefined) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ADAPTER_UNSUPPORTED",
+      "/result/invocation/harness/name",
+      `install-plan adapter semantics are not defined for ${harness}`,
+    );
+    return;
+  }
+
+  const expectedContract = `clawsec.${harness}-install-adapter/v1`;
+  if (document.adapter.contract !== expectedContract) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ADAPTER_MISMATCH",
+      "/adapter/contract",
+      `install plan for ${harness} must bind ${expectedContract}`,
+    );
+  }
+  const profile = document.adapter.profile;
+  if (profile.kind !== definition.profileKind) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ADAPTER_PROFILE_MISMATCH",
+      "/adapter/profile/kind",
+      `install plan for ${harness} must use the typed ${definition.profileKind} profile`,
+    );
+    return;
+  }
+  if (
+    profile[definition.scopeIdentityField]
+    !== document.target_state.scope_root_identity_digest
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_TARGET_ROOT_IDENTITY_MISMATCH",
+      "/target_state/scope_root_identity_digest",
+      "target-state root identity must match the adapter-selected physical scope root",
+    );
+  }
+
+  definition.validateUnbound({
+    document,
+    errors,
+    addError,
+    helpers: {
+      rejectTransformations,
+      validatePrototypePending,
+      validateReloadBehavior,
+    },
+  });
+}
+
+export function validateBoundInstallPlanAdapter({
+  document,
+  metadata,
+  errors,
+  addError,
+  pathIsAtOrBelow,
+  validatePortablePosixPath,
+}) {
+  const definition = adapterByHarness.get(
+    document.result.invocation.harness.name,
+  );
+  if (definition === undefined) return;
+  definition.validateBound({
+    document,
+    metadata,
+    errors,
+    addError,
+    helpers: {
+      validatePackageTargets,
+    },
+    pathIsAtOrBelow,
+    validatePortablePosixPath,
+  });
+}
+
+function validateReloadBehavior({
+  document,
+  profile,
+  runtimeResource,
+  instanceIdentityDigest,
+  errors,
+  addError,
+}) {
+  const operationalActions = document.actions.filter((action) => (
+    action.kind === "native_operation"
+    && ["reload_harness", "restart_harness"].includes(action.operation)
+  ));
+  if (document.disposition !== "ready") return;
+
+  const expectedOperation = profile.reload_behavior === "none"
+    ? null
+    : profile.reload_behavior;
+  const expectedCount = expectedOperation === null ? 0 : 1;
+  if (
+    operationalActions.length !== expectedCount
+    || (
+      expectedOperation !== null
+      && operationalActions[0]?.operation !== expectedOperation
+    )
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_RELOAD_ACTION_MISMATCH",
+      "/actions",
+      expectedOperation === null
+        ? "adapter reload behavior none forbids reload and restart actions"
+        : `adapter reload behavior requires exactly one ${expectedOperation} action`,
+    );
+  }
+
+  for (const action of operationalActions) {
+    if (
+      action.target.kind !== "harness_resource"
+      || action.target.value !== runtimeResource
+      || action.target.identity_digest !== instanceIdentityDigest
+    ) {
+      addError(
+        errors,
+        "INSTALL_PLAN_HARNESS_RESOURCE_IDENTITY_MISMATCH",
+        `/actions/${document.actions.indexOf(action)}/target`,
+        "harness operation must target the adapter-selected instance identity",
+      );
+    }
+  }
+}
+
+function rejectTransformations({ document, errors, addError }) {
+  for (let index = 0; index < document.actions.length; index += 1) {
+    const action = document.actions[index];
+    if (action.kind === "declared_transformation") {
+      addError(
+        errors,
+        "INSTALL_PLAN_ADAPTER_TRANSFORMATION_FORBIDDEN",
+        `/actions/${index}`,
+        "this install adapter does not permit declared transformations",
+      );
+    }
+  }
+}
+
+function validatePrototypePending({ document, profile, errors, addError }) {
+  if (profile.native_install_status !== "prototype_pending") {
+    addError(
+      errors,
+      "INSTALL_PLAN_PROTOTYPE_STATUS_INVALID",
+      "/adapter/profile/native_install_status",
+      "adapter must explicitly declare its native installer prototype pending",
+    );
+  }
+  if (
+    profile.reload_behavior !== "none"
+    || document.disposition !== "blocked"
+    || document.actions.length !== 0
+    || document.apply_context !== null
+    || document.confirmation_requirements !== null
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_PROTOTYPE_PENDING_DISPOSITION_INVALID",
+      "/disposition",
+      "prototype-pending adapters can only emit a blocked, non-actionable plan",
+    );
+  }
+  if (
+    document.blockers.length === 0
+    || document.blockers.some((blocker) => (
+      blocker.code !== "unsupported_native_operation"
+    ))
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_PROTOTYPE_PENDING_BLOCKER_INVALID",
+      "/blockers",
+      "prototype-pending adapters require only unsupported_native_operation blockers",
+    );
+  }
+}
+
+function validatePackageTargets({
+  document,
+  packageRoot,
+  errors,
+  addError,
+  pathIsAtOrBelow,
+  validatePortablePosixPath,
+}) {
+  validatePortablePosixPath(
+    packageRoot,
+    "/result/subject/component",
+    errors,
+  );
+  const managedActions = [];
+  for (let index = 0; index < document.actions.length; index += 1) {
+    const action = document.actions[index];
+    if (action.kind === "declared_transformation") {
+      continue;
+    }
+    if (action.kind !== "managed_entry") {
+      continue;
+    }
+    managedActions.push({ action, index });
+
+    const targetPath = `/actions/${index}/target`;
+    const expectedTargetPath = action.tree_entry.path === "."
+      ? packageRoot
+      : `${packageRoot}/${action.tree_entry.path}`;
+    if (
+      action.target.anchor !== "scope_root"
+      || !pathIsAtOrBelow(action.target.path, packageRoot)
+    ) {
+      addError(
+        errors,
+        "INSTALL_PLAN_PACKAGE_TARGET_INVALID",
+        targetPath,
+        "package writes must remain under the exact selected package root in scope_root",
+      );
+    }
+    if (
+      action.target.anchor !== "scope_root"
+      || action.target.path !== expectedTargetPath
+    ) {
+      addError(
+        errors,
+        "INSTALL_PLAN_TREE_ENTRY_TARGET_MISMATCH",
+        targetPath,
+        "managed target must exactly equal the package root joined to its install-tree entry path",
+      );
+    }
+  }
+  if (document.disposition !== "ready") return;
+  validateReadyPackageTree({
+    managedActions,
+    packageRoot,
+    errors,
+    addError,
+    pathIsAtOrBelow,
+  });
+}
+
+function validateReadyPackageTree({
+  managedActions,
+  packageRoot,
+  errors,
+  addError,
+  pathIsAtOrBelow,
+}) {
+  if (managedActions.length === 0) {
+    addError(
+      errors,
+      "INSTALL_PLAN_SUBJECT_PACKAGE_ACTION_REQUIRED",
+      "/actions",
+      "ready plans require at least one managed mutation for the subject package",
+    );
+    return;
+  }
+
+  const actionsByPath = new Map(managedActions.map((entry) => [
+    entry.action.target.path,
+    entry,
+  ]));
+  const packageRootAction = actionsByPath.get(packageRoot);
+  if (
+    packageRootAction === undefined
+    || packageRootAction.action.after.kind !== "directory"
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_PACKAGE_ROOT_DIRECTORY_REQUIRED",
+      "/actions",
+      "ready plans must create the exact subject package root as a managed directory",
+    );
+  }
+
+  const missingDirectories = new Set();
+  for (const child of managedActions) {
+    let parent = parentPosixPath(child.action.target.path);
+    while (
+      parent !== null
+      && pathIsAtOrBelow(parent, packageRoot)
+    ) {
+      const parentAction = actionsByPath.get(parent);
+      if (
+        parentAction === undefined
+        || parentAction.action.after.kind !== "directory"
+      ) {
+        if (!missingDirectories.has(parent)) {
+          missingDirectories.add(parent);
+          addError(
+            errors,
+            "INSTALL_PLAN_PACKAGE_INTERMEDIATE_DIRECTORY_REQUIRED",
+            `/actions/${child.index}/target/path`,
+            `managed package path requires an earlier managed directory action for ${parent}`,
+          );
+        }
+      } else if (parentAction.index >= child.index) {
+        addError(
+          errors,
+          "INSTALL_PLAN_PACKAGE_PARENT_ORDER_INVALID",
+          `/actions/${child.index}/target/path`,
+          `managed directory ${parent} must appear before its child`,
+        );
+      }
+      if (parent === packageRoot) break;
+      parent = parentPosixPath(parent);
+    }
+  }
+}
+
+function parentPosixPath(candidate) {
+  const separator = candidate.lastIndexOf("/");
+  return separator === -1 ? null : candidate.slice(0, separator);
+}

--- a/scripts/ci/validate_clawsec_install_plan.mjs
+++ b/scripts/ci/validate_clawsec_install_plan.mjs
@@ -1,0 +1,2502 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { fileURLToPath } from "node:url";
+
+import Ajv from "ajv";
+
+import {
+  classifyLifecycleVersion,
+  parseSemverV2,
+} from "./lifecycle_semver.mjs";
+import {
+  digestBytes,
+  parseJsonObjectBytes,
+  validateBoundResultEnvelope,
+  validateUnboundResultEnvelope,
+} from "./validate_clawsec_result_envelope.mjs";
+import {
+  validateBoundInstallPlanAdapter,
+  validateInstallPlanAdapter,
+} from "./install-plan-adapters/registry.mjs";
+
+export { digestBytes };
+
+const repositoryRoot = fileURLToPath(new URL("../../", import.meta.url));
+const MAXIMUM_DIAGNOSTICS = 64;
+const TYPED_ARRAY_PROTOTYPE = Object.getPrototypeOf(Uint8Array.prototype);
+const TYPED_ARRAY_BUFFER_GETTER = Object.getOwnPropertyDescriptor(
+  TYPED_ARRAY_PROTOTYPE,
+  "buffer",
+).get;
+const TYPED_ARRAY_BYTE_LENGTH_GETTER = Object.getOwnPropertyDescriptor(
+  TYPED_ARRAY_PROTOTYPE,
+  "byteLength",
+).get;
+const TYPED_ARRAY_BYTE_OFFSET_GETTER = Object.getOwnPropertyDescriptor(
+  TYPED_ARRAY_PROTOTYPE,
+  "byteOffset",
+).get;
+const EXPECTED_POLICY = Object.freeze({
+  maximumPlanBytes: 1024 * 1024,
+  maximumValiditySeconds: 900,
+  maximumActions: 64,
+  maximumBlockers: 64,
+  maximumArrayItems: 64,
+  maximumObjectKeys: 64,
+  maximumDocumentNodes: 4096,
+  maximumArchiveBytes: 128 * 1024 * 1024,
+  maximumInstalledFileBytes: 64 * 1024 * 1024,
+  maximumInstallTreeBytes: 256 * 1024 * 1024,
+  maximumInstallTreeEntries: 4096,
+  maximumPlannedOutputBytes: 256 * 1024 * 1024,
+  maximumPlannedOutputEntries: 64,
+  maximumCapturedPreimageBytes: 256 * 1024 * 1024,
+  maximumCapturedPreimageEntries: 64,
+  maximumExpansionRatio: 100,
+});
+const EXPECTED_ASSURANCE = Object.freeze({
+  provenance: "unverified",
+  catalog_authorization: "unverified",
+  release_signature_authorization: "unverified",
+  advisory_verification: "unverified",
+  operator_authorization: "unverified",
+  artifact_source_membership: "unverified",
+  action_state_derivation: "verified_when_bound",
+  installation_authorization: "not_granted",
+  execution: "not_executed",
+  preconditions_at_apply_time: "unverified",
+});
+const EXPECTED_BINDING_KEYS = Object.freeze([
+  "adapter",
+  "apply_context",
+  "artifact",
+  "staged_input",
+  "target_state",
+  "verification_refs",
+]);
+
+const planSchemaPath = path.join(
+  repositoryRoot,
+  "contracts/schemas/install/install-plan-v1.schema.json",
+);
+const resultSchemaPath = path.join(
+  repositoryRoot,
+  "contracts/schemas/result/result-v1.schema.json",
+);
+const componentRefSchemaPath = path.join(
+  repositoryRoot,
+  "contracts/schemas/component/component-ref-v1.schema.json",
+);
+const adapterSchemaPaths = [
+  ["openclaw", "openclaw-v1.schema.json"],
+  ["hermes", "hermes-v1.schema.json"],
+  ["picoclaw", "picoclaw-v1.schema.json"],
+  ["nanoclaw", "nanoclaw-v2.schema.json"],
+].map(([harness, fileName]) => [
+  harness,
+  path.join(repositoryRoot, "contracts/schemas/install/adapters", fileName),
+  `/contracts/schemas/install/adapters/${fileName}`,
+]);
+const planPolicyPath = path.join(repositoryRoot, "contracts/install-plan-policy.json");
+
+const loadedContracts = await Promise.all([
+  readContractJson(
+    planSchemaPath,
+    "INSTALL_PLAN_SCHEMA_SOURCE",
+    "/contracts/schemas/install/install-plan-v1.schema.json",
+  ),
+  readContractJson(
+    resultSchemaPath,
+    "INSTALL_PLAN_RESULT_SCHEMA_SOURCE",
+    "/contracts/schemas/result/result-v1.schema.json",
+  ),
+  readContractJson(
+    componentRefSchemaPath,
+    "INSTALL_PLAN_COMPONENT_SCHEMA_SOURCE",
+    "/contracts/schemas/component/component-ref-v1.schema.json",
+  ),
+  ...adapterSchemaPaths.map(([harness, filePath, errorPath]) => (
+    readContractJson(
+      filePath,
+      `INSTALL_PLAN_${harness.toUpperCase()}_ADAPTER_SCHEMA_SOURCE`,
+      errorPath,
+    )
+  )),
+  readContractJson(
+    planPolicyPath,
+    "INSTALL_PLAN_POLICY_SOURCE",
+    "/contracts/install-plan-policy.json",
+  ),
+]);
+
+const initializationErrors = loadedContracts.flatMap((entry) => entry.errors);
+const [
+  planSchema,
+  resultSchema,
+  componentRefSchema,
+  openclawAdapterSchema,
+  hermesAdapterSchema,
+  picoclawAdapterSchema,
+  nanoclawAdapterSchema,
+  planPolicy,
+] = loadedContracts.map((entry) => entry.value ?? {});
+
+let validatePlanSchema = null;
+if (initializationErrors.length === 0) {
+  try {
+    const ajv = new Ajv({
+      allErrors: false,
+      jsonPointers: true,
+      schemaId: "auto",
+    });
+    ajv.addSchema(componentRefSchema);
+    ajv.addSchema(resultSchema);
+    for (const adapterSchema of [
+      openclawAdapterSchema,
+      hermesAdapterSchema,
+      picoclawAdapterSchema,
+      nanoclawAdapterSchema,
+    ]) {
+      ajv.addSchema(adapterSchema);
+    }
+    validatePlanSchema = ajv.compile(planSchema);
+  } catch {
+    addError(
+      initializationErrors,
+      "INSTALL_PLAN_SCHEMA_COMPILE_FAILED",
+      "/contracts/schemas/install/install-plan-v1.schema.json",
+      "install-plan schema could not be compiled with the result and component schemas",
+    );
+  }
+}
+
+export function validateInstallPlanContractSources() {
+  const errors = [...initializationErrors];
+  if (errors.length > 0) return finishUnbound(errors);
+
+  validateClosedObject(
+    planPolicy,
+    [
+      "assurance",
+      "confirmation",
+      "contract",
+      "contract_version",
+      "dispositions",
+      "filesystem",
+      "maximum_actions",
+      "maximum_archive_bytes",
+      "maximum_array_items",
+      "maximum_blockers",
+      "maximum_captured_preimage_bytes",
+      "maximum_captured_preimage_entries",
+      "maximum_document_nodes",
+      "maximum_expansion_ratio",
+      "maximum_install_tree_bytes",
+      "maximum_install_tree_entries",
+      "maximum_installed_file_bytes",
+      "maximum_object_keys",
+      "maximum_plan_bytes",
+      "maximum_planned_output_bytes",
+      "maximum_planned_output_entries",
+      "maximum_validity_seconds",
+      "rollback",
+    ],
+    "/contracts/install-plan-policy.json",
+    errors,
+  );
+  if (planPolicy.contract !== "clawsec.install-plan-policy/v1") {
+    addError(
+      errors,
+      "INSTALL_PLAN_POLICY_CONTRACT_MISMATCH",
+      "/contracts/install-plan-policy.json/contract",
+      "expected clawsec.install-plan-policy/v1",
+    );
+  }
+  if (planPolicy.contract_version !== "1") {
+    addError(
+      errors,
+      "INSTALL_PLAN_POLICY_VERSION_MISMATCH",
+      "/contracts/install-plan-policy.json/contract_version",
+      "expected contract version 1",
+    );
+  }
+  if (planPolicy.maximum_plan_bytes !== EXPECTED_POLICY.maximumPlanBytes) {
+    addError(
+      errors,
+      "INSTALL_PLAN_POLICY_BYTE_LIMIT_MISMATCH",
+      "/contracts/install-plan-policy.json/maximum_plan_bytes",
+      `maximum plan size must be ${EXPECTED_POLICY.maximumPlanBytes} bytes`,
+    );
+  }
+  if (
+    planPolicy.maximum_validity_seconds
+    !== EXPECTED_POLICY.maximumValiditySeconds
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_POLICY_VALIDITY_LIMIT_MISMATCH",
+      "/contracts/install-plan-policy.json/maximum_validity_seconds",
+      `maximum validity must be ${EXPECTED_POLICY.maximumValiditySeconds} seconds`,
+    );
+  }
+  if (planPolicy.maximum_actions !== EXPECTED_POLICY.maximumActions) {
+    addError(
+      errors,
+      "INSTALL_PLAN_POLICY_ACTION_LIMIT_MISMATCH",
+      "/contracts/install-plan-policy.json/maximum_actions",
+      `maximum action count must be ${EXPECTED_POLICY.maximumActions}`,
+    );
+  }
+  if (planPolicy.maximum_blockers !== EXPECTED_POLICY.maximumBlockers) {
+    addError(
+      errors,
+      "INSTALL_PLAN_POLICY_BLOCKER_LIMIT_MISMATCH",
+      "/contracts/install-plan-policy.json/maximum_blockers",
+      `maximum blocker count must be ${EXPECTED_POLICY.maximumBlockers}`,
+    );
+  }
+  for (const [policyKey, expectedValue, label] of [
+    ["maximum_array_items", EXPECTED_POLICY.maximumArrayItems, "array item"],
+    ["maximum_object_keys", EXPECTED_POLICY.maximumObjectKeys, "object key"],
+    ["maximum_document_nodes", EXPECTED_POLICY.maximumDocumentNodes, "document node"],
+    ["maximum_archive_bytes", EXPECTED_POLICY.maximumArchiveBytes, "archive byte"],
+    [
+      "maximum_installed_file_bytes",
+      EXPECTED_POLICY.maximumInstalledFileBytes,
+      "installed file byte",
+    ],
+    [
+      "maximum_install_tree_bytes",
+      EXPECTED_POLICY.maximumInstallTreeBytes,
+      "install-tree byte",
+    ],
+    [
+      "maximum_install_tree_entries",
+      EXPECTED_POLICY.maximumInstallTreeEntries,
+      "install-tree entry",
+    ],
+    [
+      "maximum_planned_output_bytes",
+      EXPECTED_POLICY.maximumPlannedOutputBytes,
+      "planned output byte",
+    ],
+    [
+      "maximum_planned_output_entries",
+      EXPECTED_POLICY.maximumPlannedOutputEntries,
+      "planned output entry",
+    ],
+    [
+      "maximum_captured_preimage_bytes",
+      EXPECTED_POLICY.maximumCapturedPreimageBytes,
+      "captured preimage byte",
+    ],
+    [
+      "maximum_captured_preimage_entries",
+      EXPECTED_POLICY.maximumCapturedPreimageEntries,
+      "captured preimage entry",
+    ],
+    [
+      "maximum_expansion_ratio",
+      EXPECTED_POLICY.maximumExpansionRatio,
+      "archive expansion ratio",
+    ],
+  ]) {
+    if (planPolicy[policyKey] !== expectedValue) {
+      addError(
+        errors,
+        "INSTALL_PLAN_POLICY_RESOURCE_LIMIT_MISMATCH",
+        `/contracts/install-plan-policy.json/${policyKey}`,
+        `${label} limit must be ${expectedValue}`,
+      );
+    }
+  }
+
+  validateDispositionPolicy(errors);
+  validateConfirmationPolicy(errors);
+  validateFilesystemPolicy(errors);
+  validateRollbackPolicy(errors);
+  validateAssurancePolicy(errors);
+  validateSchemaPolicyAlignment(errors);
+  return finishUnbound(errors);
+}
+
+function validateTrustedUnboundInstallPlanObject(document) {
+  const sourceResult = validateInstallPlanContractSources();
+  const errors = [...sourceResult.errors];
+  if (!sourceResult.valid || validatePlanSchema === null) {
+    return finishUnbound(errors);
+  }
+
+  preflightDocumentShape(document, errors);
+  if (errors.length > 0) return finishUnbound(errors);
+  preflightPortablePaths(document, errors);
+  preflightRemovedNativeOperations(document, errors);
+  preflightPrototypeAdapters(document, errors);
+  preflightCodingHarnessReferences(document, errors);
+  if (errors.length > 0) return finishUnbound(errors);
+
+  if (!validatePlanSchema(document)) {
+    appendSchemaDiagnostics(validatePlanSchema.errors, errors);
+    return finishUnbound(errors);
+  }
+
+  appendNestedDiagnostics(
+    errors,
+    validateUnboundResultEnvelope(document.result).errors,
+    "/result",
+  );
+  validatePlanSemantics(document, errors);
+  return finishUnbound(errors);
+}
+
+export function validateUnboundInstallPlanBytes(planBytes) {
+  const snapshot = snapshotInstallPlanBytes(planBytes);
+  if (snapshot.errors.length > 0) return finishUnbound(snapshot.errors);
+  const parsed = parseJsonObjectBytes(snapshot.bytes, "INSTALL_PLAN", "/");
+  if (!parsed.valid) return finishUnbound(parsed.errors);
+  return validateTrustedUnboundInstallPlanObject(parsed.value);
+}
+
+export function validateBoundInstallPlan({
+  planBytes,
+  metadataBytesByDigest,
+  expectedContext,
+  expectedPlanDigest,
+  expectedBindings,
+  evaluatedAt,
+} = {}) {
+  const snapshot = snapshotInstallPlanBytes(planBytes);
+  if (snapshot.errors.length > 0) {
+    return finishBound(snapshot.errors, [], null);
+  }
+  const stablePlanBytes = snapshot.bytes;
+  const parsed = parseJsonObjectBytes(stablePlanBytes, "INSTALL_PLAN", "/");
+  if (!parsed.valid) return finishBound(parsed.errors, [], null);
+
+  const document = parsed.value;
+  const structureResult = validateTrustedUnboundInstallPlanObject(document);
+  const errors = [...structureResult.errors];
+  const warnings = [];
+  const actualPlanDigest = stablePlanBytes instanceof Uint8Array
+    ? digestBytes(stablePlanBytes)
+    : null;
+  if (!structureResult.valid || validatePlanSchema === null) {
+    return finishBound(errors, warnings, actualPlanDigest);
+  }
+
+  if (
+    typeof expectedPlanDigest !== "string"
+    || !/^sha256:[a-f0-9]{64}$/.test(expectedPlanDigest)
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_EXPECTED_DIGEST_REQUIRED",
+      "/",
+      "bound validation requires a caller-supplied SHA-256 digest of the exact plan bytes",
+    );
+  } else if (expectedPlanDigest !== actualPlanDigest) {
+    addError(
+      errors,
+      "INSTALL_PLAN_DIGEST_MISMATCH",
+      "/",
+      "plan bytes do not match the caller-supplied expected plan digest",
+    );
+  }
+
+  validateExpectedBindings(document, expectedBindings, errors);
+
+  const requiredMetadataDigests = [document.result.executor.metadata_digest];
+  if (document.result.subject.kind === "component") {
+    requiredMetadataDigests.push(
+      document.result.subject.component.metadata_digest,
+    );
+  }
+  const stableMetadataBytesByDigest = snapshotDigestBytesResolver(
+    metadataBytesByDigest,
+    requiredMetadataDigests,
+    errors,
+  );
+  const boundResult = validateBoundResultEnvelope({
+    resultBytes: Buffer.from(JSON.stringify(document.result)),
+    metadataBytesByDigest: stableMetadataBytesByDigest,
+    expectedContext,
+  });
+  appendNestedDiagnostics(errors, boundResult.errors, "/result");
+  for (const warning of boundResult.warnings ?? []) {
+    warnings.push({
+      code: warning.code,
+      path: `/result${warning.path === "/" ? "" : warning.path}`,
+      message: warning.message,
+    });
+  }
+
+  validateEvaluationTime(document, evaluatedAt, errors);
+  validateBoundTargetPaths(document, stableMetadataBytesByDigest, errors);
+  return finishBound(errors, warnings, actualPlanDigest);
+}
+
+function validatePlanSemantics(document, errors) {
+  const { result } = document;
+  if (document.path_flavor !== "posix") {
+    addError(
+      errors,
+      "INSTALL_PLAN_PATH_FLAVOR_INVALID",
+      "/path_flavor",
+      "install-plan v1 paths must use POSIX slash semantics",
+    );
+  }
+  if (result.executor.role !== "core") {
+    addError(
+      errors,
+      "INSTALL_PLAN_EXECUTOR_ROLE_INVALID",
+      "/result/executor/role",
+      "install plans must be produced by a core component",
+    );
+  }
+  if (result.invocation.operation !== "core.plan-release") {
+    addError(
+      errors,
+      "INSTALL_PLAN_OPERATION_INVALID",
+      "/result/invocation/operation",
+      "embedded result operation must be core.plan-release",
+    );
+  }
+  if (result.subject.kind !== "component") {
+    addError(
+      errors,
+      "INSTALL_PLAN_SUBJECT_INVALID",
+      "/result/subject",
+      "install plans require one exact component subject",
+    );
+  }
+
+  validateApplyContext(document, errors);
+  validateTargetInstanceBinding(document, errors);
+  validateIdentifierSeparation(document, errors);
+  validateDisposition(document, errors);
+  validateValidityWindow(document, errors);
+  validateArtifactLifecycle(document, errors);
+  validateArtifactResources(document, errors);
+  validateStagedInputBinding(document, errors);
+  validateInstallPlanAdapter(document, errors, addError);
+  validateActions(document, errors);
+  validateResultEffects(document, errors);
+  validateDerivedStateBindings(document, errors);
+  validateBlockers(document.blockers, errors);
+  validateRollbackOrder(document, errors);
+
+  if (!isDeepStrictEqual(document.assurance, EXPECTED_ASSURANCE)) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ASSURANCE_MISMATCH",
+      "/assurance",
+      "install-plan assurance must explicitly remain unverified and not executed",
+    );
+  }
+}
+
+function validateApplyContext(document, errors) {
+  if (document.disposition === "blocked") {
+    if (document.apply_context !== null) {
+      addError(
+        errors,
+        "INSTALL_PLAN_BLOCKED_APPLY_CONTEXT_FORBIDDEN",
+        "/apply_context",
+        "blocked plans cannot carry a future install invocation",
+      );
+    }
+    if (document.confirmation_requirements !== null) {
+      addError(
+        errors,
+        "INSTALL_PLAN_BLOCKED_CONFIRMATION_REQUIREMENTS_FORBIDDEN",
+        "/confirmation_requirements",
+        "blocked plans cannot carry confirmation requirements",
+      );
+    }
+    return;
+  }
+  if (!isPlainObject(document.apply_context)) {
+    addError(
+      errors,
+      "INSTALL_PLAN_READY_APPLY_CONTEXT_REQUIRED",
+      "/apply_context",
+      "ready plans require an exact future core.install-release context",
+    );
+    return;
+  }
+  if (!isPlainObject(document.confirmation_requirements)) {
+    addError(
+      errors,
+      "INSTALL_PLAN_READY_CONFIRMATION_REQUIREMENTS_REQUIRED",
+      "/confirmation_requirements",
+      "ready plans must declare non-authorizing exact-byte confirmation requirements",
+    );
+  }
+  const planningContext = {
+    executor: document.result.executor,
+    subject: document.result.subject,
+  };
+  if (!isDeepStrictEqual(document.apply_context.executor, planningContext.executor)) {
+    addError(
+      errors,
+      "INSTALL_PLAN_APPLY_EXECUTOR_MISMATCH",
+      "/apply_context/executor",
+      "future install executor must exactly match the planning executor",
+    );
+  }
+  if (!isDeepStrictEqual(document.apply_context.subject, planningContext.subject)) {
+    addError(
+      errors,
+      "INSTALL_PLAN_APPLY_SUBJECT_MISMATCH",
+      "/apply_context/subject",
+      "future install subject must exactly match the planned component",
+    );
+  }
+  if (document.apply_context.invocation.operation !== "core.install-release") {
+    addError(
+      errors,
+      "INSTALL_PLAN_APPLY_OPERATION_INVALID",
+      "/apply_context/invocation/operation",
+      "apply context operation must be core.install-release",
+    );
+  }
+  if (
+    !isDeepStrictEqual(
+      document.apply_context.invocation.harness,
+      document.result.invocation.harness,
+    )
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_APPLY_HARNESS_MISMATCH",
+      "/apply_context/invocation/harness",
+      "future install harness must exactly match the planning harness",
+    );
+  }
+  if (
+    !isDeepStrictEqual(
+      document.apply_context.invocation.scope,
+      document.result.invocation.scope,
+    )
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_APPLY_SCOPE_MISMATCH",
+      "/apply_context/invocation/scope",
+      "future install scope must exactly match the planning scope",
+    );
+  }
+}
+
+function validateTargetInstanceBinding(document, errors) {
+  const planningScopeRef = document.result.invocation.scope.ref;
+  if (document.target_state.target_instance_id !== planningScopeRef) {
+    addError(
+      errors,
+      "INSTALL_PLAN_TARGET_INSTANCE_MISMATCH",
+      "/target_state/target_instance_id",
+      "target instance must exactly match the selected planning scope reference",
+    );
+  }
+  if (
+    isPlainObject(document.apply_context)
+    && document.target_state.target_instance_id
+      !== document.apply_context.invocation.scope.ref
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_APPLY_TARGET_INSTANCE_MISMATCH",
+      "/target_state/target_instance_id",
+      "target instance must exactly match the selected apply scope reference",
+    );
+  }
+}
+
+function validateIdentifierSeparation(document, errors) {
+  const identifiers = [
+    ["plan_id", document.plan_id],
+    ["planning invocation", document.result.invocation.id],
+  ];
+  if (isPlainObject(document.apply_context)) {
+    identifiers.push(["install invocation", document.apply_context.invocation.id]);
+  }
+  const seen = new Map();
+  for (const [label, value] of identifiers) {
+    if (seen.has(value)) {
+      addError(
+        errors,
+        "INSTALL_PLAN_IDENTIFIER_REUSED",
+        "/",
+        `${label} must not reuse the ${seen.get(value)} identifier`,
+      );
+    } else {
+      seen.set(value, label);
+    }
+  }
+}
+
+function validateDisposition(document, errors) {
+  const policy = planPolicy.dispositions?.[document.disposition];
+  if (!policy) {
+    addError(
+      errors,
+      "INSTALL_PLAN_DISPOSITION_UNKNOWN",
+      "/disposition",
+      `unknown disposition ${document.disposition}`,
+    );
+    return;
+  }
+  if (document.result.outcome !== policy.result_outcome) {
+    addError(
+      errors,
+      "INSTALL_PLAN_DISPOSITION_OUTCOME_MISMATCH",
+      "/result/outcome",
+      `${document.disposition} plans require outcome ${policy.result_outcome}`,
+    );
+  }
+  if (document.actions.length < policy.minimum_actions) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ACTIONS_REQUIRED",
+      "/actions",
+      `${document.disposition} plans require at least ${policy.minimum_actions} action`,
+    );
+  }
+  if (document.actions.length > policy.maximum_actions) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ACTION_LIMIT_EXCEEDED",
+      "/actions",
+      `${document.disposition} plans permit at most ${policy.maximum_actions} actions`,
+    );
+  }
+  if (document.blockers.length < policy.minimum_blockers) {
+    addError(
+      errors,
+      "INSTALL_PLAN_BLOCKERS_REQUIRED",
+      "/blockers",
+      `${document.disposition} plans require at least ${policy.minimum_blockers} blocker`,
+    );
+  }
+  if (document.blockers.length > policy.maximum_blockers) {
+    addError(
+      errors,
+      "INSTALL_PLAN_BLOCKER_LIMIT_EXCEEDED",
+      "/blockers",
+      `${document.disposition} plans permit at most ${policy.maximum_blockers} blockers`,
+    );
+  }
+  if (
+    policy.authorizes_installation !== false
+    || typeof policy.eligible_for_confirmation !== "boolean"
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_DISPOSITION_AUTHORIZATION_INVALID",
+      `/contracts/install-plan-policy.json/dispositions/${document.disposition}`,
+      "install-plan dispositions must never authorize installation",
+    );
+  }
+  if (document.disposition === "ready" && document.blockers.length !== 0) {
+    addError(
+      errors,
+      "INSTALL_PLAN_READY_HAS_BLOCKERS",
+      "/blockers",
+      "ready plans cannot contain blockers",
+    );
+  }
+  if (document.disposition === "blocked") {
+    if (document.actions.length !== 0) {
+      addError(
+        errors,
+        "INSTALL_PLAN_BLOCKED_HAS_ACTIONS",
+        "/actions",
+        "blocked plans cannot carry executable actions",
+      );
+    }
+    if (document.rollback_order.length !== 0) {
+      addError(
+        errors,
+        "INSTALL_PLAN_BLOCKED_HAS_ROLLBACK_ORDER",
+        "/rollback_order",
+        "blocked plans are non-authorizing and cannot carry an executable rollback order",
+      );
+    }
+  }
+}
+
+function validateValidityWindow(document, errors) {
+  const reportedAt = parseTimestamp(document.result.reported_at);
+  const expiresAt = parseTimestamp(document.expires_at);
+  if (reportedAt === null || expiresAt === null) return;
+  const durationMilliseconds = expiresAt - reportedAt;
+  if (durationMilliseconds <= 0) {
+    addError(
+      errors,
+      "INSTALL_PLAN_EXPIRY_ORDER_INVALID",
+      "/expires_at",
+      "plan expiry must be later than the planning result timestamp",
+    );
+  } else if (
+    durationMilliseconds
+    > planPolicy.maximum_validity_seconds * 1000
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_VALIDITY_TOO_LONG",
+      "/expires_at",
+      `plan validity cannot exceed ${planPolicy.maximum_validity_seconds} seconds`,
+    );
+  }
+}
+
+function validateArtifactLifecycle(document, errors) {
+  if (document.result.subject.kind !== "component") return;
+  if (
+    !isDeepStrictEqual(
+      document.artifact.component,
+      document.result.subject.component,
+    )
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ARTIFACT_COMPONENT_MISMATCH",
+      "/artifact/component",
+      "artifact component must exactly match the planned result subject",
+    );
+  }
+  const version = document.result.subject.component.version;
+  let parsed;
+  let lifecycleClass;
+  try {
+    parsed = parseSemverV2(version);
+    lifecycleClass = classifyLifecycleVersion(version);
+  } catch {
+    addError(
+      errors,
+      "INSTALL_PLAN_ARTIFACT_VERSION_INVALID",
+      "/result/subject/component/version",
+      "planned component version must be strict SemVer",
+    );
+    return;
+  }
+  if (parsed.build.length > 0) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ARTIFACT_BUILD_METADATA_FORBIDDEN",
+      "/result/subject/component/version",
+      "planned artifact versions cannot contain build metadata",
+    );
+  }
+  if (
+    document.artifact.channel === "public_stable"
+    && lifecycleClass !== "final"
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_PUBLIC_PRERELEASE_FORBIDDEN",
+      "/artifact/channel",
+      "public_stable plans require a final SemVer component version",
+    );
+  }
+  if (
+    document.artifact.channel === "private_lab"
+    && !["beta", "rc", "final"].includes(lifecycleClass)
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_LAB_VERSION_CLASS_INVALID",
+      "/result/subject/component/version",
+      "private lab plans accept only beta.N, rc.N, or final stable-intent payload versions",
+    );
+  }
+
+  const authority = document.artifact.authority;
+  const expectedAuthorityKind = document.artifact.channel === "private_lab"
+    ? "private_candidate"
+    : "active_catalog_entry";
+  const expectedAuthorityContract = document.artifact.channel === "private_lab"
+    ? "clawsec.private-candidate/v1"
+    : "clawsec.catalog-entry/v1";
+  if (
+    authority.kind !== expectedAuthorityKind
+    || authority.contract !== expectedAuthorityContract
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ARTIFACT_AUTHORITY_MISMATCH",
+      "/artifact/authority",
+      `${document.artifact.channel} artifacts require an exact ${expectedAuthorityContract} reference`,
+    );
+  }
+  const authorityExpiresAt = parseTimestamp(authority.expires_at);
+  const planExpiresAt = parseTimestamp(document.expires_at);
+  if (
+    authorityExpiresAt !== null
+    && planExpiresAt !== null
+    && planExpiresAt > authorityExpiresAt
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_AUTHORITY_EXPIRES_BEFORE_PLAN",
+      "/artifact/authority/expires_at",
+      "artifact authority must remain valid for the full plan lifetime",
+    );
+  }
+}
+
+function validateArtifactResources(document, errors) {
+  const { artifact } = document;
+  if (artifact.archive_byte_length > planPolicy.maximum_archive_bytes) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ARCHIVE_TOO_LARGE",
+      "/artifact/archive_byte_length",
+      `archive cannot exceed ${planPolicy.maximum_archive_bytes} bytes`,
+    );
+  }
+  if (artifact.install_tree_entry_count > planPolicy.maximum_install_tree_entries) {
+    addError(
+      errors,
+      "INSTALL_PLAN_INSTALL_TREE_ENTRY_LIMIT_EXCEEDED",
+      "/artifact/install_tree_entry_count",
+      `install tree cannot exceed ${planPolicy.maximum_install_tree_entries} entries`,
+    );
+  }
+  if (artifact.install_tree_total_bytes > planPolicy.maximum_install_tree_bytes) {
+    addError(
+      errors,
+      "INSTALL_PLAN_INSTALL_TREE_TOO_LARGE",
+      "/artifact/install_tree_total_bytes",
+      `install tree cannot exceed ${planPolicy.maximum_install_tree_bytes} bytes`,
+    );
+  }
+  if (
+    artifact.install_tree_total_bytes
+    > artifact.archive_byte_length * planPolicy.maximum_expansion_ratio
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ARCHIVE_EXPANSION_RATIO_EXCEEDED",
+      "/artifact/install_tree_total_bytes",
+      `install tree cannot exceed ${planPolicy.maximum_expansion_ratio} times the archive size`,
+    );
+  }
+
+  let managedTreeEntryCount = 0;
+  let managedTreeFileBytes = 0;
+  let plannedOutputBytes = 0;
+  let plannedOutputEntries = 0;
+  let capturedPreimageBytes = 0;
+  const capturedPreimagesByDigest = new Map();
+  for (let index = 0; index < document.actions.length; index += 1) {
+    const action = document.actions[index];
+    if (
+      action.kind === "managed_entry"
+      || action.kind === "declared_transformation"
+    ) {
+      plannedOutputEntries += 1;
+      if (action.after.kind === "file") {
+        plannedOutputBytes += action.after.byte_length;
+      }
+    }
+    if (action.kind === "managed_entry") {
+      managedTreeEntryCount += 1;
+      if (action.tree_entry.kind === "file") {
+        managedTreeFileBytes += action.tree_entry.byte_length;
+        if (
+          action.tree_entry.byte_length
+          > planPolicy.maximum_installed_file_bytes
+        ) {
+          addError(
+            errors,
+            "INSTALL_PLAN_INSTALLED_FILE_TOO_LARGE",
+            `/actions/${index}/tree_entry/byte_length`,
+            `installed files cannot exceed ${planPolicy.maximum_installed_file_bytes} bytes`,
+          );
+        }
+      }
+    }
+    if (
+      action.kind === "declared_transformation"
+      && isPlainObject(action.rollback_source)
+    ) {
+      capturedPreimageBytes += action.rollback_source.byte_length;
+      const prior = capturedPreimagesByDigest.get(action.rollback_source.digest);
+      if (
+        prior !== undefined
+        && !isDeepStrictEqual(prior, action.rollback_source)
+      ) {
+        addError(
+          errors,
+          "INSTALL_PLAN_CAPTURED_PREIMAGE_AMBIGUOUS",
+          `/actions/${index}/rollback_source`,
+          "one captured preimage digest cannot describe different rollback material",
+        );
+      } else if (prior === undefined) {
+        capturedPreimagesByDigest.set(
+          action.rollback_source.digest,
+          action.rollback_source,
+        );
+      }
+    }
+  }
+  if (managedTreeEntryCount > artifact.install_tree_entry_count) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ARTIFACT_TREE_ENTRY_COUNT_EXCEEDED",
+      "/actions",
+      "managed tree entries cannot exceed the artifact install-tree entry count",
+    );
+  }
+  if (managedTreeFileBytes > artifact.install_tree_total_bytes) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ARTIFACT_TREE_BYTES_EXCEED_DECLARATION",
+      "/actions",
+      "managed file tree-entry bytes cannot exceed the artifact install-tree size",
+    );
+  }
+  if (document.disposition === "ready") {
+    if (managedTreeEntryCount !== artifact.install_tree_entry_count) {
+      addError(
+        errors,
+        "INSTALL_PLAN_READY_TREE_ENTRY_COVERAGE_MISMATCH",
+        "/artifact/install_tree_entry_count",
+        "ready plans require exactly one managed action for every staged install-tree entry",
+      );
+    }
+    if (managedTreeFileBytes !== artifact.install_tree_total_bytes) {
+      addError(
+        errors,
+        "INSTALL_PLAN_READY_TREE_BYTE_COVERAGE_MISMATCH",
+        "/artifact/install_tree_total_bytes",
+        "ready plans must match the exact byte total of managed file tree entries",
+      );
+    }
+  }
+  if (plannedOutputEntries > planPolicy.maximum_planned_output_entries) {
+    addError(
+      errors,
+      "INSTALL_PLAN_OUTPUT_ENTRY_LIMIT_EXCEEDED",
+      "/actions",
+      `planned output cannot exceed ${planPolicy.maximum_planned_output_entries} entries`,
+    );
+  }
+  if (plannedOutputBytes > planPolicy.maximum_planned_output_bytes) {
+    addError(
+      errors,
+      "INSTALL_PLAN_OUTPUT_BYTES_LIMIT_EXCEEDED",
+      "/actions",
+      `planned output cannot exceed ${planPolicy.maximum_planned_output_bytes} bytes`,
+    );
+  }
+  if (
+    capturedPreimagesByDigest.size
+    > planPolicy.maximum_captured_preimage_entries
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_CAPTURED_PREIMAGE_ENTRY_LIMIT_EXCEEDED",
+      "/actions",
+      `captured rollback material cannot exceed ${planPolicy.maximum_captured_preimage_entries} unique entries`,
+    );
+  }
+  if (capturedPreimageBytes > planPolicy.maximum_captured_preimage_bytes) {
+    addError(
+      errors,
+      "INSTALL_PLAN_CAPTURED_PREIMAGE_BYTES_LIMIT_EXCEEDED",
+      "/actions",
+      `total rollback capture work cannot exceed ${planPolicy.maximum_captured_preimage_bytes} bytes across all transformation targets`,
+    );
+  }
+}
+
+function validateStagedInputBinding(document, errors) {
+  if (document.staged_input.archive_digest !== document.artifact.archive_digest) {
+    addError(
+      errors,
+      "INSTALL_PLAN_STAGED_ARCHIVE_MISMATCH",
+      "/staged_input/archive_digest",
+      "staged archive digest must match the planned artifact archive digest",
+    );
+  }
+  if (
+    document.staged_input.install_tree_manifest_digest
+    !== document.artifact.install_tree_manifest_digest
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_STAGED_TREE_MISMATCH",
+      "/staged_input/install_tree_manifest_digest",
+      "staged install-tree manifest must match the planned artifact",
+    );
+  }
+}
+
+function validateActions(document, errors) {
+  const actionIds = new Set();
+  const targetKeys = new Set();
+  const pathTargets = [];
+  const managedEntriesByCaseFoldedPath = new Map();
+  const managedEntriesByManifestDigest = new Map();
+  const earlierManagedActionsById = new Map();
+  const transformationEntryDigests = new Set();
+  let sawDeclaredTransformation = false;
+  for (let index = 0; index < document.actions.length; index += 1) {
+    const action = document.actions[index];
+    const actionPath = `/actions/${index}`;
+    if (actionIds.has(action.action_id)) {
+      addError(
+        errors,
+        "INSTALL_PLAN_ACTION_ID_DUPLICATE",
+        `${actionPath}/action_id`,
+        `action id ${action.action_id} appears more than once`,
+      );
+    }
+    actionIds.add(action.action_id);
+
+    const targetKey = actionTargetKey(action);
+    if (targetKey !== null) {
+      if (targetKeys.has(targetKey)) {
+        addError(
+          errors,
+          "INSTALL_PLAN_ACTION_TARGET_DUPLICATE",
+          `${actionPath}/target`,
+          "one plan cannot mutate the same target more than once",
+        );
+      }
+      targetKeys.add(targetKey);
+    }
+
+    if (action.kind === "managed_entry") {
+      if (sawDeclaredTransformation) {
+        addError(
+          errors,
+          "INSTALL_PLAN_PACKAGE_ACTION_ORDER_INVALID",
+          actionPath,
+          "all managed package-tree actions must precede declared transformations",
+        );
+      }
+      validateManagedEntryAction(action, actionPath, errors);
+      const foldedTreePath = action.tree_entry.path.toLowerCase();
+      if (managedEntriesByCaseFoldedPath.has(foldedTreePath)) {
+        addError(
+          errors,
+          "INSTALL_PLAN_TREE_ENTRY_PATH_DUPLICATE",
+          `${actionPath}/tree_entry/path`,
+          "managed install-tree entry paths must be unique without case-folded collisions",
+        );
+      } else {
+        managedEntriesByCaseFoldedPath.set(foldedTreePath, action.tree_entry);
+      }
+      const priorManifestEntry = managedEntriesByManifestDigest.get(
+        action.tree_entry.manifest_entry_digest,
+      );
+      if (
+        priorManifestEntry !== undefined
+        && !isDeepStrictEqual(priorManifestEntry, action.tree_entry)
+      ) {
+        addError(
+          errors,
+          "INSTALL_PLAN_MANIFEST_ENTRY_DIGEST_AMBIGUOUS",
+          `${actionPath}/tree_entry/manifest_entry_digest`,
+          "one manifest-entry digest cannot describe different install-tree entries",
+        );
+      } else if (priorManifestEntry === undefined) {
+        managedEntriesByManifestDigest.set(
+          action.tree_entry.manifest_entry_digest,
+          action.tree_entry,
+        );
+      }
+      earlierManagedActionsById.set(action.action_id, action);
+      pathTargets.push({ action, actionPath });
+    } else if (action.kind === "declared_transformation") {
+      sawDeclaredTransformation = true;
+      if (
+        transformationEntryDigests.has(
+          action.declaration.transformation_entry_digest,
+        )
+      ) {
+        addError(
+          errors,
+          "INSTALL_PLAN_TRANSFORMATION_ENTRY_DIGEST_DUPLICATE",
+          `${actionPath}/declaration/transformation_entry_digest`,
+          "one release-manifest transformation entry can appear only once in a plan",
+        );
+      }
+      transformationEntryDigests.add(
+        action.declaration.transformation_entry_digest,
+      );
+      validateTransformationAction(action, actionPath, document, errors);
+      const managedSourceAction = earlierManagedActionsById.get(
+        action.declaration.source.managed_action_id,
+      );
+      if (
+        managedSourceAction === undefined
+        || managedSourceAction.tree_entry.kind !== "file"
+        || managedSourceAction.tree_entry.manifest_entry_digest
+          !== action.declaration.source.manifest_entry_digest
+      ) {
+        addError(
+          errors,
+          "INSTALL_PLAN_TRANSFORMATION_SOURCE_NOT_MANAGED",
+          `${actionPath}/declaration/source`,
+          "transformation source must reference an earlier managed file action and its exact manifest-entry digest",
+        );
+      }
+      pathTargets.push({ action, actionPath });
+    } else if (action.kind === "native_operation") {
+      validateNativeOperationAction(
+        action,
+        actionPath,
+        document.result.invocation.harness.name,
+        errors,
+      );
+      if (
+        ["reload_harness", "restart_harness"].includes(action.operation)
+        && index !== document.actions.length - 1
+      ) {
+        addError(
+          errors,
+          "INSTALL_PLAN_OPERATIONAL_ACTION_ORDER_INVALID",
+          actionPath,
+          "reload or restart must be the final action after every filesystem mutation",
+        );
+      }
+    }
+
+  }
+  validatePathTargetGraph(pathTargets, errors);
+  if (
+    document.disposition === "ready"
+    && !document.actions.some((action) => action.kind === "managed_entry")
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_SUBJECT_PACKAGE_ACTION_REQUIRED",
+      "/actions",
+      "ready plans require at least one managed mutation for the subject package",
+    );
+  }
+}
+
+function validateManagedEntryAction(action, actionPath, errors) {
+  const beforeAbsent = action.before.kind === "absent";
+  if (
+    action.operation !== "create"
+    || !beforeAbsent
+    || !["file", "directory"].includes(action.after.kind)
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_FRESH_CREATE_REQUIRED",
+      actionPath,
+      "install-plan managed entries must create a file or directory over an absent target",
+    );
+  }
+  if (action.rollback_source !== null) {
+    addError(
+      errors,
+      "INSTALL_PLAN_CREATE_ROLLBACK_SOURCE_FORBIDDEN",
+      `${actionPath}/rollback_source`,
+      "fresh create rollback removes the new entry and cannot carry predecessor material",
+    );
+  }
+
+  validateEntryStateSafety(action.before, `${actionPath}/before`, errors);
+  validateEntryStateSafety(action.after, `${actionPath}/after`, errors);
+  const stateFields = ["kind", "mode"];
+  if (
+    action.tree_entry.kind === "file"
+    && action.after.kind === "file"
+  ) {
+    stateFields.push("digest", "byte_length");
+  }
+  for (const field of stateFields) {
+    if (action.tree_entry[field] !== action.after[field]) {
+      addError(
+        errors,
+        "INSTALL_PLAN_TREE_ENTRY_STATE_MISMATCH",
+        `${actionPath}/tree_entry/${field}`,
+        `install-tree entry ${field} must match the managed post-state`,
+      );
+    }
+  }
+}
+
+function validateTransformationAction(action, actionPath, document, errors) {
+  const allowedOutput = action.declaration.allowed_output;
+  if (
+    !isDeepStrictEqual(action.target, allowedOutput.target)
+    || !isDeepStrictEqual(action.before, allowedOutput.before)
+    || !isDeepStrictEqual(action.after, allowedOutput.after)
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_TRANSFORMATION_DECLARATION_MISMATCH",
+      `${actionPath}/declaration/allowed_output`,
+      "transformation target and states must exactly match the declared allowed output",
+    );
+  }
+  if (
+    action.declaration.release_manifest_digest
+    !== document.artifact.release_manifest_digest
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_TRANSFORMATION_RELEASE_MANIFEST_MISMATCH",
+      `${actionPath}/declaration/release_manifest_digest`,
+      "transformation declaration must bind the artifact's exact release manifest",
+    );
+  }
+  validateCodingHarness(
+    action.declaration.coding_harness,
+    `${actionPath}/declaration/coding_harness`,
+    errors,
+  );
+  if (action.before.digest === action.after.digest) {
+    addError(
+      errors,
+      "INSTALL_PLAN_TRANSFORMATION_NO_CHANGE",
+      `${actionPath}/after/digest`,
+      "declared transformation preimage and postimage digests must differ",
+    );
+  }
+  validateEntryStateSafety(action.before, `${actionPath}/before`, errors);
+  validateEntryStateSafety(action.after, `${actionPath}/after`, errors);
+  validateRollbackSource(action.before, action.rollback_source, actionPath, errors);
+}
+
+function validateCodingHarness(codingHarness, harnessPath, errors) {
+  if (!isPlainObject(codingHarness)) return;
+  for (const field of [
+    "implementation_digest",
+    "toolchain_digest",
+    "configuration_digest",
+  ]) {
+    if (
+      typeof codingHarness[field] !== "string"
+      || !/^sha256:[a-f0-9]{64}$/.test(codingHarness[field])
+    ) {
+      addError(
+        errors,
+        "INSTALL_PLAN_CODING_HARNESS_DIGEST_REQUIRED",
+        `${harnessPath}/${field}`,
+        `coding harness ${field} must be an exact SHA-256 digest`,
+      );
+    }
+  }
+
+  const reference = codingHarness.immutable_reference;
+  if (!isPlainObject(reference)) return;
+  if (
+    typeof reference.value === "string"
+    && isFloatingReference(reference.value)
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_CODING_HARNESS_REFERENCE_NOT_IMMUTABLE",
+      `${harnessPath}/immutable_reference/value`,
+      "coding harness identity cannot use latest, stable, main, master, head, or trunk",
+    );
+    return;
+  }
+  let immutable = false;
+  if (reference.kind === "exact_version") {
+    try {
+      immutable = parseSemverV2(reference.value).build.length === 0;
+    } catch {
+      immutable = false;
+    }
+  } else if (reference.kind === "commit") {
+    immutable = (
+      typeof reference.value === "string"
+      && /^[a-f0-9]{40}$/.test(reference.value)
+    );
+  } else if (reference.kind === "content_digest") {
+    immutable = (
+      typeof reference.value === "string"
+      && /^sha256:[a-f0-9]{64}$/.test(reference.value)
+    );
+    if (
+      immutable
+      && reference.value !== codingHarness.implementation_digest
+    ) {
+      addError(
+        errors,
+        "INSTALL_PLAN_CODING_HARNESS_CONTENT_IDENTITY_MISMATCH",
+        `${harnessPath}/immutable_reference/value`,
+        "content-addressed coding harness reference must equal its implementation digest",
+      );
+    }
+  }
+  if (!immutable) {
+    addError(
+      errors,
+      "INSTALL_PLAN_CODING_HARNESS_REFERENCE_NOT_IMMUTABLE",
+      `${harnessPath}/immutable_reference`,
+      "coding harness must use an exact SemVer without build metadata, a full commit, or a content digest",
+    );
+  }
+}
+
+function validateNativeOperationAction(
+  action,
+  actionPath,
+  harness,
+  errors,
+) {
+  const expectedAdapter = `clawsec.${harness}-install-adapter/v1`;
+  if (action.adapter_contract !== expectedAdapter) {
+    addError(
+      errors,
+      "INSTALL_PLAN_NATIVE_ADAPTER_MISMATCH",
+      `${actionPath}/adapter_contract`,
+      `native operation must use ${expectedAdapter}`,
+    );
+  }
+  if (action.state_effect === "operational_non_mutating") {
+    if (
+      !["reload_harness", "restart_harness"].includes(action.operation)
+      || action.rollback !== null
+      || action.precondition_digest !== action.expected_postcondition_digest
+    ) {
+      addError(
+        errors,
+        "INSTALL_PLAN_NATIVE_OPERATIONAL_ACTION_INVALID",
+        actionPath,
+        "reload and restart must target the selected harness resource, preserve state, and carry no rollback",
+      );
+    }
+    return;
+  }
+  addError(
+    errors,
+    "INSTALL_PLAN_NATIVE_OPERATION_UNSUPPORTED",
+    actionPath,
+    "install-plan v1 native operations are limited to non-mutating reload or restart",
+  );
+}
+
+function validateResultEffects(document, errors) {
+  const effects = document.result.effects;
+  if (document.disposition === "blocked") {
+    if (effects.length !== 0) {
+      addError(
+        errors,
+        "INSTALL_PLAN_BLOCKED_HAS_EFFECTS",
+        "/result/effects",
+        "blocked plans cannot report proposed effects",
+      );
+    }
+    return;
+  }
+  if (document.confirmation_requirements.disclosure_source !== "install_plan_actions") {
+    addError(
+      errors,
+      "INSTALL_PLAN_CONFIRMATION_DISCLOSURE_INVALID",
+      "/confirmation_requirements/disclosure_source",
+      "confirmation must disclose the complete install-plan action list",
+    );
+  }
+  if (effects.length !== document.actions.length) {
+    addError(
+      errors,
+      "INSTALL_PLAN_EFFECT_ACTION_COUNT_MISMATCH",
+      "/result/effects",
+      "ready plans require exactly one reported effect for every planned action",
+    );
+  }
+  const effectsById = new Map();
+  for (let index = 0; index < effects.length; index += 1) {
+    const effect = effects[index];
+    if (effectsById.has(effect.effect_id)) {
+      addError(
+        errors,
+        "INSTALL_PLAN_EFFECT_ID_DUPLICATE",
+        `/result/effects/${index}/effect_id`,
+        "reported plan effect identifiers must be unique",
+      );
+    }
+    effectsById.set(effect.effect_id, effect);
+  }
+  for (let index = 0; index < document.actions.length; index += 1) {
+    const action = document.actions[index];
+    const effect = effectsById.get(action.action_id);
+    const expectedTarget = actionEffectTarget(action);
+    if (
+      effect === undefined
+      || effect.state !== "proposed"
+      || !isDeepStrictEqual(effect.target, expectedTarget)
+    ) {
+      addError(
+        errors,
+        "INSTALL_PLAN_EFFECT_ACTION_MISMATCH",
+        `/result/effects`,
+        `action ${action.action_id} requires one proposed effect against its exact compatible target`,
+      );
+    }
+  }
+}
+
+export function computeInstallPlanStateBindings(documentOrActions) {
+  const actions = Array.isArray(documentOrActions)
+    ? documentOrActions
+    : documentOrActions.actions;
+  const prestate = [];
+  const poststate = [];
+  for (const action of actions) {
+    const target = action.target;
+    if (
+      action.kind === "managed_entry"
+      || action.kind === "declared_transformation"
+    ) {
+      prestate.push({
+        action_id: action.action_id,
+        target,
+        state: action.before,
+      });
+      poststate.push({
+        action_id: action.action_id,
+        target,
+        state: action.after,
+      });
+    } else if (action.kind === "native_operation") {
+      prestate.push({
+        action_id: action.action_id,
+        target,
+        state: {
+          kind: "native_condition",
+          digest: action.precondition_digest,
+        },
+      });
+      poststate.push({
+        action_id: action.action_id,
+        target,
+        state: {
+          kind: "native_condition",
+          digest: action.expected_postcondition_digest,
+        },
+      });
+    }
+  }
+  const sortRecords = (records) => records.sort((left, right) => {
+    const leftJson = canonicalJson(left);
+    const rightJson = canonicalJson(right);
+    return leftJson < rightJson ? -1 : leftJson > rightJson ? 1 : 0;
+  });
+  return {
+    action_set_digest: digestCanonical(actions),
+    touched_prestate_digest: digestCanonical(sortRecords(prestate)),
+    touched_expected_poststate_digest: digestCanonical(sortRecords(poststate)),
+  };
+}
+
+function validateDerivedStateBindings(document, errors) {
+  const expected = computeInstallPlanStateBindings(document);
+  for (const [field, digest] of Object.entries(expected)) {
+    if (document.target_state[field] !== digest) {
+      addError(
+        errors,
+        "INSTALL_PLAN_DERIVED_STATE_MISMATCH",
+        `/target_state/${field}`,
+        `${field} must be derived deterministically from the exact planned actions`,
+      );
+    }
+  }
+}
+
+function validateRollbackSource(before, rollbackSource, actionPath, errors) {
+  if (
+    before.kind !== "file"
+    || !isPlainObject(rollbackSource)
+    || rollbackSource.kind !== "captured_file"
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ROLLBACK_SOURCE_REQUIRED",
+      `${actionPath}/rollback_source`,
+      "declared transformations require a captured file matching the exact pre-state",
+    );
+    return;
+  }
+  const stateFields = [
+    "digest",
+    "byte_length",
+    "mode",
+    "owner_identity_digest",
+    "group_identity_digest",
+  ];
+  for (const field of stateFields) {
+    if (rollbackSource[field] !== before[field]) {
+      addError(
+        errors,
+        "INSTALL_PLAN_ROLLBACK_SOURCE_MISMATCH",
+        `${actionPath}/rollback_source/${field}`,
+        `captured rollback ${field} must match the exact pre-state`,
+      );
+    }
+  }
+}
+
+function validateEntryStateSafety(state, statePath, errors) {
+  if (state.kind === "absent") return;
+  const mode = Number.parseInt(state.mode, 8);
+  if (!Number.isInteger(mode) || (mode & 0o022) !== 0) {
+    addError(
+      errors,
+      "INSTALL_PLAN_UNSAFE_MODE_FORBIDDEN",
+      `${statePath}/mode`,
+      "planned filesystem state cannot be group-writable or world-writable",
+    );
+  }
+  if (
+    state.kind === "file"
+    && state.byte_length > planPolicy.maximum_installed_file_bytes
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_INSTALLED_FILE_TOO_LARGE",
+      `${statePath}/byte_length`,
+      `installed files cannot exceed ${planPolicy.maximum_installed_file_bytes} bytes`,
+    );
+  }
+}
+
+function validatePathTargetGraph(pathTargets, errors) {
+  for (let leftIndex = 0; leftIndex < pathTargets.length; leftIndex += 1) {
+    const left = pathTargets[leftIndex];
+    const leftTarget = left.action.target;
+    const leftFolded = leftTarget.path.toLowerCase();
+    for (
+      let rightIndex = leftIndex + 1;
+      rightIndex < pathTargets.length;
+      rightIndex += 1
+    ) {
+      const right = pathTargets[rightIndex];
+      const rightTarget = right.action.target;
+      if (leftTarget.anchor !== rightTarget.anchor) continue;
+      const rightFolded = rightTarget.path.toLowerCase();
+      if (leftFolded === rightFolded) {
+        if (leftTarget.path !== rightTarget.path) {
+          addError(
+            errors,
+            "INSTALL_PLAN_PATH_CASE_COLLISION",
+            `${right.actionPath}/target/path`,
+            "planned paths cannot differ only by case",
+          );
+        }
+        continue;
+      }
+
+      const [ancestor, descendant] = leftFolded.length < rightFolded.length
+        ? [left, right]
+        : [right, left];
+      const ancestorPath = ancestor.action.target.path.toLowerCase();
+      const descendantPath = descendant.action.target.path.toLowerCase();
+      if (!descendantPath.startsWith(`${ancestorPath}/`)) continue;
+      if (
+        actionExpectedEntryKind(descendant.action) !== "absent"
+        && actionExpectedEntryKind(ancestor.action) !== "directory"
+      ) {
+        addError(
+          errors,
+          "INSTALL_PLAN_PATH_ANCESTOR_CONFLICT",
+          `${descendant.actionPath}/target/path`,
+          "a planned child path cannot exist below a non-directory or removed planned ancestor",
+        );
+      }
+    }
+  }
+}
+
+function actionExpectedEntryKind(action) {
+  if (action.kind === "managed_entry") return action.after.kind;
+  if (action.kind === "declared_transformation") return "file";
+  return null;
+}
+
+function validateBlockers(blockers, errors) {
+  const blockerIds = new Set();
+  for (let index = 0; index < blockers.length; index += 1) {
+    const blocker = blockers[index];
+    if (blockerIds.has(blocker.blocker_id)) {
+      addError(
+        errors,
+        "INSTALL_PLAN_BLOCKER_ID_DUPLICATE",
+        `/blockers/${index}/blocker_id`,
+        `blocker id ${blocker.blocker_id} appears more than once`,
+      );
+    }
+    blockerIds.add(blocker.blocker_id);
+  }
+}
+
+function validateRollbackOrder(document, errors) {
+  if (document.disposition !== "ready") return;
+  const expected = document.actions
+    .filter((action) => action.kind !== "native_operation")
+    .map((action) => action.action_id)
+    .reverse();
+  if (!isDeepStrictEqual(document.rollback_order, expected)) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ROLLBACK_ORDER_MISMATCH",
+      "/rollback_order",
+      "ready plans must roll back every filesystem mutation exactly once in reverse execution order",
+    );
+  }
+}
+
+function validateExpectedBindings(document, expectedBindings, errors) {
+  if (
+    !isPlainObject(expectedBindings)
+    || !isDeepStrictEqual(Object.keys(expectedBindings).sort(), EXPECTED_BINDING_KEYS)
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_EXPECTED_BINDINGS_REQUIRED",
+      "/",
+      `bound validation requires caller-owned ${EXPECTED_BINDING_KEYS.join(", ")}`,
+    );
+    return;
+  }
+  for (const key of EXPECTED_BINDING_KEYS) {
+    if (!isDeepStrictEqual(document[key], expectedBindings[key])) {
+      addError(
+        errors,
+        "INSTALL_PLAN_EXPECTED_BINDING_MISMATCH",
+        `/${key}`,
+        `${key} does not match the caller-owned expected value`,
+      );
+    }
+  }
+}
+
+function validateEvaluationTime(document, evaluatedAt, errors) {
+  const evaluationTime = parseTimestamp(evaluatedAt);
+  if (evaluationTime === null) {
+    addError(
+      errors,
+      "INSTALL_PLAN_EVALUATION_TIME_REQUIRED",
+      "/",
+      "bound validation requires a caller-supplied UTC evaluation timestamp",
+    );
+    return;
+  }
+  const reportedAt = parseTimestamp(document.result.reported_at);
+  const expiresAt = parseTimestamp(document.expires_at);
+  if (reportedAt !== null && evaluationTime < reportedAt) {
+    addError(
+      errors,
+      "INSTALL_PLAN_EVALUATION_BEFORE_PLAN",
+      "/",
+      "evaluation time cannot precede the planning result",
+    );
+  }
+  if (expiresAt !== null && evaluationTime >= expiresAt) {
+    addError(
+      errors,
+      "INSTALL_PLAN_EXPIRED",
+      "/expires_at",
+      "plan expired before the caller's evaluation time",
+    );
+  }
+  const authorityExpiresAt = parseTimestamp(
+    document.artifact.authority.expires_at,
+  );
+  if (authorityExpiresAt !== null && evaluationTime >= authorityExpiresAt) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ARTIFACT_AUTHORITY_EXPIRED",
+      "/artifact/authority/expires_at",
+      "artifact authority expired before evaluation",
+    );
+  }
+}
+
+function validateBoundTargetPaths(document, metadataBytesByDigest, errors) {
+  if (document.result.subject.kind !== "component") return;
+  const component = document.result.subject.component;
+  const metadataBytes = resolveDigestBytes(
+    metadataBytesByDigest,
+    component.metadata_digest,
+  );
+  if (!(metadataBytes instanceof Uint8Array)) return;
+  const parsedMetadata = parseJsonObjectBytes(
+    metadataBytes,
+    "INSTALL_PLAN_SUBJECT_METADATA",
+    "/result/subject/component",
+  );
+  if (!parsedMetadata.valid) return;
+
+  validateBoundInstallPlanAdapter({
+    document,
+    metadata: parsedMetadata.value,
+    errors,
+    addError,
+    pathIsAtOrBelow,
+    validatePortablePosixPath,
+  });
+}
+
+function validateDispositionPolicy(errors) {
+  const expected = {
+    blocked: {
+      result_outcome: "blocked",
+      eligible_for_confirmation: false,
+      authorizes_installation: false,
+      minimum_actions: 0,
+      maximum_actions: 0,
+      minimum_blockers: 1,
+      maximum_blockers: 64,
+    },
+    ready: {
+      result_outcome: "pass",
+      eligible_for_confirmation: true,
+      authorizes_installation: false,
+      minimum_actions: 1,
+      maximum_actions: 64,
+      minimum_blockers: 0,
+      maximum_blockers: 0,
+    },
+  };
+  if (!isDeepStrictEqual(planPolicy.dispositions, expected)) {
+    addError(
+      errors,
+      "INSTALL_PLAN_DISPOSITION_POLICY_MISMATCH",
+      "/contracts/install-plan-policy.json/dispositions",
+      "disposition policy does not match the required v1 ready and blocked invariants",
+    );
+  }
+}
+
+function validateConfirmationPolicy(errors) {
+  const expected = {
+    binding: "sha256_exact_plan_bytes",
+    disclosure_source: "install_plan_actions",
+    external_nonce_required: true,
+    authenticated_principal_required: true,
+    target_instance_binding_required: true,
+    one_time_ledger_required: true,
+    expires_with_plan: true,
+    confirmation_authorizes_installation: false,
+    apply_reverification_required: true,
+  };
+  if (!isDeepStrictEqual(planPolicy.confirmation, expected)) {
+    addError(
+      errors,
+      "INSTALL_PLAN_CONFIRMATION_POLICY_MISMATCH",
+      "/contracts/install-plan-policy.json/confirmation",
+      "confirmation requirements must be external, exact-byte-bound, single-use, non-authorizing, and apply-reverified",
+    );
+  }
+}
+
+function validateFilesystemPolicy(errors) {
+  const expected = {
+    path_flavor: "posix",
+    target_anchor: "scope_root",
+    paths_are_scope_relative: true,
+    symlinks_allowed: false,
+    special_files_allowed: false,
+    group_or_other_write_allowed: false,
+    trailing_dot_segments_allowed: false,
+    windows_device_basenames_allowed: false,
+    managed_entries_are_fresh_create_only: true,
+    managed_entries_require_absent_prestate: true,
+    existing_target_entries_are_blockers: true,
+    install_tree_entries_require_manifest_entry_digest: true,
+  };
+  if (!isDeepStrictEqual(planPolicy.filesystem, expected)) {
+    addError(
+      errors,
+      "INSTALL_PLAN_FILESYSTEM_POLICY_MISMATCH",
+      "/contracts/install-plan-policy.json/filesystem",
+      "filesystem policy must require scope-relative fresh creates over absent targets",
+    );
+  }
+}
+
+function validateRollbackPolicy(errors) {
+  const expected = {
+    state_mutating_actions_require_rollback: true,
+    managed_create_rolls_back_by_removal: true,
+    declared_transformation_requires_captured_preimage: true,
+    non_state_mutating_actions_have_null_rollback: true,
+    non_state_mutating_actions_excluded_from_rollback_order: true,
+  };
+  if (!isDeepStrictEqual(planPolicy.rollback, expected)) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ROLLBACK_POLICY_MISMATCH",
+      "/contracts/install-plan-policy.json/rollback",
+      "rollback policy must require exact reversible state changes and exclude operational actions",
+    );
+  }
+}
+
+function validateAssurancePolicy(errors) {
+  const expected = {
+    exact_plan_bytes: "verified",
+    exact_component_metadata: "verified_when_bound",
+    caller_expected_artifact: "verified_when_bound",
+    future_install_context: "verified_when_ready",
+    provenance: "unverified",
+    catalog_authorization: "unverified",
+    release_signature_authorization: "unverified",
+    advisory_verification: "unverified",
+    operator_authorization: "unverified",
+    artifact_source_membership: "unverified",
+    action_state_derivation: "verified_when_bound",
+    installation_authorization: "not_granted",
+    execution: "not_executed",
+    preconditions_at_apply_time: "unverified",
+  };
+  if (!isDeepStrictEqual(planPolicy.assurance, expected)) {
+    addError(
+      errors,
+      "INSTALL_PLAN_ASSURANCE_POLICY_MISMATCH",
+      "/contracts/install-plan-policy.json/assurance",
+      "assurance policy must preserve the exact-byte binding and unverified security boundaries",
+    );
+  }
+}
+
+function validateSchemaPolicyAlignment(errors) {
+  if (planSchema?.properties?.actions?.maxItems !== planPolicy.maximum_actions) {
+    addError(
+      errors,
+      "INSTALL_PLAN_SCHEMA_ACTION_LIMIT_MISMATCH",
+      "/contracts/schemas/install/install-plan-v1.schema.json/properties/actions/maxItems",
+      "schema action limit must match install-plan policy",
+    );
+  }
+  if (planSchema?.properties?.blockers?.maxItems !== planPolicy.maximum_blockers) {
+    addError(
+      errors,
+      "INSTALL_PLAN_SCHEMA_BLOCKER_LIMIT_MISMATCH",
+      "/contracts/schemas/install/install-plan-v1.schema.json/properties/blockers/maxItems",
+      "schema blocker limit must match install-plan policy",
+    );
+  }
+  if (
+    !isDeepStrictEqual(
+      planSchema?.properties?.disposition?.enum,
+      ["blocked", "ready"],
+    )
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_SCHEMA_DISPOSITION_MISMATCH",
+      "/contracts/schemas/install/install-plan-v1.schema.json/properties/disposition/enum",
+      "schema dispositions must be blocked and ready",
+    );
+  }
+  if (
+    planSchema?.properties?.path_flavor?.const
+      !== planPolicy.filesystem?.path_flavor
+    || planSchema?.definitions?.anchoredPath?.properties?.anchor?.const
+      !== planPolicy.filesystem?.target_anchor
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_SCHEMA_PATH_MODEL_MISMATCH",
+      "/contracts/schemas/install/install-plan-v1.schema.json",
+      "schema and policy must use POSIX paths in one canonical scope_root target space",
+    );
+  }
+  const nativeActionRefs = (
+    planSchema?.definitions?.nativeOperationAction?.oneOf ?? []
+  ).map((entry) => entry.$ref);
+  if (
+    !isDeepStrictEqual(nativeActionRefs, [
+      "#/definitions/reloadHarnessAction",
+      "#/definitions/restartHarnessAction",
+    ])
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_SCHEMA_NATIVE_OPERATION_SET_MISMATCH",
+      "/contracts/schemas/install/install-plan-v1.schema.json/definitions/nativeOperationAction",
+      "install-plan v1 native operations must be limited to reload and restart",
+    );
+  }
+}
+
+async function readContractJson(filePath, label, errorPath) {
+  try {
+    const bytes = await readFile(filePath);
+    const parsed = parseJsonObjectBytes(bytes, label, errorPath);
+    return {
+      value: parsed.valid ? parsed.value : null,
+      errors: parsed.errors,
+    };
+  } catch {
+    return {
+      value: null,
+      errors: [{
+        code: `${label}_READ_FAILED`,
+        path: errorPath,
+        message: "contract source could not be read",
+      }],
+    };
+  }
+}
+
+function appendSchemaDiagnostics(schemaErrors, errors) {
+  for (const schemaError of schemaErrors ?? []) {
+    const additionalProperty = schemaError.keyword === "additionalProperties"
+      ? schemaError.params?.additionalProperty
+      : null;
+    const errorPath = additionalProperty
+      ? joinJsonPointer(schemaError.dataPath || "", additionalProperty)
+      : schemaError.dataPath || "/";
+    addError(
+      errors,
+      "INSTALL_PLAN_SCHEMA_INVALID",
+      errorPath,
+      `${schemaError.keyword}: ${schemaError.message}`,
+    );
+    if (errors.length >= MAXIMUM_DIAGNOSTICS) break;
+  }
+}
+
+function appendNestedDiagnostics(errors, nestedErrors, prefix) {
+  for (const nested of nestedErrors ?? []) {
+    const nestedPath = nested.path === "/" ? "" : nested.path;
+    addError(
+      errors,
+      nested.code,
+      `${prefix}${nestedPath}` || prefix,
+      nested.message,
+    );
+  }
+}
+
+function finishUnbound(errors) {
+  return {
+    valid: errors.length === 0,
+    errors: errors.slice(0, MAXIMUM_DIAGNOSTICS),
+    binding: "unverified",
+    authorization: "not_granted",
+    execution: "not_executed",
+    warnings: [],
+  };
+}
+
+function finishBound(errors, warnings, planDigest) {
+  return {
+    valid: errors.length === 0,
+    errors: errors.slice(0, MAXIMUM_DIAGNOSTICS),
+    plan_digest: planDigest,
+    binding: errors.length === 0
+      ? "exact_plan_bytes_metadata_and_caller_inputs"
+      : "unverified",
+    provenance: "unverified",
+    catalog_authorization: "unverified",
+    release_signature_authorization: "unverified",
+    advisory_verification: "unverified",
+    operator_authorization: "unverified",
+    artifact_source_membership: "unverified",
+    action_state_derivation: errors.length === 0
+      ? "verified_from_plan_actions"
+      : "unverified",
+    installation_authorization: "not_granted",
+    execution: "not_executed",
+    preconditions_at_apply_time: "unverified",
+    warnings: warnings.slice(0, MAXIMUM_DIAGNOSTICS),
+  };
+}
+
+function addError(errors, code, errorPath, message) {
+  if (errors.length >= MAXIMUM_DIAGNOSTICS) return;
+  if (
+    errors.some((entry) => (
+      entry.code === code
+      && entry.path === errorPath
+      && entry.message === message
+    ))
+  ) {
+    return;
+  }
+  errors.push({ code, path: errorPath, message });
+}
+
+function validateClosedObject(value, expectedKeys, errorPath, errors) {
+  if (!isPlainObject(value)) {
+    addError(errors, "INSTALL_PLAN_POLICY_INVALID", errorPath, "policy must be an object");
+    return;
+  }
+  if (!isDeepStrictEqual(Object.keys(value).sort(), [...expectedKeys].sort())) {
+    addError(
+      errors,
+      "INSTALL_PLAN_POLICY_FIELDS_INVALID",
+      errorPath,
+      `expected fields ${[...expectedKeys].sort().join(", ")}`,
+    );
+  }
+}
+
+function preflightDocumentShape(document, errors) {
+  const maximumArrayItems = planPolicy.maximum_array_items
+    ?? EXPECTED_POLICY.maximumArrayItems;
+  const maximumObjectKeys = planPolicy.maximum_object_keys
+    ?? EXPECTED_POLICY.maximumObjectKeys;
+  const maximumDocumentNodes = planPolicy.maximum_document_nodes
+    ?? EXPECTED_POLICY.maximumDocumentNodes;
+  const stack = [{ path: "/", value: document }];
+  const seen = new WeakSet();
+  let nodeCount = 0;
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    nodeCount += 1;
+    if (nodeCount > maximumDocumentNodes) {
+      addError(
+        errors,
+        "INSTALL_PLAN_DOCUMENT_NODE_LIMIT_EXCEEDED",
+        "/",
+        `plan cannot contain more than ${maximumDocumentNodes} JSON nodes`,
+      );
+      return;
+    }
+
+    const { value } = current;
+    if (value === null || typeof value !== "object") continue;
+    if (seen.has(value)) {
+      addError(
+        errors,
+        "INSTALL_PLAN_DOCUMENT_CYCLE_FORBIDDEN",
+        current.path,
+        "plan must be an acyclic JSON document",
+      );
+      return;
+    }
+    seen.add(value);
+
+    if (Array.isArray(value)) {
+      if (value.length > maximumArrayItems) {
+        addError(
+          errors,
+          "INSTALL_PLAN_ARRAY_LIMIT_EXCEEDED",
+          current.path,
+          `plan arrays cannot contain more than ${maximumArrayItems} items`,
+        );
+        return;
+      }
+      for (let index = value.length - 1; index >= 0; index -= 1) {
+        stack.push({
+          path: joinJsonPointer(current.path === "/" ? "" : current.path, index),
+          value: value[index],
+        });
+      }
+      continue;
+    }
+
+    let keyCount = 0;
+    for (const key in value) {
+      if (!Object.hasOwn(value, key)) continue;
+      keyCount += 1;
+      if (keyCount > maximumObjectKeys) {
+        addError(
+          errors,
+          "INSTALL_PLAN_OBJECT_KEY_LIMIT_EXCEEDED",
+          current.path,
+          `plan objects cannot contain more than ${maximumObjectKeys} keys`,
+        );
+        return;
+      }
+      stack.push({
+        path: joinJsonPointer(current.path === "/" ? "" : current.path, key),
+        value: value[key],
+      });
+    }
+  }
+}
+
+function preflightPortablePaths(document, errors) {
+  if (!isPlainObject(document)) return;
+  if (
+    Object.hasOwn(document, "path_flavor")
+    && document.path_flavor !== "posix"
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_PATH_FLAVOR_INVALID",
+      "/path_flavor",
+      "install-plan v1 paths must use POSIX slash semantics",
+    );
+  }
+
+  const inspectAnchoredTarget = (target, targetPath) => {
+    if (!isPlainObject(target)) return;
+    if (
+      typeof target.anchor === "string"
+      && target.anchor !== "scope_root"
+    ) {
+      addError(
+        errors,
+        "INSTALL_PLAN_FILESYSTEM_ANCHOR_INVALID",
+        `${targetPath}/anchor`,
+        "install-plan v1 filesystem targets must use the one canonical scope_root anchor",
+      );
+    }
+    validatePortablePosixPath(target.path, `${targetPath}/path`, errors);
+  };
+
+  const actions = Array.isArray(document.actions) ? document.actions : [];
+  for (let index = 0; index < actions.length; index += 1) {
+    const action = actions[index];
+    if (!isPlainObject(action)) continue;
+    const actionPath = `/actions/${index}`;
+    if (
+      action.kind === "managed_entry"
+      || action.kind === "declared_transformation"
+    ) {
+      inspectAnchoredTarget(action.target, `${actionPath}/target`);
+    }
+    if (
+      isPlainObject(action.tree_entry)
+      && !(
+        action.tree_entry.kind === "directory"
+        && action.tree_entry.path === "."
+      )
+    ) {
+      validatePortablePosixPath(
+        action.tree_entry.path,
+        `${actionPath}/tree_entry/path`,
+        errors,
+      );
+    }
+    if (isPlainObject(action.declaration?.allowed_output?.target)) {
+      inspectAnchoredTarget(
+        action.declaration.allowed_output.target,
+        `${actionPath}/declaration/allowed_output/target`,
+      );
+    }
+  }
+
+  const blockers = Array.isArray(document.blockers) ? document.blockers : [];
+  for (let index = 0; index < blockers.length; index += 1) {
+    const target = blockers[index]?.target;
+    if (!isPlainObject(target)) continue;
+    if (typeof target.anchor === "string") {
+      inspectAnchoredTarget(target, `/blockers/${index}/target`);
+    } else if (target.kind === "relative_path") {
+      validatePortablePosixPath(
+        target.value,
+        `/blockers/${index}/target/value`,
+        errors,
+      );
+    }
+  }
+
+  const skillRootPath = document.adapter?.profile?.skill_root_path;
+  if (typeof skillRootPath === "string") {
+    validatePortablePosixPath(
+      skillRootPath,
+      "/adapter/profile/skill_root_path",
+      errors,
+    );
+  }
+}
+
+function preflightRemovedNativeOperations(document, errors) {
+  if (!isPlainObject(document)) return;
+  const actions = Array.isArray(document.actions) ? document.actions : [];
+  for (let index = 0; index < actions.length; index += 1) {
+    const action = actions[index];
+    if (
+      isPlainObject(action)
+      && ["activate_package", "deactivate_package"].includes(action.operation)
+    ) {
+      addError(
+        errors,
+        "INSTALL_PLAN_NATIVE_PACKAGE_ACTIVATION_UNSUPPORTED",
+        `/actions/${index}/operation`,
+        "exact-tree filesystem writes are package activation in install-plan v1; activate and deactivate operations are not supported",
+      );
+    }
+  }
+}
+
+function preflightPrototypeAdapters(document, errors) {
+  if (!isPlainObject(document)) return;
+  const harness = document.result?.invocation?.harness?.name;
+  if (!["hermes", "picoclaw"].includes(harness)) return;
+  if (document.adapter?.profile?.native_install_status !== "prototype_pending") {
+    addError(
+      errors,
+      "INSTALL_PLAN_PROTOTYPE_STATUS_INVALID",
+      "/adapter/profile/native_install_status",
+      `${harness} install planning must explicitly declare prototype_pending`,
+    );
+  }
+  if (
+    document.disposition !== "blocked"
+    || (Array.isArray(document.actions) && document.actions.length !== 0)
+    || document.apply_context !== null
+    || document.confirmation_requirements !== null
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_PROTOTYPE_PENDING_DISPOSITION_INVALID",
+      "/disposition",
+      `${harness} native installation is prototype pending and can only produce a blocked plan`,
+    );
+  }
+  if (
+    !Array.isArray(document.blockers)
+    || document.blockers.length === 0
+    || document.blockers.some((blocker) => (
+      blocker?.code !== "unsupported_native_operation"
+    ))
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_PROTOTYPE_PENDING_BLOCKER_INVALID",
+      "/blockers",
+      `${harness} prototype-pending plans require only unsupported_native_operation blockers`,
+    );
+  }
+}
+
+function preflightCodingHarnessReferences(document, errors) {
+  if (!isPlainObject(document)) return;
+  const candidates = [{
+    value: document.adapter?.profile?.coding_harness,
+    path: "/adapter/profile/coding_harness",
+  }];
+  const actions = Array.isArray(document.actions) ? document.actions : [];
+  for (let index = 0; index < actions.length; index += 1) {
+    const codingHarness = actions[index]?.declaration?.coding_harness;
+    candidates.push({
+      value: codingHarness,
+      path: `/actions/${index}/declaration/coding_harness`,
+    });
+  }
+  for (const candidate of candidates) {
+    validateCodingHarness(candidate.value, candidate.path, errors);
+  }
+}
+
+function validatePortablePosixPath(candidate, errorPath, errors) {
+  if (typeof candidate !== "string") return;
+  const segments = candidate.split("/");
+  if (
+    candidate.length === 0
+    || candidate.startsWith("/")
+    || candidate.includes("\\")
+    || segments.some((segment) => (
+      segment.length === 0 || segment === "." || segment === ".."
+    ))
+  ) {
+    addError(
+      errors,
+      "INSTALL_PLAN_PATH_NOT_POSIX",
+      errorPath,
+      "path must be a normalized non-empty relative POSIX path",
+    );
+    return;
+  }
+  if (segments.some((segment) => segment.endsWith("."))) {
+    addError(
+      errors,
+      "INSTALL_PLAN_PATH_TRAILING_DOT_FORBIDDEN",
+      errorPath,
+      "POSIX path segments cannot end with a dot in a portable install plan",
+    );
+  }
+  for (const segment of segments) {
+    const basename = segment.split(".", 1)[0].replace(/[ .]+$/u, "");
+    if (
+      /^(?:con|prn|aux|nul|clock\$|com[1-9]|lpt[1-9])$/iu.test(basename)
+    ) {
+      addError(
+        errors,
+        "INSTALL_PLAN_WINDOWS_DEVICE_PATH_FORBIDDEN",
+        errorPath,
+        "portable install paths cannot use Windows device basenames",
+      );
+      break;
+    }
+  }
+}
+
+function isFloatingReference(value) {
+  return /^(?:latest|stable|main|master|head|trunk)$/iu.test(value);
+}
+
+function actionTargetKey(action) {
+  if (
+    action.kind === "managed_entry"
+    || action.kind === "declared_transformation"
+  ) {
+    return `${action.target.anchor}:${action.target.path}`;
+  }
+  if (action.kind === "native_operation") {
+    if (typeof action.target.anchor === "string") {
+      return `${action.target.anchor}:${action.target.path}:native:${action.operation}`;
+    }
+    return `${action.target.kind}:${action.target.value}:native:${action.operation}`;
+  }
+  return null;
+}
+
+function actionEffectTarget(action) {
+  if (typeof action.target.anchor === "string") {
+    return {
+      kind: "relative_path",
+      value: action.target.path,
+    };
+  }
+  return {
+    kind: "harness_resource",
+    value: action.target.value,
+  };
+}
+
+function digestCanonical(value) {
+  return digestBytes(Buffer.from(canonicalJson(value), "utf8"));
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+  }
+  const keys = Object.keys(value).sort();
+  return `{${keys.map((key) => (
+    `${JSON.stringify(key)}:${canonicalJson(value[key])}`
+  )).join(",")}}`;
+}
+
+function parseTimestamp(value) {
+  if (
+    typeof value !== "string"
+    || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value)
+  ) {
+    return null;
+  }
+  const milliseconds = Date.parse(value);
+  return Number.isFinite(milliseconds) ? milliseconds : null;
+}
+
+function resolveDigestBytes(resolver, digest) {
+  if (resolver instanceof Map) {
+    try {
+      return Map.prototype.get.call(resolver, digest);
+    } catch {
+      return null;
+    }
+  }
+  if (isPlainObject(resolver)) {
+    try {
+      const descriptor = Object.getOwnPropertyDescriptor(resolver, digest);
+      if (descriptor && Object.hasOwn(descriptor, "value")) {
+        return descriptor.value;
+      }
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function snapshotInstallPlanBytes(planBytes) {
+  const errors = [];
+  if (!(planBytes instanceof Uint8Array)) {
+    return { bytes: planBytes, errors };
+  }
+  const view = fixedUint8ArrayView(planBytes);
+  if (view === null) {
+    addError(
+      errors,
+      "INSTALL_PLAN_BYTES_REQUIRED",
+      "/",
+      "input must be a stable Buffer or Uint8Array view",
+    );
+    return { bytes: null, errors };
+  }
+  if (view.byteLength > EXPECTED_POLICY.maximumPlanBytes) {
+    addError(
+      errors,
+      "INSTALL_PLAN_TOO_LARGE",
+      "/",
+      `input exceeds the ${EXPECTED_POLICY.maximumPlanBytes}-byte contract limit`,
+    );
+    return { bytes: null, errors };
+  }
+  try {
+    return { bytes: Buffer.from(view), errors };
+  } catch {
+    addError(
+      errors,
+      "INSTALL_PLAN_BYTES_SNAPSHOT_FAILED",
+      "/",
+      "input bytes changed shape before a bounded private snapshot could be made",
+    );
+    return { bytes: null, errors };
+  }
+}
+
+function snapshotDigestBytesResolver(resolver, requiredDigests, errors) {
+  const snapshot = new Map();
+  for (const digest of new Set(requiredDigests)) {
+    const bytes = resolveDigestBytes(resolver, digest);
+    if (!(bytes instanceof Uint8Array)) continue;
+    const view = fixedUint8ArrayView(bytes);
+    if (view === null) continue;
+    if (view.byteLength > EXPECTED_POLICY.maximumPlanBytes) {
+      addError(
+        errors,
+        "INSTALL_PLAN_METADATA_TOO_LARGE",
+        "/metadataBytesByDigest",
+        `metadata ${digest} exceeds the ${EXPECTED_POLICY.maximumPlanBytes}-byte contract limit`,
+      );
+      continue;
+    }
+    try {
+      snapshot.set(digest, Buffer.from(view));
+    } catch {
+      addError(
+        errors,
+        "INSTALL_PLAN_METADATA_SNAPSHOT_FAILED",
+        "/metadataBytesByDigest",
+        `metadata ${digest} changed shape before a bounded private snapshot could be made`,
+      );
+    }
+  }
+  return snapshot;
+}
+
+function fixedUint8ArrayView(bytes) {
+  try {
+    const buffer = TYPED_ARRAY_BUFFER_GETTER.call(bytes);
+    const byteLength = TYPED_ARRAY_BYTE_LENGTH_GETTER.call(bytes);
+    const byteOffset = TYPED_ARRAY_BYTE_OFFSET_GETTER.call(bytes);
+    return new Uint8Array(buffer, byteOffset, byteLength);
+  } catch {
+    return null;
+  }
+}
+
+function pathIsAtOrBelow(candidate, root) {
+  return candidate === root || candidate.startsWith(`${root}/`);
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function joinJsonPointer(base, token) {
+  const prefix = base === "/" ? "" : base;
+  return `${prefix}/${String(token).replaceAll("~", "~0").replaceAll("/", "~1")}`;
+}

--- a/scripts/ci/validate_clawsec_result_envelope.mjs
+++ b/scripts/ci/validate_clawsec_result_envelope.mjs
@@ -1305,7 +1305,7 @@ function isStrictSemver(version) {
   }
 }
 
-function parseJsonObjectBytes(bytes, label, errorPath) {
+export function parseJsonObjectBytes(bytes, label, errorPath) {
   const errors = [];
   if (!(bytes instanceof Uint8Array)) {
     addError(

--- a/scripts/test-skill-install-plan-contract.mjs
+++ b/scripts/test-skill-install-plan-contract.mjs
@@ -1,0 +1,2873 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
+
+import {
+  computeInstallPlanStateBindings,
+  digestBytes,
+  validateBoundInstallPlan,
+  validateInstallPlanContractSources,
+  validateUnboundInstallPlanBytes,
+} from "./ci/validate_clawsec_install_plan.mjs";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const metadataFixtureRoot = path.join(
+  repositoryRoot,
+  "contracts/fixtures/component-metadata-v1/valid",
+);
+const planFixtureRoot = path.join(
+  repositoryRoot,
+  "contracts/fixtures/install-plan-v1/valid",
+);
+
+const [
+  coreNanoBytes,
+  suiteNanoBytes,
+  coreOpenclawSeedBytes,
+  suiteHermesSeedBytes,
+  readyFixtureBytes,
+  blockedFixtureBytes,
+] = await Promise.all([
+  readFile(path.join(metadataFixtureRoot, "core-nanoclaw-v2.json")),
+  readFile(path.join(metadataFixtureRoot, "suite-nanoclaw-v2.json")),
+  readFile(path.join(metadataFixtureRoot, "core-openclaw.json")),
+  readFile(path.join(metadataFixtureRoot, "suite-hermes.json")),
+  readFile(path.join(planFixtureRoot, "nanoclaw-v2-ready.json")),
+  readFile(path.join(
+    planFixtureRoot,
+    "nanoclaw-v2-blocked-unowned-path.json",
+  )),
+]);
+
+const readyFixture = JSON.parse(readyFixtureBytes);
+const blockedFixture = JSON.parse(blockedFixtureBytes);
+
+assertValid(
+  validateInstallPlanContractSources(),
+  "install-plan contract sources",
+);
+assert.equal(
+  digestBytes(readyFixtureBytes),
+  `sha256:${createHash("sha256").update(readyFixtureBytes).digest("hex")}`,
+  "the test must hash the exact committed fixture bytes",
+);
+
+for (const [label, bytes, document] of [
+  ["ready fixture", readyFixtureBytes, readyFixture],
+  ["blocked fixture", blockedFixtureBytes, blockedFixture],
+]) {
+  const unbound = validateUnboundInstallPlanBytes(bytes);
+  assertValid(unbound, `${label} unbound`);
+  assert.deepEqual(
+    {
+      binding: unbound.binding,
+      authorization: unbound.authorization,
+      execution: unbound.execution,
+      warnings: unbound.warnings,
+    },
+    {
+      binding: "unverified",
+      authorization: "not_granted",
+      execution: "not_executed",
+      warnings: [],
+    },
+    `${label} must disclose what unbound validation does not establish`,
+  );
+
+  const bound = validateBoundInstallPlan({
+    planBytes: bytes,
+    metadataBytesByDigest: metadataMap(coreNanoBytes, suiteNanoBytes),
+    expectedContext: expectedContextFor(document),
+    expectedPlanDigest: digestBytes(bytes),
+    expectedBindings: expectedBindingsFor(document),
+    evaluatedAt: document.result.reported_at,
+  });
+  assertValid(bound, `${label} bound`);
+  assert.equal(bound.plan_digest, digestBytes(bytes));
+  assertBoundAssurance(bound, label);
+}
+
+assert.equal(
+  readyFixture.apply_context.invocation.operation,
+  "core.install-release",
+  "a ready plan must bind the exact future install invocation",
+);
+assert.equal(
+  readyFixture.confirmation_requirements.binding,
+  "sha256_exact_plan_bytes",
+  "a ready plan must require confirmation of the exact serialized plan bytes",
+);
+assert.equal(
+  readyFixture.confirmation_requirements.disclosure_source,
+  "install_plan_actions",
+  "confirmation must display the typed actions rather than result summaries",
+);
+assert.equal(
+  blockedFixture.apply_context,
+  null,
+  "a blocked plan must not claim a future install context",
+);
+assert.equal(
+  blockedFixture.confirmation_requirements,
+  null,
+  "a blocked plan must not issue confirmation requirements",
+);
+
+const harnessBundles = new Map();
+for (const harness of ["openclaw", "hermes", "picoclaw"]) {
+  const coreBytes = syntheticMetadata(harness, "core");
+  const suiteBytes = syntheticMetadata(harness, "suite");
+  const document = planForHarness(
+    readyFixture,
+    harness,
+    componentRefFromMetadata(coreBytes),
+    componentRefFromMetadata(suiteBytes),
+  );
+  if (harness === "openclaw") {
+    assertValid(
+      validateBound(document, [coreBytes, suiteBytes]),
+      "openclaw ready install plan",
+    );
+    harnessBundles.set(harness, { coreBytes, suiteBytes, document });
+    continue;
+  }
+
+  assertCode(
+    validateBound(document, [coreBytes, suiteBytes]),
+    "INSTALL_PLAN_PROTOTYPE_PENDING_DISPOSITION_INVALID",
+    `${harness} ready plan while native installation is prototype-pending`,
+  );
+  const blockedDocument = planForPrototypePendingHarness(
+    blockedFixture,
+    harness,
+    componentRefFromMetadata(coreBytes),
+    componentRefFromMetadata(suiteBytes),
+  );
+  assertValid(
+    validateBound(blockedDocument, [coreBytes, suiteBytes]),
+    `${harness} prototype-pending blocked plan`,
+  );
+  const wrongPrototypeBlocker = clone(blockedDocument);
+  wrongPrototypeBlocker.blockers[0].code = "scope_ambiguous";
+  assertCode(
+    validateUnbound(wrongPrototypeBlocker),
+    "INSTALL_PLAN_PROTOTYPE_PENDING_BLOCKER_INVALID",
+    `${harness} prototype-pending plan with the wrong blocker`,
+  );
+  harnessBundles.set(harness, {
+    blockedDocument,
+    coreBytes,
+    document,
+    suiteBytes,
+  });
+}
+assertValid(
+  validateBound(readyFixture, [coreNanoBytes, suiteNanoBytes]),
+  "nanoclaw ready install plan",
+);
+assert.deepEqual(
+  [...harnessBundles.keys(), "nanoclaw"].sort(),
+  ["hermes", "nanoclaw", "openclaw", "picoclaw"],
+  "all four harness contexts must be exercised",
+);
+
+const digestMismatch = validateBoundInstallPlan({
+  planBytes: readyFixtureBytes,
+  metadataBytesByDigest: metadataMap(coreNanoBytes, suiteNanoBytes),
+  expectedContext: expectedContextFor(readyFixture),
+  expectedPlanDigest: `sha256:${"0".repeat(64)}`,
+  expectedBindings: expectedBindingsFor(readyFixture),
+  evaluatedAt: readyFixture.result.reported_at,
+});
+assertCode(
+  digestMismatch,
+  "INSTALL_PLAN_DIGEST_MISMATCH",
+  "exact plan-byte digest substitution",
+);
+
+const contextMismatch = expectedContextFor(readyFixture);
+contextMismatch.invocation.scope.ref = "different-checkout";
+assertCode(
+  validateBoundInstallPlan({
+    planBytes: readyFixtureBytes,
+    metadataBytesByDigest: metadataMap(coreNanoBytes, suiteNanoBytes),
+    expectedContext: contextMismatch,
+    expectedPlanDigest: digestBytes(readyFixtureBytes),
+    expectedBindings: expectedBindingsFor(readyFixture),
+    evaluatedAt: readyFixture.result.reported_at,
+  }),
+  "RESULT_INVOCATION_MISMATCH",
+  "caller planning-context substitution",
+);
+
+const bindingMismatch = expectedBindingsFor(readyFixture);
+bindingMismatch.adapter.configuration_digest = `sha256:${"0".repeat(64)}`;
+assertCode(
+  validateBoundInstallPlan({
+    planBytes: readyFixtureBytes,
+    metadataBytesByDigest: metadataMap(coreNanoBytes, suiteNanoBytes),
+    expectedContext: expectedContextFor(readyFixture),
+    expectedPlanDigest: digestBytes(readyFixtureBytes),
+    expectedBindings: bindingMismatch,
+    evaluatedAt: readyFixture.result.reported_at,
+  }),
+  "INSTALL_PLAN_EXPECTED_BINDING_MISMATCH",
+  "caller-owned adapter binding substitution",
+);
+
+const missingAdapterBinding = expectedBindingsFor(readyFixture);
+delete missingAdapterBinding.adapter;
+assertCode(
+  validateBoundInstallPlan({
+    planBytes: readyFixtureBytes,
+    metadataBytesByDigest: metadataMap(coreNanoBytes, suiteNanoBytes),
+    expectedContext: expectedContextFor(readyFixture),
+    expectedPlanDigest: digestBytes(readyFixtureBytes),
+    expectedBindings: missingAdapterBinding,
+    evaluatedAt: readyFixture.result.reported_at,
+  }),
+  "INSTALL_PLAN_EXPECTED_BINDINGS_REQUIRED",
+  "incomplete expected-binding set",
+);
+
+assertCode(
+  validateBoundInstallPlan({
+    planBytes: readyFixtureBytes,
+    metadataBytesByDigest: metadataMap(coreNanoBytes, suiteNanoBytes),
+    expectedContext: expectedContextFor(readyFixture),
+    expectedPlanDigest: digestBytes(readyFixtureBytes),
+    expectedBindings: expectedBindingsFor(readyFixture),
+    evaluatedAt: "2026-07-24T09:05:01Z",
+  }),
+  "INSTALL_PLAN_EXPIRED",
+  "expired plan",
+);
+assertCode(
+  validateBoundInstallPlan({
+    planBytes: readyFixtureBytes,
+    metadataBytesByDigest: metadataMap(coreNanoBytes, suiteNanoBytes),
+    expectedContext: expectedContextFor(readyFixture),
+    expectedPlanDigest: digestBytes(readyFixtureBytes),
+    expectedBindings: expectedBindingsFor(readyFixture),
+    evaluatedAt: readyFixture.expires_at,
+  }),
+  "INSTALL_PLAN_EXPIRED",
+  "plan evaluated exactly at expiry",
+);
+
+const publicPrerelease = clone(readyFixture);
+publicPrerelease.artifact.channel = "public_stable";
+assertCode(
+  validateUnbound(publicPrerelease),
+  "INSTALL_PLAN_PUBLIC_PRERELEASE_FORBIDDEN",
+  "public prerelease artifact",
+);
+
+const labAlpha = clone(readyFixture);
+setSubjectVersion(labAlpha, "0.1.0-alpha.1");
+assertCode(
+  validateUnbound(labAlpha),
+  "INSTALL_PLAN_LAB_VERSION_CLASS_INVALID",
+  "private-lab alpha artifact",
+);
+
+const openclaw = harnessBundles.get("openclaw");
+const stableSuiteBytes = setMetadataVersion(openclaw.suiteBytes, "0.1.0");
+const publicStable = clone(openclaw.document);
+const stableSuiteRef = componentRefFromMetadata(stableSuiteBytes);
+replaceSubjectRef(publicStable, stableSuiteRef);
+publicStable.artifact.channel = "public_stable";
+publicStable.artifact.authority = {
+  kind: "active_catalog_entry",
+  contract: "clawsec.catalog-entry/v1",
+  document_digest: `sha256:${"c".repeat(64)}`,
+  signature_digest: `sha256:${"d".repeat(64)}`,
+  root_fingerprint: `sha256:${"e".repeat(64)}`,
+  expires_at: "2026-07-24T09:30:00Z",
+};
+assertValid(
+  validateBound(publicStable, [openclaw.coreBytes, stableSuiteBytes]),
+  "public stable final artifact",
+);
+
+const artifactComponentMismatch = clone(readyFixture);
+artifactComponentMismatch.artifact.component.name = "clawsec-suite-picoclaw";
+assertCode(
+  validateUnbound(artifactComponentMismatch),
+  "INSTALL_PLAN_ARTIFACT_COMPONENT_MISMATCH",
+  "artifact component substitution",
+);
+
+const verificationDecision = clone(readyFixture);
+verificationDecision.verification_refs.decision = "deny";
+assertCode(
+  validateUnbound(verificationDecision),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "non-reported verification decision",
+);
+
+const adapterMismatch = clone(readyFixture);
+adapterMismatch.adapter.contract = "clawsec.openclaw-install-adapter/v1";
+assertCode(
+  validateUnbound(adapterMismatch),
+  "INSTALL_PLAN_ADAPTER_MISMATCH",
+  "wrong harness adapter",
+);
+
+const applyExecutorSubstitution = clone(readyFixture);
+applyExecutorSubstitution.apply_context.executor.version = "0.1.0-rc.2";
+assertCode(
+  validateUnbound(applyExecutorSubstitution),
+  "INSTALL_PLAN_APPLY_EXECUTOR_MISMATCH",
+  "future install executor substitution",
+);
+
+const applyScopeSubstitution = clone(readyFixture);
+applyScopeSubstitution.apply_context.invocation.scope.ref = "other-checkout";
+assertCode(
+  validateUnbound(applyScopeSubstitution),
+  "INSTALL_PLAN_APPLY_SCOPE_MISMATCH",
+  "future install scope substitution",
+);
+
+const targetInstanceSubstitution = clone(readyFixture);
+targetInstanceSubstitution.target_state.target_instance_id =
+  "other-nanoclaw-checkout";
+assertCode(
+  validateUnbound(targetInstanceSubstitution),
+  "INSTALL_PLAN_TARGET_INSTANCE_MISMATCH",
+  "target-instance substitution",
+);
+
+const readyWithoutChallenge = clone(readyFixture);
+readyWithoutChallenge.confirmation_requirements = null;
+assertCode(
+  validateUnbound(readyWithoutChallenge),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "ready plan without confirmation requirements",
+);
+
+const blockedWithApplyContext = clone(blockedFixture);
+blockedWithApplyContext.apply_context = clone(readyFixture.apply_context);
+assertCode(
+  validateUnbound(blockedWithApplyContext),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "blocked plan carrying an install context",
+);
+
+const blockedWithChallenge = clone(blockedFixture);
+blockedWithChallenge.confirmation_requirements = clone(
+  readyFixture.confirmation_requirements,
+);
+assertCode(
+  validateUnbound(blockedWithChallenge),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "blocked plan carrying confirmation requirements",
+);
+
+const blockedWithActions = clone(blockedFixture);
+blockedWithActions.actions = clone(readyFixture.actions);
+blockedWithActions.rollback_order = clone(readyFixture.rollback_order);
+blockedWithActions.result.effects = clone(readyFixture.result.effects);
+refreshDerivedState(blockedWithActions);
+assertCode(
+  validateUnbound(blockedWithActions),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "blocked plan carrying executable actions",
+);
+
+const resourceLimitBlocked = clone(blockedFixture);
+resourceLimitBlocked.artifact.install_tree_entry_count = 65;
+resourceLimitBlocked.blockers[0] = {
+  blocker_id: "install-resource-limit",
+  code: "resource_limit",
+  summary:
+    "The candidate cannot be planned within the bounded install resources.",
+};
+assertValid(
+  validateBound(resourceLimitBlocked, [coreNanoBytes, suiteNanoBytes]),
+  "blocked plan for a 65-entry tree beyond the 64-action exact-disclosure limit",
+);
+
+const invalidCreatePrestate = clone(readyFixture);
+invalidCreatePrestate.actions[0].before = {
+  kind: "directory",
+  mode: "0755",
+};
+assertCode(
+  validateUnbound(invalidCreatePrestate),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "create action over an existing entry",
+);
+
+const missingTreeEntry = clone(readyFixture);
+delete missingTreeEntry.actions[1].tree_entry;
+assertCode(
+  validateUnbound(missingTreeEntry),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "managed file action without an exact install-tree entry",
+);
+
+const treeEntryContentMismatch = clone(readyFixture);
+treeEntryContentMismatch.actions[1].tree_entry.digest =
+  `sha256:${"0".repeat(64)}`;
+refreshDerivedState(treeEntryContentMismatch);
+assertCode(
+  validateUnbound(treeEntryContentMismatch),
+  "INSTALL_PLAN_TREE_ENTRY_STATE_MISMATCH",
+  "install-tree file digest that differs from its managed post-state",
+);
+
+const treeEntryWithoutManifestDigest = clone(readyFixture);
+delete treeEntryWithoutManifestDigest.actions[1]
+  .tree_entry.manifest_entry_digest;
+assertCode(
+  validateUnbound(treeEntryWithoutManifestDigest),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "install-tree entry without an exact manifest-entry digest",
+);
+
+const readyTreeEntryOverstatement = clone(readyFixture);
+readyTreeEntryOverstatement.artifact.install_tree_entry_count += 1;
+assertCode(
+  validateUnbound(readyTreeEntryOverstatement),
+  "INSTALL_PLAN_READY_TREE_ENTRY_COVERAGE_MISMATCH",
+  "ready plan overstating the staged tree entry count",
+);
+
+const readyTreeByteOverstatement = clone(readyFixture);
+readyTreeByteOverstatement.artifact.install_tree_total_bytes += 1;
+assertCode(
+  validateUnbound(readyTreeByteOverstatement),
+  "INSTALL_PLAN_READY_TREE_BYTE_COVERAGE_MISMATCH",
+  "ready plan overstating the staged tree byte total",
+);
+
+const managedReplacement = clone(readyFixture);
+managedReplacement.actions[1].operation = "replace";
+assertCode(
+  validateUnbound(managedReplacement),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "managed replacement operation removed from fresh-install contract v1",
+);
+
+const duplicateAction = clone(readyFixture);
+duplicateAction.actions[1].action_id = duplicateAction.actions[0].action_id;
+duplicateAction.rollback_order = [
+  duplicateAction.actions[1].action_id,
+  duplicateAction.actions[0].action_id,
+];
+assertCode(
+  validateUnbound(duplicateAction),
+  "INSTALL_PLAN_ACTION_ID_DUPLICATE",
+  "duplicate action identifier",
+);
+
+const wrongRollback = clone(readyFixture);
+wrongRollback.rollback_order.reverse();
+assertCode(
+  validateUnbound(wrongRollback),
+  "INSTALL_PLAN_ROLLBACK_ORDER_MISMATCH",
+  "rollback order that is not the reverse of execution",
+);
+
+const duplicateBlocker = clone(blockedFixture);
+duplicateBlocker.blockers.push(clone(duplicateBlocker.blockers[0]));
+assertCode(
+  validateUnbound(duplicateBlocker),
+  "INSTALL_PLAN_BLOCKER_ID_DUPLICATE",
+  "duplicate blocker identifier",
+);
+
+const tooManyActions = clone(readyFixture);
+tooManyActions.actions = Array.from({ length: 65 }, (_, index) => {
+  const action = clone(readyFixture.actions[0]);
+  action.action_id = `create-directory-${index}`;
+  action.target.path = `.claude/skills/clawsec-suite-nanoclaw/path-${index}`;
+  return action;
+});
+tooManyActions.rollback_order = tooManyActions.actions
+  .map((action) => action.action_id)
+  .reverse();
+tooManyActions.result.effects = effectsForActions(tooManyActions.actions);
+refreshDerivedState(tooManyActions);
+assertCode(
+  validateUnbound(tooManyActions),
+  "INSTALL_PLAN_ARRAY_LIMIT_EXCEEDED",
+  "plan exceeding the 64-action limit",
+);
+
+const nanoTargetEscape = clone(readyFixture);
+nanoTargetEscape.actions[0].target = {
+  anchor: "scope_root",
+  path: ".claude/skills/other-package",
+};
+nanoTargetEscape.result.effects = effectsForActions(nanoTargetEscape.actions);
+refreshDerivedState(nanoTargetEscape);
+assertCode(
+  validateBound(nanoTargetEscape, [coreNanoBytes, suiteNanoBytes]),
+  "INSTALL_PLAN_PACKAGE_TARGET_INVALID",
+  "NanoClaw action outside the metadata-declared package root",
+);
+
+const packageTargetEscape = clone(openclaw.document);
+packageTargetEscape.actions[0].target.path = "another-package";
+packageTargetEscape.result.effects = effectsForActions(
+  packageTargetEscape.actions,
+);
+refreshDerivedState(packageTargetEscape);
+assertCode(
+  validateBound(
+    packageTargetEscape,
+    [openclaw.coreBytes, openclaw.suiteBytes],
+  ),
+  "INSTALL_PLAN_PACKAGE_TARGET_INVALID",
+  "non-Nano action outside the exact component directory",
+);
+
+const packageRootOmitted = clone(readyFixture);
+packageRootOmitted.actions = packageRootOmitted.actions.slice(1);
+packageRootOmitted.artifact.install_tree_entry_count = 1;
+packageRootOmitted.artifact.install_tree_total_bytes = 1_024;
+packageRootOmitted.rollback_order = rollbackOrderForActions(
+  packageRootOmitted.actions,
+);
+packageRootOmitted.result.effects = effectsForActions(
+  packageRootOmitted.actions,
+);
+refreshDerivedState(packageRootOmitted);
+assertCode(
+  validateBound(packageRootOmitted, [coreNanoBytes, suiteNanoBytes]),
+  "INSTALL_PLAN_PACKAGE_ROOT_DIRECTORY_REQUIRED",
+  "package file without an explicit package-root directory",
+);
+
+const missingIntermediateDirectories = clone(readyFixture);
+missingIntermediateDirectories.actions[1].target.path =
+  ".claude/skills/clawsec-suite-nanoclaw/nested/deeper/SKILL.md";
+missingIntermediateDirectories.actions[1].tree_entry.path =
+  "nested/deeper/SKILL.md";
+missingIntermediateDirectories.result.effects = effectsForActions(
+  missingIntermediateDirectories.actions,
+);
+refreshDerivedState(missingIntermediateDirectories);
+assertCode(
+  validateBound(
+    missingIntermediateDirectories,
+    [coreNanoBytes, suiteNanoBytes],
+  ),
+  "INSTALL_PLAN_PACKAGE_INTERMEDIATE_DIRECTORY_REQUIRED",
+  "package file without every intermediate directory action",
+);
+
+const childBeforeParent = clone(readyFixture);
+childBeforeParent.actions.reverse();
+childBeforeParent.rollback_order = rollbackOrderForActions(
+  childBeforeParent.actions,
+);
+childBeforeParent.result.effects = effectsForActions(
+  childBeforeParent.actions,
+);
+refreshDerivedState(childBeforeParent);
+assertCode(
+  validateBound(childBeforeParent, [coreNanoBytes, suiteNanoBytes]),
+  "INSTALL_PLAN_PACKAGE_PARENT_ORDER_INVALID",
+  "package child action ordered before its parent directory",
+);
+
+const nestedPackageTree = planWithNestedPackageTree(readyFixture);
+assertValid(
+  validateBound(nestedPackageTree, [coreNanoBytes, suiteNanoBytes]),
+  "package tree with every parent directory ordered first",
+);
+
+const permutedFileTargets = planWithSecondFileEntry(readyFixture);
+const firstPermutedFile = permutedFileTargets.actions.find(
+  (action) => action.action_id === "write-skill-document",
+);
+const secondPermutedFile = permutedFileTargets.actions.find(
+  (action) => action.action_id === "write-copy-skill-document",
+);
+[
+  firstPermutedFile.target,
+  secondPermutedFile.target,
+] = [
+  secondPermutedFile.target,
+  firstPermutedFile.target,
+];
+permutedFileTargets.result.effects = effectsForActions(
+  permutedFileTargets.actions,
+);
+refreshDerivedState(permutedFileTargets);
+assertCode(
+  validateBound(permutedFileTargets, [coreNanoBytes, suiteNanoBytes]),
+  "INSTALL_PLAN_TREE_ENTRY_TARGET_MISMATCH",
+  "two signed file entries permuted across each other's targets",
+);
+
+const emptyDirectorySubstitution = clone(nestedPackageTree);
+const substitutedEmptyDirectory = emptyDirectorySubstitution.actions.find(
+  (action) => action.action_id === "create-empty-directory",
+);
+substitutedEmptyDirectory.target.path =
+  ".claude/skills/clawsec-suite-nanoclaw/substituted-empty";
+emptyDirectorySubstitution.result.effects = effectsForActions(
+  emptyDirectorySubstitution.actions,
+);
+refreshDerivedState(emptyDirectorySubstitution);
+assertCode(
+  validateBound(
+    emptyDirectorySubstitution,
+    [coreNanoBytes, suiteNanoBytes],
+  ),
+  "INSTALL_PLAN_TREE_ENTRY_TARGET_MISMATCH",
+  "signed empty-directory entry substituted onto another target",
+);
+
+const rootModeMismatch = clone(readyFixture);
+rootModeMismatch.actions[0].tree_entry.mode = "0700";
+refreshDerivedState(rootModeMismatch);
+assertCode(
+  validateUnbound(rootModeMismatch),
+  "INSTALL_PLAN_TREE_ENTRY_STATE_MISMATCH",
+  "package-root directory mode differs from its signed tree entry",
+);
+
+const directoryModeMismatch = clone(nestedPackageTree);
+directoryModeMismatch.actions.find(
+  (action) => action.action_id === "create-empty-directory",
+).tree_entry.mode = "0700";
+refreshDerivedState(directoryModeMismatch);
+assertCode(
+  validateUnbound(directoryModeMismatch),
+  "INSTALL_PLAN_TREE_ENTRY_STATE_MISMATCH",
+  "nested directory mode differs from its signed tree entry",
+);
+
+for (const [label, treeEntryPath, expectedCode] of [
+  [
+    "install-tree entry containing parent traversal",
+    "../SKILL.md",
+    "INSTALL_PLAN_PATH_NOT_POSIX",
+  ],
+  [
+    "install-tree entry using a Windows device basename",
+    "CON/config.json",
+    "INSTALL_PLAN_WINDOWS_DEVICE_PATH_FORBIDDEN",
+  ],
+  [
+    "install-tree entry containing a trailing-dot segment",
+    "docs./SKILL.md",
+    "INSTALL_PLAN_PATH_TRAILING_DOT_FORBIDDEN",
+  ],
+]) {
+  const unsafeTreeEntryPath = clone(readyFixture);
+  unsafeTreeEntryPath.actions[1].tree_entry.path = treeEntryPath;
+  assertCode(
+    validateUnbound(unsafeTreeEntryPath),
+    expectedCode,
+    label,
+  );
+}
+
+const caseFoldedTreeEntryDuplicate = planWithSecondFileEntry(readyFixture);
+const caseFoldedCopy = caseFoldedTreeEntryDuplicate.actions.find(
+  (action) => action.action_id === "write-copy-skill-document",
+);
+caseFoldedCopy.target.path =
+  ".claude/skills/clawsec-suite-nanoclaw/skill.md";
+caseFoldedCopy.tree_entry.path = "skill.md";
+caseFoldedTreeEntryDuplicate.result.effects = effectsForActions(
+  caseFoldedTreeEntryDuplicate.actions,
+);
+refreshDerivedState(caseFoldedTreeEntryDuplicate);
+assertCode(
+  validateUnbound(caseFoldedTreeEntryDuplicate),
+  "INSTALL_PLAN_TREE_ENTRY_PATH_DUPLICATE",
+  "two install-tree paths that differ only by case",
+);
+
+const ambiguousManifestEntry = planWithSecondFileEntry(readyFixture);
+ambiguousManifestEntry.actions.find(
+  (action) => action.action_id === "write-copy-skill-document",
+).tree_entry.manifest_entry_digest =
+  readyFixture.actions[1].tree_entry.manifest_entry_digest;
+refreshDerivedState(ambiguousManifestEntry);
+assertCode(
+  validateUnbound(ambiguousManifestEntry),
+  "INSTALL_PLAN_MANIFEST_ENTRY_DIGEST_AMBIGUOUS",
+  "one manifest-entry digest describing two distinct tree entries",
+);
+
+const emptyDirectoryOmitted = clone(nestedPackageTree);
+emptyDirectoryOmitted.actions = emptyDirectoryOmitted.actions.filter(
+  (action) => action.action_id !== "create-empty-directory",
+);
+emptyDirectoryOmitted.rollback_order = rollbackOrderForActions(
+  emptyDirectoryOmitted.actions,
+);
+emptyDirectoryOmitted.result.effects = effectsForActions(
+  emptyDirectoryOmitted.actions,
+);
+refreshDerivedState(emptyDirectoryOmitted);
+assertCode(
+  validateUnbound(emptyDirectoryOmitted),
+  "INSTALL_PLAN_READY_TREE_ENTRY_COVERAGE_MISMATCH",
+  "signed empty-directory tree entry omitted from managed actions",
+);
+
+const artifactActionOmitted = clone(readyFixture);
+artifactActionOmitted.actions = artifactActionOmitted.actions.slice(0, 1);
+artifactActionOmitted.rollback_order = rollbackOrderForActions(
+  artifactActionOmitted.actions,
+);
+artifactActionOmitted.result.effects = effectsForActions(
+  artifactActionOmitted.actions,
+);
+refreshDerivedState(artifactActionOmitted);
+const artifactActionOmittedResult = validateUnbound(artifactActionOmitted);
+assertCode(
+  artifactActionOmittedResult,
+  "INSTALL_PLAN_READY_TREE_ENTRY_COVERAGE_MISMATCH",
+  "artifact tree entry omitted from the action set",
+);
+assertCode(
+  artifactActionOmittedResult,
+  "INSTALL_PLAN_READY_TREE_BYTE_COVERAGE_MISMATCH",
+  "artifact file bytes omitted from the action set",
+);
+
+const removedPackageActivation = planWithRemovedPackageActivation(
+  readyFixture,
+);
+assertCode(
+  validateUnbound(removedPackageActivation),
+  "INSTALL_PLAN_NATIVE_PACKAGE_ACTIVATION_UNSUPPORTED",
+  "removed native package activation operation",
+);
+
+for (const operation of ["reload_harness", "restart_harness"]) {
+  const operationalPlan = planWithOperationalAction(readyFixture, operation);
+  const operationalAction = operationalPlan.actions.find(
+    (action) => action.operation === operation,
+  );
+  assert.equal(
+    operationalAction.rollback,
+    null,
+    `${operation} must carry no rollback operation`,
+  );
+  assert(
+    !operationalPlan.rollback_order.includes(operationalAction.action_id),
+    `${operation} must be excluded from rollback order`,
+  );
+  assertValid(
+    validateBound(operationalPlan, [coreNanoBytes, suiteNanoBytes]),
+    `${operation} non-state-mutating plan`,
+  );
+
+  const operationalActionBeforeMutations = clone(operationalPlan);
+  operationalActionBeforeMutations.actions = [
+    operationalActionBeforeMutations.actions.at(-1),
+    ...operationalActionBeforeMutations.actions.slice(0, -1),
+  ];
+  operationalActionBeforeMutations.result.effects = effectsForActions(
+    operationalActionBeforeMutations.actions,
+  );
+  refreshDerivedState(operationalActionBeforeMutations);
+  assertCode(
+    validateUnbound(operationalActionBeforeMutations),
+    "INSTALL_PLAN_OPERATIONAL_ACTION_ORDER_INVALID",
+    `${operation} before package mutations`,
+  );
+
+  const operationalActionInRollback = clone(operationalPlan);
+  operationalActionInRollback.rollback_order.unshift(
+    operationalAction.action_id,
+  );
+  assertCode(
+    validateUnbound(operationalActionInRollback),
+    "INSTALL_PLAN_ROLLBACK_ORDER_MISMATCH",
+    `${operation} included in rollback order`,
+  );
+}
+
+const reloadOnlyReady = planWithOperationalAction(
+  readyFixture,
+  "reload_harness",
+);
+reloadOnlyReady.actions = reloadOnlyReady.actions.filter(
+  (action) => action.operation === "reload_harness",
+);
+reloadOnlyReady.rollback_order = [];
+reloadOnlyReady.result.effects = effectsForActions(reloadOnlyReady.actions);
+refreshDerivedState(reloadOnlyReady);
+assertCode(
+  validateUnbound(reloadOnlyReady),
+  "INSTALL_PLAN_SUBJECT_PACKAGE_ACTION_REQUIRED",
+  "reload-only ready plan",
+);
+
+const missingRequiredReload = clone(readyFixture);
+missingRequiredReload.adapter.profile.reload_behavior = "reload_harness";
+assertCode(
+  validateUnbound(missingRequiredReload),
+  "INSTALL_PLAN_RELOAD_ACTION_MISMATCH",
+  "adapter-required reload omitted from the disclosed actions",
+);
+
+const unexpectedReload = planWithOperationalAction(
+  readyFixture,
+  "reload_harness",
+);
+unexpectedReload.adapter.profile.reload_behavior = "none";
+assertCode(
+  validateUnbound(unexpectedReload),
+  "INSTALL_PLAN_RELOAD_ACTION_MISMATCH",
+  "reload action forbidden by adapter profile",
+);
+
+const substitutedNativeInstance = planWithOperationalAction(
+  readyFixture,
+  "reload_harness",
+);
+substitutedNativeInstance.actions.find(
+  (action) => action.operation === "reload_harness",
+).target.identity_digest = `sha256:${"0".repeat(64)}`;
+substitutedNativeInstance.result.effects = effectsForActions(
+  substitutedNativeInstance.actions,
+);
+refreshDerivedState(substitutedNativeInstance);
+assertCode(
+  validateUnbound(substitutedNativeInstance),
+  "INSTALL_PLAN_HARNESS_RESOURCE_IDENTITY_MISMATCH",
+  "native harness target-instance identity substitution",
+);
+
+const transformationPlan = planWithNanoTransformation(readyFixture);
+assertValid(
+  validateBound(transformationPlan, [coreNanoBytes, suiteNanoBytes]),
+  "NanoClaw declared transformation plan",
+);
+assert.equal(
+  transformationPlan.actions.filter(
+    (action) => action.kind === "managed_entry",
+  ).length,
+  transformationPlan.artifact.install_tree_entry_count,
+  "transformation source must be counted once as its managed tree entry",
+);
+assert.equal(
+  transformationPlan.actions.filter(
+    (action) => action.kind === "declared_transformation",
+  ).length,
+  1,
+  "transformation output is not a second staged install-tree entry",
+);
+
+const transformationFirst = clone(transformationPlan);
+const transformationFirstIndex = transformationFirst.actions.findIndex(
+  (action) => action.kind === "declared_transformation",
+);
+const [earlyTransformation] = transformationFirst.actions.splice(
+  transformationFirstIndex,
+  1,
+);
+transformationFirst.actions.unshift(earlyTransformation);
+transformationFirst.rollback_order = rollbackOrderForActions(
+  transformationFirst.actions,
+);
+transformationFirst.result.effects = effectsForActions(
+  transformationFirst.actions,
+);
+refreshDerivedState(transformationFirst);
+assertCode(
+  validateUnbound(transformationFirst),
+  "INSTALL_PLAN_PACKAGE_ACTION_ORDER_INVALID",
+  "declared transformation before managed package actions",
+);
+
+const transformationSourceMissing = clone(transformationPlan);
+declaredTransformationFor(transformationSourceMissing)
+  .declaration.source.managed_action_id = "missing-source-action";
+refreshDerivedState(transformationSourceMissing);
+assertCode(
+  validateUnbound(transformationSourceMissing),
+  "INSTALL_PLAN_TRANSFORMATION_SOURCE_NOT_MANAGED",
+  "transformation source referencing a missing managed action",
+);
+
+const transformationSourceWrongDigest = clone(transformationPlan);
+declaredTransformationFor(transformationSourceWrongDigest)
+  .declaration.source.manifest_entry_digest =
+    `sha256:${"0".repeat(64)}`;
+refreshDerivedState(transformationSourceWrongDigest);
+assertCode(
+  validateUnbound(transformationSourceWrongDigest),
+  "INSTALL_PLAN_TRANSFORMATION_SOURCE_NOT_MANAGED",
+  "transformation source using the wrong managed manifest-entry digest",
+);
+
+const transformationSourceDirectory = clone(transformationPlan);
+const rootDirectoryAction = transformationSourceDirectory.actions.find(
+  (action) => action.tree_entry?.path === ".",
+);
+declaredTransformationFor(transformationSourceDirectory)
+  .declaration.source = {
+    managed_action_id: rootDirectoryAction.action_id,
+    manifest_entry_digest:
+      rootDirectoryAction.tree_entry.manifest_entry_digest,
+  };
+refreshDerivedState(transformationSourceDirectory);
+assertCode(
+  validateUnbound(transformationSourceDirectory),
+  "INSTALL_PLAN_TRANSFORMATION_SOURCE_NOT_MANAGED",
+  "transformation source referencing a managed directory",
+);
+
+const transformationSourceLater = clone(transformationPlan);
+const laterSourceId = declaredTransformationFor(
+  transformationSourceLater,
+).declaration.source.managed_action_id;
+const laterSourceIndex = transformationSourceLater.actions.findIndex(
+  (action) => action.action_id === laterSourceId,
+);
+const [laterSourceAction] = transformationSourceLater.actions.splice(
+  laterSourceIndex,
+  1,
+);
+transformationSourceLater.actions.push(laterSourceAction);
+transformationSourceLater.rollback_order = rollbackOrderForActions(
+  transformationSourceLater.actions,
+);
+transformationSourceLater.result.effects = effectsForActions(
+  transformationSourceLater.actions,
+);
+refreshDerivedState(transformationSourceLater);
+assertCode(
+  validateUnbound(transformationSourceLater),
+  "INSTALL_PLAN_TRANSFORMATION_SOURCE_NOT_MANAGED",
+  "transformation source action disclosed only after the transformation",
+);
+
+const duplicatedTransformationEntry = clone(transformationPlan);
+const secondTransformation = clone(
+  declaredTransformationFor(duplicatedTransformationEntry),
+);
+secondTransformation.action_id = "transform-generated-config-second";
+secondTransformation.target.path =
+  "container/agent-runner/generated-config-second.json";
+secondTransformation.after.digest = `sha256:${"4".repeat(64)}`;
+secondTransformation.declaration.allowed_output = {
+  target: clone(secondTransformation.target),
+  before: clone(secondTransformation.before),
+  after: clone(secondTransformation.after),
+};
+duplicatedTransformationEntry.actions.push(secondTransformation);
+duplicatedTransformationEntry.rollback_order = rollbackOrderForActions(
+  duplicatedTransformationEntry.actions,
+);
+duplicatedTransformationEntry.result.effects = effectsForActions(
+  duplicatedTransformationEntry.actions,
+);
+refreshDerivedState(duplicatedTransformationEntry);
+assertCode(
+  validateUnbound(duplicatedTransformationEntry),
+  "INSTALL_PLAN_TRANSFORMATION_ENTRY_DIGEST_DUPLICATE",
+  "two transformations reusing one release-manifest entry digest",
+);
+
+const nanoSkillTreeCaseAlias = clone(transformationPlan);
+const nanoCaseAliasTransformation = declaredTransformationFor(
+  nanoSkillTreeCaseAlias,
+);
+nanoCaseAliasTransformation.target.path =
+  ".CLAUDE/skills/unreviewed/generated-config.json";
+nanoCaseAliasTransformation.declaration.allowed_output.target =
+  clone(nanoCaseAliasTransformation.target);
+nanoSkillTreeCaseAlias.result.effects = effectsForActions(
+  nanoSkillTreeCaseAlias.actions,
+);
+refreshDerivedState(nanoSkillTreeCaseAlias);
+assertCode(
+  validateUnbound(nanoSkillTreeCaseAlias),
+  "INSTALL_PLAN_NANOCLAW_TRANSFORMATION_PACKAGE_TREE_FORBIDDEN",
+  "case-aliased NanoClaw skill-tree transformation target",
+);
+
+const transformationTargetEscape = clone(transformationPlan);
+const escapedTransformation = declaredTransformationFor(
+  transformationTargetEscape,
+);
+escapedTransformation.target.path =
+  ".claude/skills/unreviewed-package/generated-config.json";
+escapedTransformation.declaration.allowed_output.target =
+  clone(escapedTransformation.target);
+transformationTargetEscape.result.effects = effectsForActions(
+  transformationTargetEscape.actions,
+);
+refreshDerivedState(transformationTargetEscape);
+assertCode(
+  validateBound(
+    transformationTargetEscape,
+    [coreNanoBytes, suiteNanoBytes],
+  ),
+  "INSTALL_PLAN_NANOCLAW_TRANSFORMATION_PACKAGE_TREE_FORBIDDEN",
+  "declared transformation reaching into the selected skill tree",
+);
+
+for (const [label, forbiddenPath] of [
+  ["Git metadata", ".git/config"],
+  ["environment file", ".env"],
+  ["live database", "runtime/sessions.sqlite"],
+  [
+    "container skill tree",
+    "container/skills/unreviewed/SKILL.md",
+  ],
+  ["credential file", "credentials.json"],
+  ["secret file", "secrets.yaml"],
+  ["token file", "token.txt"],
+  ["private key", "id_ed25519.pub"],
+]) {
+  const forbiddenTransformation = clone(transformationPlan);
+  const forbiddenAction = declaredTransformationFor(
+    forbiddenTransformation,
+  );
+  forbiddenAction.target = {
+    anchor: "scope_root",
+    path: forbiddenPath,
+  };
+  forbiddenAction.declaration.allowed_output.target =
+    clone(forbiddenAction.target);
+  forbiddenTransformation.result.effects = effectsForActions(
+    forbiddenTransformation.actions,
+  );
+  refreshDerivedState(forbiddenTransformation);
+  assertCode(
+    validateUnbound(forbiddenTransformation),
+    "INSTALL_PLAN_NANOCLAW_TRANSFORMATION_PATH_FORBIDDEN",
+    `NanoClaw transformation targeting ${label}`,
+  );
+}
+
+const ordinaryCredentialNamedSource = clone(transformationPlan);
+const ordinaryCredentialAction = declaredTransformationFor(
+  ordinaryCredentialNamedSource,
+);
+ordinaryCredentialAction.target.path =
+  "src/credentials.ts";
+ordinaryCredentialAction.declaration.allowed_output.target =
+  clone(ordinaryCredentialAction.target);
+ordinaryCredentialNamedSource.result.effects = effectsForActions(
+  ordinaryCredentialNamedSource.actions,
+);
+refreshDerivedState(ordinaryCredentialNamedSource);
+assertValid(
+  validateBound(
+    ordinaryCredentialNamedSource,
+    [coreNanoBytes, suiteNanoBytes],
+  ),
+  "reviewed ordinary source module named credentials.ts",
+);
+
+const nonScopeManagedTarget = clone(readyFixture);
+nonScopeManagedTarget.actions[1].target.anchor = "skill_root";
+assertCode(
+  validateUnbound(nonScopeManagedTarget),
+  "INSTALL_PLAN_FILESYSTEM_ANCHOR_INVALID",
+  "managed action using a non-scope root",
+);
+
+const nonScopeTransformationTarget = clone(transformationPlan);
+const nonScopeTransformationAction = declaredTransformationFor(
+  nonScopeTransformationTarget,
+);
+nonScopeTransformationAction.target.anchor = "harness_runtime_root";
+nonScopeTransformationAction.declaration.allowed_output.target.anchor =
+  "harness_runtime_root";
+assertCode(
+  validateUnbound(nonScopeTransformationTarget),
+  "INSTALL_PLAN_FILESYSTEM_ANCHOR_INVALID",
+  "declared transformation using a non-scope root",
+);
+
+const transformationDeclarationMismatch = clone(transformationPlan);
+declaredTransformationFor(transformationDeclarationMismatch)
+  .declaration.allowed_output.after.digest = `sha256:${"0".repeat(64)}`;
+assertCode(
+  validateUnbound(transformationDeclarationMismatch),
+  "INSTALL_PLAN_TRANSFORMATION_DECLARATION_MISMATCH",
+  "transformation output that differs from its exact declaration",
+);
+
+const transformationReleaseManifestMismatch = clone(transformationPlan);
+declaredTransformationFor(transformationReleaseManifestMismatch)
+  .declaration.release_manifest_digest =
+  `sha256:${"0".repeat(64)}`;
+assertCode(
+  validateUnbound(transformationReleaseManifestMismatch),
+  "INSTALL_PLAN_TRANSFORMATION_RELEASE_MANIFEST_MISMATCH",
+  "transformation bound to a different release manifest",
+);
+
+const transformationEntryMismatch = clone(transformationPlan);
+declaredTransformationFor(transformationEntryMismatch)
+  .declaration.transformation_entry_digest =
+    `sha256:${"0".repeat(64)}`;
+assertCode(
+  validateUnbound(transformationEntryMismatch),
+  "INSTALL_PLAN_DERIVED_STATE_MISMATCH",
+  "post-plan transformation-entry digest tampering",
+);
+
+const structurallyUniqueTransformationEntry = clone(transformationPlan);
+declaredTransformationFor(structurallyUniqueTransformationEntry)
+  .declaration.transformation_entry_digest =
+    `sha256:${"0".repeat(64)}`;
+refreshDerivedState(structurallyUniqueTransformationEntry);
+assertValid(
+  validateUnbound(structurallyUniqueTransformationEntry),
+  "a unique transformation-entry digest is structurally valid while release-manifest membership remains unverified",
+);
+
+const transformationWithoutPreimage = clone(transformationPlan);
+declaredTransformationFor(transformationWithoutPreimage).rollback_source =
+  null;
+assertCode(
+  validateUnbound(transformationWithoutPreimage),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "declared transformation without captured preimage",
+);
+
+const transformationPreimageMismatch = clone(transformationPlan);
+declaredTransformationFor(transformationPreimageMismatch)
+  .rollback_source.digest =
+  `sha256:${"0".repeat(64)}`;
+assertCode(
+  validateUnbound(transformationPreimageMismatch),
+  "INSTALL_PLAN_ROLLBACK_SOURCE_MISMATCH",
+  "declared transformation with mismatched captured preimage",
+);
+
+const transformationWithoutCodingHarness = clone(transformationPlan);
+transformationWithoutCodingHarness.adapter.profile.coding_harness = null;
+assertCode(
+  validateUnbound(transformationWithoutCodingHarness),
+  "INSTALL_PLAN_NANOCLAW_CODING_HARNESS_REQUIRED",
+  "NanoClaw transformation without an adapter-bound coding harness",
+);
+
+for (const mutableReference of [
+  { kind: "exact_version", value: "latest" },
+  { kind: "commit", value: "main" },
+  { kind: "exact_version", value: "stable" },
+]) {
+  const mutableCodingHarness = clone(transformationPlan);
+  mutableCodingHarness.adapter.profile.coding_harness.immutable_reference =
+    clone(mutableReference);
+  declaredTransformationFor(mutableCodingHarness)
+    .declaration.coding_harness.immutable_reference =
+      clone(mutableReference);
+  assertCode(
+    validateUnbound(mutableCodingHarness),
+    "INSTALL_PLAN_CODING_HARNESS_REFERENCE_NOT_IMMUTABLE",
+    `mutable coding-harness reference ${mutableReference.value}`,
+  );
+}
+
+for (const immutableReference of [
+  {
+    kind: "commit",
+    value: "a".repeat(40),
+  },
+  {
+    kind: "content_digest",
+    value:
+      transformationPlan.adapter.profile.coding_harness
+        .implementation_digest,
+  },
+]) {
+  const immutableCodingHarness = clone(transformationPlan);
+  immutableCodingHarness.adapter.profile.coding_harness
+    .immutable_reference = clone(immutableReference);
+  declaredTransformationFor(immutableCodingHarness)
+    .declaration.coding_harness.immutable_reference =
+      clone(immutableReference);
+  refreshDerivedState(immutableCodingHarness);
+  assertValid(
+    validateUnbound(immutableCodingHarness),
+    `coding harness pinned by immutable ${immutableReference.kind}`,
+  );
+}
+
+for (
+  const digestField of [
+    "implementation_digest",
+    "toolchain_digest",
+    "configuration_digest",
+  ]
+) {
+  const codingHarnessWithoutDigest = clone(transformationPlan);
+  delete codingHarnessWithoutDigest.adapter.profile
+    .coding_harness[digestField];
+  delete declaredTransformationFor(codingHarnessWithoutDigest)
+    .declaration.coding_harness[digestField];
+  assertCode(
+    validateUnbound(codingHarnessWithoutDigest),
+    "INSTALL_PLAN_CODING_HARNESS_DIGEST_REQUIRED",
+    `coding harness without ${digestField}`,
+  );
+}
+
+const transformationCodingHarnessMismatch = clone(transformationPlan);
+declaredTransformationFor(transformationCodingHarnessMismatch)
+  .declaration.coding_harness
+  .configuration_digest = `sha256:${"0".repeat(64)}`;
+refreshDerivedState(transformationCodingHarnessMismatch);
+assertCode(
+  validateUnbound(transformationCodingHarnessMismatch),
+  "INSTALL_PLAN_NANOCLAW_CODING_HARNESS_MISMATCH",
+  "transformation coding harness that differs from its adapter binding",
+);
+
+const codingHarnessContentIdentityMismatch = clone(transformationPlan);
+const mismatchedContentReference = {
+  kind: "content_digest",
+  value: `sha256:${"0".repeat(64)}`,
+};
+codingHarnessContentIdentityMismatch.adapter.profile.coding_harness
+  .immutable_reference = clone(mismatchedContentReference);
+declaredTransformationFor(codingHarnessContentIdentityMismatch)
+  .declaration.coding_harness
+  .immutable_reference = clone(mismatchedContentReference);
+refreshDerivedState(codingHarnessContentIdentityMismatch);
+assertCode(
+  validateUnbound(codingHarnessContentIdentityMismatch),
+  "INSTALL_PLAN_CODING_HARNESS_CONTENT_IDENTITY_MISMATCH",
+  "content-addressed coding harness whose reference differs from its implementation",
+);
+
+for (const requiredStep of ["host_build", "host_tests", "skill_tests"]) {
+  const nanoWithoutBaselineValidation = clone(readyFixture);
+  nanoWithoutBaselineValidation.adapter.profile.validation_steps =
+    nanoWithoutBaselineValidation.adapter.profile.validation_steps
+      .filter((step) => step !== requiredStep);
+  assertCode(
+    validateUnbound(nanoWithoutBaselineValidation),
+    "INSTALL_PLAN_NANOCLAW_VALIDATION_STEP_REQUIRED",
+    `NanoClaw v2 plan without ${requiredStep}`,
+  );
+}
+
+for (
+  const requiredStep of [
+    "container_build",
+    "container_typecheck",
+    "container_tests",
+  ]
+) {
+  const transformationWithoutRequiredValidation = clone(transformationPlan);
+  transformationWithoutRequiredValidation.adapter.profile.validation_steps =
+    transformationWithoutRequiredValidation.adapter.profile.validation_steps
+      .filter((step) => step !== requiredStep);
+  assertCode(
+    validateUnbound(transformationWithoutRequiredValidation),
+    "INSTALL_PLAN_NANOCLAW_VALIDATION_STEP_REQUIRED",
+    `agent-runner transformation without ${requiredStep}`,
+  );
+}
+
+const genericContainerTransformation = clone(transformationPlan);
+const genericContainerAction = declaredTransformationFor(
+  genericContainerTransformation,
+);
+genericContainerAction.target.path =
+  "container/generated-config.json";
+genericContainerAction.declaration.allowed_output.target =
+  clone(genericContainerAction.target);
+genericContainerTransformation.adapter.profile.validation_steps =
+  genericContainerTransformation.adapter.profile.validation_steps.filter(
+    (step) => !["container_typecheck", "container_tests"].includes(step),
+  );
+genericContainerTransformation.result.effects = effectsForActions(
+  genericContainerTransformation.actions,
+);
+refreshDerivedState(genericContainerTransformation);
+assertValid(
+  validateBound(
+    genericContainerTransformation,
+    [coreNanoBytes, suiteNanoBytes],
+  ),
+  "generic container transformation with build validation",
+);
+
+const genericContainerWithoutBuild = clone(genericContainerTransformation);
+genericContainerWithoutBuild.adapter.profile.validation_steps =
+  genericContainerWithoutBuild.adapter.profile.validation_steps.filter(
+    (step) => step !== "container_build",
+  );
+assertCode(
+  validateUnbound(genericContainerWithoutBuild),
+  "INSTALL_PLAN_NANOCLAW_VALIDATION_STEP_REQUIRED",
+  "generic container transformation without container_build",
+);
+
+const nonNanoExternalTransformation = clone(openclaw.document);
+const nonNanoTransformation = clone(
+  declaredTransformationFor(transformationPlan),
+);
+const nonNanoSourceAction = nonNanoExternalTransformation.actions.find(
+  (action) => action.tree_entry?.kind === "file",
+);
+nonNanoTransformation.declaration.source = {
+  managed_action_id: nonNanoSourceAction.action_id,
+  manifest_entry_digest:
+    nonNanoSourceAction.tree_entry.manifest_entry_digest,
+};
+nonNanoExternalTransformation.actions.push(nonNanoTransformation);
+nonNanoTransformation.declaration.release_manifest_digest =
+    nonNanoExternalTransformation.artifact.release_manifest_digest;
+nonNanoExternalTransformation.rollback_order = rollbackOrderForActions(
+  nonNanoExternalTransformation.actions,
+);
+nonNanoExternalTransformation.result.effects = effectsForActions(
+  nonNanoExternalTransformation.actions,
+);
+refreshDerivedState(nonNanoExternalTransformation);
+assertCode(
+  validateBound(
+    nonNanoExternalTransformation,
+    [openclaw.coreBytes, openclaw.suiteBytes],
+  ),
+  "INSTALL_PLAN_ADAPTER_TRANSFORMATION_FORBIDDEN",
+  "external transformation on a non-NanoClaw adapter",
+);
+
+const nanoCorePlan = planForNanoCore(readyFixture, coreNanoBytes);
+assertValid(
+  validateBound(nanoCorePlan, [coreNanoBytes]),
+  "NanoClaw core plan with required REMOVE.md",
+);
+const nanoCoreWithoutRemoveDocument = clone(nanoCorePlan);
+nanoCoreWithoutRemoveDocument.actions = nanoCoreWithoutRemoveDocument.actions
+  .filter((action) => action.action_id !== "write-remove-document");
+nanoCoreWithoutRemoveDocument.artifact.install_tree_entry_count = 2;
+nanoCoreWithoutRemoveDocument.artifact.install_tree_total_bytes = 1_024;
+nanoCoreWithoutRemoveDocument.rollback_order = nanoCoreWithoutRemoveDocument
+  .actions.map((action) => action.action_id).reverse();
+nanoCoreWithoutRemoveDocument.result.effects = effectsForActions(
+  nanoCoreWithoutRemoveDocument.actions,
+);
+refreshDerivedState(nanoCoreWithoutRemoveDocument);
+assertCode(
+  validateBound(nanoCoreWithoutRemoveDocument, [coreNanoBytes]),
+  "INSTALL_PLAN_NANOCLAW_REMOVE_DOCUMENT_REQUIRED",
+  "NanoClaw package that omits its metadata-required REMOVE.md",
+);
+
+const rawCommand = clone(readyFixture);
+rawCommand.actions[0].command = "cp staged target";
+assertCode(
+  validateUnbound(rawCommand),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "raw command field",
+);
+
+const nonPosixPlan = clone(readyFixture);
+nonPosixPlan.path_flavor = "windows";
+assertCode(
+  validateUnbound(nonPosixPlan),
+  "INSTALL_PLAN_PATH_FLAVOR_INVALID",
+  "non-POSIX install plan",
+);
+
+for (const [label, unsafePath] of [
+  ["absolute path", "/tmp/clawsec"],
+  ["parent traversal", "../clawsec"],
+]) {
+  const unsafePlan = clone(readyFixture);
+  unsafePlan.actions[0].target.path = unsafePath;
+  assertCode(
+    validateUnbound(unsafePlan),
+    "INSTALL_PLAN_PATH_NOT_POSIX",
+    label,
+  );
+}
+
+for (const [label, unsafePath, code] of [
+  [
+    "POSIX trailing-dot segment",
+    ".claude/skills/clawsec-suite-nanoclaw/SKILL.",
+    "INSTALL_PLAN_PATH_TRAILING_DOT_FORBIDDEN",
+  ],
+  [
+    "Windows device basename",
+    ".claude/skills/clawsec-suite-nanoclaw/NUL.txt",
+    "INSTALL_PLAN_WINDOWS_DEVICE_PATH_FORBIDDEN",
+  ],
+  [
+    "non-POSIX separator",
+    ".claude\\skills\\clawsec-suite-nanoclaw\\SKILL.md",
+    "INSTALL_PLAN_PATH_NOT_POSIX",
+  ],
+]) {
+  const nonPortablePath = clone(readyFixture);
+  nonPortablePath.actions[1].target.path = unsafePath;
+  assertCode(
+    validateUnbound(nonPortablePath),
+    code,
+    label,
+  );
+}
+
+const symlinkState = clone(readyFixture);
+symlinkState.actions[0].after = {
+  kind: "symlink",
+  target: "SKILL.md",
+};
+assertCode(
+  validateUnbound(symlinkState),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "symlink post-state",
+);
+
+const embeddedConfirmation = clone(readyFixture);
+embeddedConfirmation.confirmation_requirements.confirmed = true;
+assertCode(
+  validateUnbound(embeddedConfirmation),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "embedded confirmed field",
+);
+
+const effectOmission = clone(readyFixture);
+effectOmission.result.effects.pop();
+assertCode(
+  validateUnbound(effectOmission),
+  "INSTALL_PLAN_EFFECT_ACTION_MISMATCH",
+  "result effects that omit an action",
+);
+
+const stateBindingSubstitution = clone(readyFixture);
+stateBindingSubstitution.target_state.action_set_digest =
+  `sha256:${"0".repeat(64)}`;
+assertCode(
+  validateUnbound(stateBindingSubstitution),
+  "INSTALL_PLAN_DERIVED_STATE_MISMATCH",
+  "action-set state substitution",
+);
+
+const caseFoldCollision = clone(readyFixture);
+const collidingAction = clone(caseFoldCollision.actions[1]);
+collidingAction.action_id = "write-case-colliding-skill-document";
+collidingAction.target.path =
+  ".claude/skills/clawsec-suite-nanoclaw/skill.md";
+collidingAction.tree_entry.path = "skill.md";
+collidingAction.tree_entry.manifest_entry_digest =
+  `sha256:${"3".repeat(64)}`;
+caseFoldCollision.actions.push(collidingAction);
+caseFoldCollision.artifact.install_tree_entry_count = 3;
+caseFoldCollision.artifact.install_tree_total_bytes = 2_048;
+caseFoldCollision.rollback_order =
+  caseFoldCollision.actions.map((action) => action.action_id).reverse();
+caseFoldCollision.result.effects = effectsForActions(caseFoldCollision.actions);
+refreshDerivedState(caseFoldCollision);
+assertCode(
+  validateUnbound(caseFoldCollision),
+  "INSTALL_PLAN_PATH_CASE_COLLISION",
+  "case-folding filesystem collision",
+);
+
+const fileDescendantCollision = clone(readyFixture);
+const fileDescendant = clone(fileDescendantCollision.actions[1]);
+fileDescendant.action_id = "write-file-descendant";
+fileDescendant.target.path =
+  ".claude/skills/clawsec-suite-nanoclaw/SKILL.md/child.txt";
+fileDescendant.tree_entry.path = "SKILL.md/child.txt";
+fileDescendant.tree_entry.manifest_entry_digest =
+  `sha256:${"b".repeat(64)}`;
+fileDescendantCollision.actions.push(fileDescendant);
+fileDescendantCollision.artifact.install_tree_entry_count = 3;
+fileDescendantCollision.artifact.install_tree_total_bytes = 2_048;
+fileDescendantCollision.rollback_order = rollbackOrderForActions(
+  fileDescendantCollision.actions,
+);
+fileDescendantCollision.result.effects = effectsForActions(
+  fileDescendantCollision.actions,
+);
+refreshDerivedState(fileDescendantCollision);
+assertCode(
+  validateUnbound(fileDescendantCollision),
+  "INSTALL_PLAN_PATH_ANCESTOR_CONFLICT",
+  "file target with a planned descendant",
+);
+
+const managedRemoval = clone(readyFixture);
+managedRemoval.actions[1].operation = "remove";
+managedRemoval.actions[1].after = {
+  kind: "absent",
+};
+assertCode(
+  validateUnbound(managedRemoval),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "fresh-install plan carrying a managed removal",
+);
+
+const secondFileEntry = planWithSecondFileEntry(readyFixture);
+assertValid(
+  validateBound(secondFileEntry, [coreNanoBytes, suiteNanoBytes]),
+  "two exact managed file entries with distinct tree identities",
+);
+
+const unsafeMode = clone(readyFixture);
+unsafeMode.actions[1].after.mode = "0777";
+unsafeMode.actions[1].tree_entry.mode = "0777";
+refreshDerivedState(unsafeMode);
+assertCode(
+  validateUnbound(unsafeMode),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "world-writable installed file",
+);
+
+const expiredCandidateManifest = clone(readyFixture);
+expiredCandidateManifest.artifact.authority.expires_at =
+  expiredCandidateManifest.result.reported_at;
+assertCode(
+  validateBound(expiredCandidateManifest, [coreNanoBytes, suiteNanoBytes]),
+  "INSTALL_PLAN_AUTHORITY_EXPIRES_BEFORE_PLAN",
+  "private candidate authority shorter than the plan lifetime",
+);
+
+const mismatchedPublicAuthority = clone(readyFixture);
+mismatchedPublicAuthority.artifact.channel = "public_stable";
+assertCode(
+  validateUnbound(mismatchedPublicAuthority),
+  "INSTALL_PLAN_ARTIFACT_AUTHORITY_MISMATCH",
+  "public channel carrying private-candidate authority",
+);
+
+const embeddedCandidateLifecycle = clone(readyFixture);
+embeddedCandidateLifecycle.artifact.authority.candidate_id =
+  "11111111-1111-4111-8111-111111111111";
+assertCode(
+  validateUnbound(embeddedCandidateLifecycle),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "authority reference carrying embedded candidate lifecycle state",
+);
+
+const stagedInputHandle = clone(readyFixture);
+stagedInputHandle.staged_input.ref =
+  "nano-lab-01:stage:44444444";
+assertCode(
+  validateUnbound(stagedInputHandle),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "staged input carrying a live mutable handle",
+);
+
+const stagedInputWithoutSnapshot = clone(readyFixture);
+delete stagedInputWithoutSnapshot.staged_input.snapshot_digest;
+assertCode(
+  validateUnbound(stagedInputWithoutSnapshot),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "staged input without an immutable snapshot digest",
+);
+
+const conflictedNanoCheckout = clone(readyFixture);
+conflictedNanoCheckout.adapter.profile.checkout_status = "conflicted";
+assertCode(
+  validateUnbound(conflictedNanoCheckout),
+  "INSTALL_PLAN_NANOCLAW_CHECKOUT_CONFLICTED",
+  "NanoClaw v2 conflicted checkout",
+);
+
+const nanoWithoutPostimageValidation = clone(readyFixture);
+nanoWithoutPostimageValidation.adapter.profile.validation_steps = [
+  "host_tests",
+];
+assertCode(
+  validateUnbound(nanoWithoutPostimageValidation),
+  "INSTALL_PLAN_SCHEMA_INVALID",
+  "NanoClaw v2 plan without postimage-manifest validation",
+);
+
+for (const [label, mutate] of [
+  [
+    "archive exceeding the byte limit",
+    (document) => {
+      document.artifact.archive_byte_length = 134_217_729;
+    },
+  ],
+  [
+    "install tree exceeding the entry limit",
+    (document) => {
+      document.artifact.install_tree_entry_count = 4_097;
+    },
+  ],
+  [
+    "install tree exceeding the byte limit",
+    (document) => {
+      document.artifact.install_tree_total_bytes = 268_435_457;
+    },
+  ],
+  [
+    "installed file exceeding the byte limit",
+    (document) => {
+      document.actions[1].after.byte_length = 67_108_865;
+      document.actions[1].tree_entry.byte_length = 67_108_865;
+      refreshDerivedState(document);
+    },
+  ],
+]) {
+  const overLimit = clone(readyFixture);
+  mutate(overLimit);
+  assertCode(
+    validateUnbound(overLimit),
+    "INSTALL_PLAN_SCHEMA_INVALID",
+    label,
+  );
+}
+
+const excessiveExpansion = clone(readyFixture);
+excessiveExpansion.artifact.archive_byte_length = 10;
+assertCode(
+  validateUnbound(excessiveExpansion),
+  "INSTALL_PLAN_ARCHIVE_EXPANSION_RATIO_EXCEEDED",
+  "archive expansion exceeding 100 times compressed size",
+);
+
+const excessivePlannedOutput = planWithExcessiveOutput(transformationPlan);
+assertCode(
+  validateUnbound(excessivePlannedOutput),
+  "INSTALL_PLAN_OUTPUT_BYTES_LIMIT_EXCEEDED",
+  "combined transformation output exceeding the planned postimage limit",
+);
+
+const excessiveCapturedPreimages =
+  planWithExcessiveCapturedPreimages(transformationPlan);
+assertCode(
+  validateUnbound(excessiveCapturedPreimages),
+  "INSTALL_PLAN_CAPTURED_PREIMAGE_BYTES_LIMIT_EXCEEDED",
+  "combined captured preimages exceeding the rollback byte limit",
+);
+
+const repeatedCapturedPreimageWork =
+  planWithRepeatedCapturedPreimageWork(transformationPlan);
+assertCode(
+  validateUnbound(repeatedCapturedPreimageWork),
+  "INSTALL_PLAN_CAPTURED_PREIMAGE_BYTES_LIMIT_EXCEEDED",
+  "five distinct transformation targets reusing one content digest still count as five rollback captures",
+);
+
+const ambiguousCapturedPreimage =
+  planWithAmbiguousCapturedPreimage(transformationPlan);
+assertCode(
+  validateUnbound(ambiguousCapturedPreimage),
+  "INSTALL_PLAN_CAPTURED_PREIMAGE_AMBIGUOUS",
+  "one preimage digest carrying contradictory captured metadata",
+);
+
+const underreportedTreeEntryCount = planWithSecondFileEntry(readyFixture);
+underreportedTreeEntryCount.artifact.install_tree_entry_count = 2;
+assertCode(
+  validateUnbound(underreportedTreeEntryCount),
+  "INSTALL_PLAN_ARTIFACT_TREE_ENTRY_COUNT_EXCEEDED",
+  "managed tree-entry count exceeding the artifact declaration",
+);
+
+const underreportedTreeBytes = clone(readyFixture);
+underreportedTreeBytes.artifact.install_tree_total_bytes = 1_023;
+assertCode(
+  validateUnbound(underreportedTreeBytes),
+  "INSTALL_PLAN_ARTIFACT_TREE_BYTES_EXCEED_DECLARATION",
+  "managed tree-entry bytes exceeding the artifact declaration",
+);
+
+const undisclosedTreeEntry = clone(readyFixture);
+undisclosedTreeEntry.artifact.install_tree_entry_count = 3;
+assertCode(
+  validateUnbound(undisclosedTreeEntry),
+  "INSTALL_PLAN_READY_TREE_ENTRY_COVERAGE_MISMATCH",
+  "ready plan omitting one staged install-tree entry",
+);
+
+const undisclosedTreeBytes = clone(readyFixture);
+undisclosedTreeBytes.artifact.install_tree_total_bytes = 1_025;
+assertCode(
+  validateUnbound(undisclosedTreeBytes),
+  "INSTALL_PLAN_READY_TREE_BYTE_COVERAGE_MISMATCH",
+  "ready plan omitting staged install-tree bytes",
+);
+
+const effectTargetMismatch = clone(readyFixture);
+effectTargetMismatch.result.effects[0].target.value =
+  ".claude/skills/unreviewed-package";
+assertCode(
+  validateUnbound(effectTargetMismatch),
+  "INSTALL_PLAN_EFFECT_ACTION_MISMATCH",
+  "reported effect target that differs from its action",
+);
+
+const amplifiedSchemaInput = clone(readyFixture);
+amplifiedSchemaInput.actions = Array.from({ length: 10_000 }, () => null);
+const amplifiedStart = performance.now();
+const amplifiedResult = validateUnbound(amplifiedSchemaInput);
+const amplifiedElapsed = performance.now() - amplifiedStart;
+assertCode(
+  amplifiedResult,
+  "INSTALL_PLAN_ARRAY_LIMIT_EXCEEDED",
+  "pre-schema action amplification",
+);
+assert(
+  amplifiedElapsed < 1_500,
+  `shape preflight took ${amplifiedElapsed.toFixed(1)}ms`,
+);
+
+const racePlanByteLength = 1024 * 1024;
+const racePlanBytes = Buffer.concat([
+  readyFixtureBytes,
+  Buffer.alloc(racePlanByteLength - readyFixtureBytes.byteLength, 0x20),
+]);
+const pathFlavorOffset = racePlanBytes.indexOf(Buffer.from("posix"));
+assert(pathFlavorOffset >= 0, "race fixture must contain path_flavor posix");
+const invalidRacePlanBytes = Buffer.from(racePlanBytes);
+invalidRacePlanBytes[pathFlavorOffset] = "n".charCodeAt(0);
+const validRacePlanDigest = digestBytes(racePlanBytes);
+const invalidRacePlanDigest = digestBytes(invalidRacePlanBytes);
+const racePlanStorage = new globalThis.SharedArrayBuffer(
+  racePlanBytes.byteLength,
+);
+const mutableRacePlanBytes = new Uint8Array(racePlanStorage);
+mutableRacePlanBytes.set(racePlanBytes);
+const raceControlStorage = new globalThis.SharedArrayBuffer(
+  Int32Array.BYTES_PER_ELEMENT * 3,
+);
+const raceControl = new Int32Array(raceControlStorage);
+const planRaceWorker = new Worker(`
+  const { workerData } = require("node:worker_threads");
+  const bytes = new Uint8Array(workerData.planStorage);
+  const control = new Int32Array(workerData.controlStorage);
+  let next = 0x6e;
+  Atomics.store(bytes, workerData.pathFlavorOffset, next);
+  Atomics.add(control, 2, 1);
+  next = 0x70;
+  Atomics.store(control, 0, 1);
+  Atomics.notify(control, 0);
+  while (Atomics.load(control, 1) === 0) {
+    Atomics.store(bytes, workerData.pathFlavorOffset, next);
+    Atomics.add(control, 2, 1);
+    next = next === 0x6e ? 0x70 : 0x6e;
+  }
+`, {
+  eval: true,
+  workerData: {
+    planStorage: racePlanStorage,
+    controlStorage: raceControlStorage,
+    pathFlavorOffset,
+  },
+});
+if (Atomics.load(raceControl, 0) === 0) {
+  Atomics.wait(raceControl, 0, 0, 5_000);
+}
+assert.equal(
+  Atomics.load(raceControl, 0),
+  1,
+  "plan mutation worker must start before validation",
+);
+const observedPlanDigests = new Set();
+const validateRacingPlan = () => validateBoundInstallPlan({
+  planBytes: mutableRacePlanBytes,
+  metadataBytesByDigest: metadataMap(coreNanoBytes, suiteNanoBytes),
+  expectedContext: expectedContextFor(readyFixture),
+  expectedPlanDigest: validRacePlanDigest,
+  expectedBindings: expectedBindingsFor(readyFixture),
+  evaluatedAt: readyFixture.result.reported_at,
+});
+const assertCoherentRacedPlan = (racedResult) => {
+  observedPlanDigests.add(racedResult.plan_digest);
+  const errorCodes = new Set(racedResult.errors.map((error) => error.code));
+  assert(
+    racedResult.plan_digest === validRacePlanDigest
+      || racedResult.plan_digest === invalidRacePlanDigest,
+    "bound validation must hash the same bounded private plan snapshot it parsed",
+  );
+  if (racedResult.plan_digest === validRacePlanDigest) {
+    assert(
+      !errorCodes.has("INSTALL_PLAN_PATH_FLAVOR_INVALID"),
+      "a posix plan digest cannot be paired with parsed non-posix content",
+    );
+  } else {
+    assert(
+      errorCodes.has("INSTALL_PLAN_PATH_FLAVOR_INVALID"),
+      "a non-posix plan digest must be paired with parsed non-posix content",
+    );
+  }
+};
+const planMutationCountBeforeRace = Atomics.load(raceControl, 2);
+let planMutationCountAfterRace;
+try {
+  for (let index = 0; index < 128; index += 1) {
+    assertCoherentRacedPlan(validateRacingPlan());
+  }
+  planMutationCountAfterRace = Atomics.load(raceControl, 2);
+} finally {
+  Atomics.store(raceControl, 1, 1);
+  await planRaceWorker.terminate();
+}
+assert(
+  planMutationCountAfterRace > planMutationCountBeforeRace,
+  "plan mutation worker must change bytes during concurrent validation",
+);
+assert.deepEqual(
+  [...observedPlanDigests].sort(),
+  [validRacePlanDigest, invalidRacePlanDigest].sort(),
+  "the concurrent plan snapshot race must observe both complete plan states",
+);
+for (const byte of [0x70, 0x6e]) {
+  Atomics.store(mutableRacePlanBytes, pathFlavorOffset, byte);
+  assertCoherentRacedPlan(validateRacingPlan());
+}
+
+const raceMetadataByteLength = 1024 * 1024;
+const validRaceMetadataBytes = Buffer.concat([
+  suiteNanoBytes,
+  Buffer.alloc(raceMetadataByteLength - suiteNanoBytes.byteLength, 0x20),
+]);
+const installLocationMarker = Buffer.from(
+  '"install_location": ".claude/skills/',
+);
+const installLocationMarkerOffset =
+  validRaceMetadataBytes.indexOf(installLocationMarker);
+assert(
+  installLocationMarkerOffset >= 0,
+  "metadata race fixture must contain the NanoClaw install location",
+);
+const installLocationByteOffset = installLocationMarkerOffset
+  + Buffer.byteLength('"install_location": "');
+const invalidRaceMetadataBytes = Buffer.from(validRaceMetadataBytes);
+invalidRaceMetadataBytes[installLocationByteOffset] = 0x2f;
+const validRaceMetadataDigest = digestBytes(validRaceMetadataBytes);
+const invalidRaceMetadataDigest = digestBytes(invalidRaceMetadataBytes);
+assert.notEqual(
+  validRaceMetadataDigest,
+  invalidRaceMetadataDigest,
+  "metadata race variants must have distinct content digests",
+);
+const metadataRacePlan = clone(readyFixture);
+metadataRacePlan.result.subject.component.metadata_digest =
+  validRaceMetadataDigest;
+metadataRacePlan.artifact.component.metadata_digest =
+  validRaceMetadataDigest;
+metadataRacePlan.apply_context.subject.component.metadata_digest =
+  validRaceMetadataDigest;
+refreshDerivedState(metadataRacePlan);
+const metadataRacePlanBytes = encode(metadataRacePlan);
+const raceMetadataStorage = new globalThis.SharedArrayBuffer(
+  validRaceMetadataBytes.byteLength,
+);
+const mutableRaceMetadataBytes = new Uint8Array(raceMetadataStorage);
+mutableRaceMetadataBytes.set(validRaceMetadataBytes);
+const metadataRaceControlStorage = new globalThis.SharedArrayBuffer(
+  Int32Array.BYTES_PER_ELEMENT * 3,
+);
+const metadataRaceControl = new Int32Array(metadataRaceControlStorage);
+const metadataRaceWorker = new Worker(`
+  const { workerData } = require("node:worker_threads");
+  const bytes = new Uint8Array(workerData.metadataStorage);
+  const control = new Int32Array(workerData.controlStorage);
+  let next = 0x2f;
+  Atomics.store(bytes, workerData.installLocationByteOffset, next);
+  Atomics.add(control, 2, 1);
+  next = 0x2e;
+  Atomics.store(control, 0, 1);
+  Atomics.notify(control, 0);
+  while (Atomics.load(control, 1) === 0) {
+    Atomics.store(bytes, workerData.installLocationByteOffset, next);
+    Atomics.add(control, 2, 1);
+    next = next === 0x2f ? 0x2e : 0x2f;
+  }
+`, {
+  eval: true,
+  workerData: {
+    metadataStorage: raceMetadataStorage,
+    controlStorage: metadataRaceControlStorage,
+    installLocationByteOffset,
+  },
+});
+if (Atomics.load(metadataRaceControl, 0) === 0) {
+  Atomics.wait(metadataRaceControl, 0, 0, 5_000);
+}
+assert.equal(
+  Atomics.load(metadataRaceControl, 0),
+  1,
+  "metadata mutation worker must start before validation",
+);
+const observedMetadataStates = new Set();
+const validateRacingMetadata = () => validateBoundInstallPlan({
+  planBytes: metadataRacePlanBytes,
+  metadataBytesByDigest: new Map([
+    [digestBytes(coreNanoBytes), coreNanoBytes],
+    [validRaceMetadataDigest, mutableRaceMetadataBytes],
+  ]),
+  expectedContext: expectedContextFor(metadataRacePlan),
+  expectedPlanDigest: digestBytes(metadataRacePlanBytes),
+  expectedBindings: expectedBindingsFor(metadataRacePlan),
+  evaluatedAt: metadataRacePlan.result.reported_at,
+});
+const assertCoherentRacedMetadata = (racedResult) => {
+  const errorCodes = new Set(racedResult.errors.map((error) => error.code));
+  const digestMismatch = errorCodes.has(
+    "RESULT_SUBJECT_METADATA_DIGEST_MISMATCH",
+  );
+  const invalidInstallLocation = errorCodes.has("INSTALL_PLAN_PATH_NOT_POSIX");
+  assert.equal(
+    digestMismatch,
+    invalidInstallLocation,
+    "metadata digest validation and adapter path validation must consume one private metadata snapshot",
+  );
+  observedMetadataStates.add(digestMismatch ? "invalid" : "valid");
+};
+const metadataMutationCountBeforeRace =
+  Atomics.load(metadataRaceControl, 2);
+let metadataMutationCountAfterRace;
+try {
+  for (let index = 0; index < 128; index += 1) {
+    assertCoherentRacedMetadata(validateRacingMetadata());
+  }
+  metadataMutationCountAfterRace = Atomics.load(metadataRaceControl, 2);
+} finally {
+  Atomics.store(metadataRaceControl, 1, 1);
+  await metadataRaceWorker.terminate();
+}
+assert(
+  metadataMutationCountAfterRace > metadataMutationCountBeforeRace,
+  "metadata mutation worker must change bytes during concurrent validation",
+);
+assert.deepEqual(
+  [...observedMetadataStates].sort(),
+  ["invalid", "valid"],
+  "the concurrent metadata snapshot race must observe both complete byte states",
+);
+for (const byte of [0x2e, 0x2f]) {
+  Atomics.store(mutableRaceMetadataBytes, installLocationByteOffset, byte);
+  assertCoherentRacedMetadata(validateRacingMetadata());
+}
+
+class HostileMetadataResolver extends Map {
+  entries() {
+    throw new Error("bound validation iterated the caller-owned resolver");
+  }
+
+  get() {
+    throw new Error("bound validation read through the caller-owned resolver");
+  }
+}
+
+const hostileMetadataResolver = new HostileMetadataResolver(
+  metadataMap(coreNanoBytes, suiteNanoBytes),
+);
+Map.prototype.set.call(
+  hostileMetadataResolver,
+  `sha256:${"f".repeat(64)}`,
+  new Uint8Array((4 * 1024 * 1024) + 1),
+);
+const hostileMetadataResult = validateBoundInstallPlan({
+  planBytes: readyFixtureBytes,
+  metadataBytesByDigest: hostileMetadataResolver,
+  expectedContext: expectedContextFor(readyFixture),
+  expectedPlanDigest: digestBytes(readyFixtureBytes),
+  expectedBindings: expectedBindingsFor(readyFixture),
+  evaluatedAt: readyFixture.result.reported_at,
+});
+assertValid(
+  hostileMetadataResult,
+  "bound validation must snapshot only exact referenced metadata through non-virtual Map access",
+);
+
+const oversizedRelevantMetadata = metadataMap(
+  coreNanoBytes,
+  suiteNanoBytes,
+);
+Map.prototype.set.call(
+  oversizedRelevantMetadata,
+  digestBytes(coreNanoBytes),
+  new Uint8Array((1024 * 1024) + 1),
+);
+assertCode(
+  validateBoundInstallPlan({
+    planBytes: readyFixtureBytes,
+    metadataBytesByDigest: oversizedRelevantMetadata,
+    expectedContext: expectedContextFor(readyFixture),
+    expectedPlanDigest: digestBytes(readyFixtureBytes),
+    expectedBindings: expectedBindingsFor(readyFixture),
+    evaluatedAt: readyFixture.result.reported_at,
+  }),
+  "INSTALL_PLAN_METADATA_TOO_LARGE",
+  "oversized referenced metadata rejected before snapshot copying",
+);
+
+const shadowedOversizedMetadataBytes =
+  new Uint8Array((1024 * 1024) + 1);
+Object.defineProperty(shadowedOversizedMetadataBytes, "byteLength", {
+  value: 1,
+});
+const shadowedOversizedMetadata = metadataMap(
+  coreNanoBytes,
+  suiteNanoBytes,
+);
+Map.prototype.set.call(
+  shadowedOversizedMetadata,
+  digestBytes(coreNanoBytes),
+  shadowedOversizedMetadataBytes,
+);
+assertCode(
+  validateBoundInstallPlan({
+    planBytes: readyFixtureBytes,
+    metadataBytesByDigest: shadowedOversizedMetadata,
+    expectedContext: expectedContextFor(readyFixture),
+    expectedPlanDigest: digestBytes(readyFixtureBytes),
+    expectedBindings: expectedBindingsFor(readyFixture),
+    evaluatedAt: readyFixture.result.reported_at,
+  }),
+  "INSTALL_PLAN_METADATA_TOO_LARGE",
+  "intrinsic metadata view length defeats a shadowed byteLength",
+);
+
+assertCode(
+  validateBoundInstallPlan({
+    planBytes: new Uint8Array((1024 * 1024) + 1),
+  }),
+  "INSTALL_PLAN_TOO_LARGE",
+  "oversized bound plan rejected before snapshot copying",
+);
+
+const shadowedOversizedPlanBytes = new Uint8Array((1024 * 1024) + 1);
+Object.defineProperty(shadowedOversizedPlanBytes, "byteLength", {
+  value: 1,
+});
+assertCode(
+  validateBoundInstallPlan({
+    planBytes: shadowedOversizedPlanBytes,
+  }),
+  "INSTALL_PLAN_TOO_LARGE",
+  "intrinsic plan view length defeats a shadowed byteLength",
+);
+
+assertCode(
+  validateUnboundInstallPlanBytes({}),
+  "INSTALL_PLAN_BYTES_REQUIRED",
+  "non-byte parser input",
+);
+assertCode(
+  validateUnboundInstallPlanBytes(
+    Buffer.from('{"schema":"first","schema":"second"}'),
+  ),
+  "INSTALL_PLAN_DUPLICATE_KEY",
+  "duplicate JSON key",
+);
+assertCode(
+  validateUnboundInstallPlanBytes(Buffer.alloc((1024 * 1024) + 1, 0x20)),
+  "INSTALL_PLAN_TOO_LARGE",
+  "oversized plan bytes",
+);
+assertCode(
+  validateUnboundInstallPlanBytes(
+    Buffer.from(`${"[".repeat(66)}0${"]".repeat(66)}`),
+  ),
+  "INSTALL_PLAN_NESTING_TOO_DEEP",
+  "excessive JSON nesting",
+);
+assertCode(
+  validateUnboundInstallPlanBytes(
+    Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), readyFixtureBytes]),
+  ),
+  "INSTALL_PLAN_BOM_FORBIDDEN",
+  "UTF-8 BOM",
+);
+
+const deterministicDocument = clone(readyFixture);
+deterministicDocument.actions[0].target.path = "../escape";
+const deterministicBytes = encode(deterministicDocument);
+assert.deepEqual(
+  validateUnboundInstallPlanBytes(deterministicBytes),
+  validateUnboundInstallPlanBytes(deterministicBytes),
+  "invalid input must produce deterministic diagnostics",
+);
+
+console.log("install-plan contract tests passed");
+
+function validateUnbound(document) {
+  return validateUnboundInstallPlanBytes(encode(document));
+}
+
+function validateBound(document, metadataBytes) {
+  const planBytes = encode(document);
+  return validateBoundInstallPlan({
+    planBytes,
+    metadataBytesByDigest: metadataMap(...metadataBytes),
+    expectedContext: expectedContextFor(document),
+    expectedPlanDigest: digestBytes(planBytes),
+    expectedBindings: expectedBindingsFor(document),
+    evaluatedAt: document.result.reported_at,
+  });
+}
+
+function expectedContextFor(document) {
+  return clone({
+    executor: document.result.executor,
+    subject: document.result.subject,
+    invocation: document.result.invocation,
+  });
+}
+
+function expectedBindingsFor(document) {
+  return clone({
+    adapter: document.adapter,
+    apply_context: document.apply_context,
+    artifact: document.artifact,
+    staged_input: document.staged_input,
+    target_state: document.target_state,
+    verification_refs: document.verification_refs,
+  });
+}
+
+function metadataMap(...metadataBytes) {
+  return new Map(metadataBytes.map((bytes) => [digestBytes(bytes), bytes]));
+}
+
+function syntheticMetadata(harness, role) {
+  const seedBytes = role === "core"
+    ? coreOpenclawSeedBytes
+    : suiteHermesSeedBytes;
+  const metadata = JSON.parse(seedBytes);
+  for (const platform of ["openclaw", "hermes", "nanoclaw", "picoclaw"]) {
+    delete metadata[platform];
+  }
+  metadata[harness] = {};
+  metadata.name = `clawsec-${role}-${harness}`;
+  metadata.platform = harness;
+  metadata.description = `Synthetic ${harness} ${role} metadata for install-plan contract tests.`;
+  metadata.clawsec.supported_harness = {
+    name: harness,
+    minimum_version: "0.0.0",
+    maximum_version_exclusive: "0.0.1",
+  };
+  metadata.clawsec.legacy_names = [];
+  delete metadata.clawsec.native;
+  if (role === "core") {
+    metadata.clawsec.runtime_requires = [];
+  } else {
+    metadata.clawsec.runtime_requires = [{
+      name: `clawsec-core-${harness}`,
+      minimum_version: "0.1.0-rc.1",
+      maximum_version_exclusive: "1.0.0",
+    }];
+  }
+  return encode(metadata);
+}
+
+function componentRefFromMetadata(metadataBytes) {
+  const metadata = JSON.parse(metadataBytes);
+  return {
+    schema: "clawsec.component-ref/v1",
+    name: metadata.name,
+    version: metadata.version,
+    harness: metadata.clawsec.supported_harness.name,
+    role: metadata.clawsec.role,
+    metadata_digest: digestBytes(metadataBytes),
+  };
+}
+
+function planForHarness(base, harness, executorRef, subjectRef) {
+  const document = clone(base);
+  const harnessVersion = harness === "nanoclaw" ? "2.1.17" : "0.0.0";
+  const scope = {
+    openclaw: { kind: "openclaw.workspace", ref: "fixture-workspace" },
+    hermes: { kind: "hermes.profile", ref: "fixture-profile" },
+    nanoclaw: { kind: "nanoclaw.checkout", ref: "fixture-checkout" },
+    picoclaw: { kind: "picoclaw.home", ref: "fixture-home" },
+  }[harness];
+  const adapterProfile = adapterProfileFor(harness);
+  const packageRoot = harness === "nanoclaw"
+    ? `.claude/skills/${subjectRef.name}`
+    : harness === "openclaw"
+    ? `${adapterProfile.skill_root_path}/${subjectRef.name}`
+    : subjectRef.name;
+  const anchor = "scope_root";
+
+  document.result.executor = clone(executorRef);
+  document.result.subject.component = clone(subjectRef);
+  document.result.invocation.harness = {
+    name: harness,
+    version: harnessVersion,
+  };
+  document.result.invocation.scope = clone(scope);
+  document.artifact.component = clone(subjectRef);
+  document.adapter.contract = `clawsec.${harness}-install-adapter/v1`;
+  document.adapter.profile = adapterProfile;
+  document.apply_context.executor = clone(executorRef);
+  document.apply_context.subject.component = clone(subjectRef);
+  document.apply_context.invocation.harness = {
+    name: harness,
+    version: harnessVersion,
+  };
+  document.apply_context.invocation.scope = clone(scope);
+  document.target_state.target_instance_id = scope.ref;
+  document.target_state.scope_root_identity_digest =
+    scopeRootIdentityForProfile(adapterProfile);
+  document.actions[0].target = { anchor, path: packageRoot };
+  document.actions[1].target = {
+    anchor,
+    path: `${packageRoot}/SKILL.md`,
+  };
+  document.rollback_order = rollbackOrderForActions(document.actions);
+  document.result.effects = effectsForActions(document.actions);
+  refreshDerivedState(document);
+  return document;
+}
+
+function planForPrototypePendingHarness(
+  base,
+  harness,
+  executorRef,
+  subjectRef,
+) {
+  const document = clone(base);
+  const scope = {
+    hermes: { kind: "hermes.profile", ref: "fixture-profile" },
+    picoclaw: { kind: "picoclaw.home", ref: "fixture-home" },
+  }[harness];
+  const profile = adapterProfileFor(harness);
+
+  document.disposition = "blocked";
+  document.result.executor = clone(executorRef);
+  document.result.subject.component = clone(subjectRef);
+  document.result.invocation.harness = {
+    name: harness,
+    version: "0.0.0",
+  };
+  document.result.invocation.scope = clone(scope);
+  document.result.outcome = "blocked";
+  document.result.reason_code = "prerequisite_missing";
+  document.result.summary =
+    `${harness} native installation remains a prototype.`;
+  document.result.effects = [];
+  document.artifact.component = clone(subjectRef);
+  document.adapter.contract = `clawsec.${harness}-install-adapter/v1`;
+  document.adapter.profile = profile;
+  document.apply_context = null;
+  document.target_state.target_instance_id = scope.ref;
+  document.target_state.scope_root_identity_digest =
+    scopeRootIdentityForProfile(profile);
+  document.actions = [];
+  document.rollback_order = [];
+  document.blockers = [{
+    blocker_id: `${harness}-native-install-prototype`,
+    code: "unsupported_native_operation",
+    summary:
+      `${harness} native installation is not implemented in contract v1.`,
+  }];
+  document.confirmation_requirements = null;
+  refreshDerivedState(document);
+  return document;
+}
+
+function planForNanoCore(base, coreMetadataBytes) {
+  const coreRef = componentRefFromMetadata(coreMetadataBytes);
+  const document = planForHarness(
+    base,
+    "nanoclaw",
+    coreRef,
+    coreRef,
+  );
+  const packageRoot = ".claude/skills/clawsec-core-nanoclaw";
+  const removeAction = clone(document.actions[1]);
+  removeAction.action_id = "write-remove-document";
+  removeAction.target.path = `${packageRoot}/REMOVE.md`;
+  removeAction.after.digest = `sha256:${"a".repeat(64)}`;
+  removeAction.after.byte_length = 768;
+  removeAction.tree_entry.path = "REMOVE.md";
+  removeAction.tree_entry.digest = removeAction.after.digest;
+  removeAction.tree_entry.byte_length = removeAction.after.byte_length;
+  removeAction.tree_entry.manifest_entry_digest =
+    `sha256:${"b".repeat(64)}`;
+  document.actions.push(removeAction);
+  document.artifact.install_tree_entry_count = 3;
+  document.artifact.install_tree_total_bytes = 1792;
+  document.rollback_order = document.actions
+    .map((action) => action.action_id)
+    .reverse();
+  document.result.effects = effectsForActions(document.actions);
+  refreshDerivedState(document);
+  return document;
+}
+
+function planWithNestedPackageTree(base) {
+  const document = clone(base);
+  const packageRoot =
+    ".claude/skills/clawsec-suite-nanoclaw";
+  const nestedDirectory = clone(document.actions[0]);
+  nestedDirectory.action_id = "create-nested-directory";
+  nestedDirectory.target.path = `${packageRoot}/lib`;
+  nestedDirectory.tree_entry.path = "lib";
+  nestedDirectory.tree_entry.manifest_entry_digest =
+    `sha256:${"3".repeat(64)}`;
+  const deepDirectory = clone(document.actions[0]);
+  deepDirectory.action_id = "create-deep-directory";
+  deepDirectory.target.path = `${packageRoot}/lib/security`;
+  deepDirectory.tree_entry.path = "lib/security";
+  deepDirectory.tree_entry.manifest_entry_digest =
+    `sha256:${"4".repeat(64)}`;
+  const deepFile = clone(document.actions[1]);
+  deepFile.action_id = "write-deep-file";
+  deepFile.target.path = `${packageRoot}/lib/security/config.json`;
+  deepFile.after.digest = `sha256:${"9".repeat(64)}`;
+  deepFile.after.byte_length = 512;
+  deepFile.tree_entry.path = "lib/security/config.json";
+  deepFile.tree_entry.digest = deepFile.after.digest;
+  deepFile.tree_entry.byte_length = deepFile.after.byte_length;
+  deepFile.tree_entry.manifest_entry_digest =
+    `sha256:${"a".repeat(64)}`;
+  const emptyDirectory = clone(document.actions[0]);
+  emptyDirectory.action_id = "create-empty-directory";
+  emptyDirectory.target.path = `${packageRoot}/empty`;
+  emptyDirectory.tree_entry.path = "empty";
+  emptyDirectory.tree_entry.manifest_entry_digest =
+    `sha256:${"5".repeat(64)}`;
+  document.actions.push(
+    nestedDirectory,
+    deepDirectory,
+    deepFile,
+    emptyDirectory,
+  );
+  document.artifact.install_tree_entry_count = 6;
+  document.artifact.install_tree_total_bytes = 1_536;
+  document.rollback_order = rollbackOrderForActions(document.actions);
+  document.result.effects = effectsForActions(document.actions);
+  refreshDerivedState(document);
+  return document;
+}
+
+function planWithRemovedPackageActivation(base) {
+  const document = clone(base);
+  const target = {
+    anchor: "scope_root",
+    path: ".claude/skills/clawsec-suite-nanoclaw",
+  };
+  const argumentsValue = { activation_mode: "exact_tree" };
+  const preconditionDigest = `sha256:${"4".repeat(64)}`;
+  const postconditionDigest = `sha256:${"5".repeat(64)}`;
+  document.actions.push({
+    action_id: "activate-package",
+    kind: "native_operation",
+    adapter_contract: document.adapter.contract,
+    operation: "activate_package",
+    state_effect: "mutating",
+    target,
+    arguments: argumentsValue,
+    precondition_digest: preconditionDigest,
+    expected_postcondition_digest: postconditionDigest,
+    rollback: {
+      operation: "deactivate_package",
+      target: clone(target),
+      arguments: clone(argumentsValue),
+      precondition_digest: postconditionDigest,
+      expected_postcondition_digest: preconditionDigest,
+    },
+  });
+  document.rollback_order = rollbackOrderForActions(document.actions);
+  document.result.effects = effectsForActions(document.actions);
+  refreshDerivedState(document);
+  return document;
+}
+
+function planWithOperationalAction(base, operation) {
+  const document = clone(base);
+  const conditionDigest = `sha256:${"4".repeat(64)}`;
+  document.adapter.profile.reload_behavior = operation;
+  document.actions.push({
+    action_id: `${operation.replace("_", "-")}-after-install`,
+    kind: "native_operation",
+    adapter_contract: document.adapter.contract,
+    operation,
+    state_effect: "operational_non_mutating",
+    target: {
+      kind: "harness_resource",
+      value: "nanoclaw.host",
+      identity_digest:
+        document.adapter.profile.checkout_identity_digest,
+    },
+    arguments: {},
+    precondition_digest: conditionDigest,
+    expected_postcondition_digest: conditionDigest,
+    rollback: null,
+  });
+  document.rollback_order = rollbackOrderForActions(document.actions);
+  document.result.effects = effectsForActions(document.actions);
+  refreshDerivedState(document);
+  return document;
+}
+
+function declaredTransformationFor(document) {
+  return document.actions.find(
+    (action) => action.kind === "declared_transformation",
+  );
+}
+
+function planWithNanoTransformation(base) {
+  const document = clone(base);
+  const target = {
+    anchor: "scope_root",
+    path:
+      "container/agent-runner/generated-config.json",
+  };
+  const codingHarness = {
+    name: "codex",
+    immutable_reference: {
+      kind: "exact_version",
+      value: "1.0.0",
+    },
+    implementation_digest: `sha256:${"c".repeat(64)}`,
+    toolchain_digest: `sha256:${"d".repeat(64)}`,
+    configuration_digest: `sha256:${"e".repeat(64)}`,
+  };
+  const before = {
+    kind: "file",
+    digest: `sha256:${"a".repeat(64)}`,
+    byte_length: 256,
+    mode: "0644",
+    owner_identity_digest: `sha256:${"7".repeat(64)}`,
+    group_identity_digest: `sha256:${"8".repeat(64)}`,
+  };
+  const after = {
+    kind: "file",
+    digest: `sha256:${"b".repeat(64)}`,
+    byte_length: 384,
+    mode: "0644",
+    owner_identity_digest: `sha256:${"7".repeat(64)}`,
+    group_identity_digest: `sha256:${"8".repeat(64)}`,
+  };
+  const packageRoot = document.actions[0].target.path;
+  const sourceDirectory = clone(document.actions[0]);
+  sourceDirectory.action_id = "create-transformations-directory";
+  sourceDirectory.target.path = `${packageRoot}/transformations`;
+  sourceDirectory.tree_entry.path = "transformations";
+  sourceDirectory.tree_entry.manifest_entry_digest =
+    `sha256:${"1".repeat(64)}`;
+  const sourceFile = clone(document.actions[1]);
+  sourceFile.action_id = "install-transformation-declaration";
+  sourceFile.target.path =
+    `${packageRoot}/transformations/nanoclaw-generated-config.json`;
+  sourceFile.after.digest = `sha256:${"d".repeat(64)}`;
+  sourceFile.after.byte_length = 512;
+  sourceFile.tree_entry.path =
+    "transformations/nanoclaw-generated-config.json";
+  sourceFile.tree_entry.digest = sourceFile.after.digest;
+  sourceFile.tree_entry.byte_length = sourceFile.after.byte_length;
+  sourceFile.tree_entry.manifest_entry_digest =
+    `sha256:${"e".repeat(64)}`;
+  const declarationSource = {
+    managed_action_id: sourceFile.action_id,
+    manifest_entry_digest:
+      sourceFile.tree_entry.manifest_entry_digest,
+  };
+  document.adapter.profile.coding_harness = clone(codingHarness);
+  document.adapter.profile.validation_steps = [
+    "postimage_manifest",
+    "host_build",
+    "host_tests",
+    "skill_tests",
+    "container_typecheck",
+    "container_build",
+    "container_tests",
+  ];
+  const transformation = {
+    action_id: "transform-generated-config",
+    kind: "declared_transformation",
+    target,
+    declaration: {
+      source: declarationSource,
+      release_manifest_digest:
+        document.artifact.release_manifest_digest,
+      transformation_entry_digest: `sha256:${"f".repeat(64)}`,
+      allowed_output: {
+        target: clone(target),
+        before: clone(before),
+        after: clone(after),
+      },
+      coding_harness: clone(codingHarness),
+    },
+    before,
+    after,
+    rollback_source: {
+      kind: "captured_file",
+      digest: before.digest,
+      byte_length: before.byte_length,
+      mode: before.mode,
+      owner_identity_digest: before.owner_identity_digest,
+      group_identity_digest: before.group_identity_digest,
+    },
+  };
+  document.actions = [
+    ...document.actions,
+    sourceDirectory,
+    sourceFile,
+    transformation,
+  ];
+  document.artifact.install_tree_entry_count = 4;
+  document.artifact.install_tree_total_bytes = 1_536;
+  document.rollback_order = rollbackOrderForActions(document.actions);
+  document.result.effects = effectsForActions(document.actions);
+  refreshDerivedState(document);
+  return document;
+}
+
+function planWithSecondFileEntry(base) {
+  const document = clone(base);
+  const duplicate = clone(document.actions[1]);
+  duplicate.action_id = "write-copy-skill-document";
+  duplicate.target.path =
+    ".claude/skills/clawsec-suite-nanoclaw/COPY.md";
+  duplicate.tree_entry.path = "COPY.md";
+  duplicate.tree_entry.manifest_entry_digest =
+    `sha256:${"4".repeat(64)}`;
+  document.actions.push(duplicate);
+  document.artifact.install_tree_entry_count = 3;
+  document.artifact.install_tree_total_bytes = 2_048;
+  document.rollback_order = rollbackOrderForActions(document.actions);
+  document.result.effects = effectsForActions(document.actions);
+  refreshDerivedState(document);
+  return document;
+}
+
+function planWithExcessiveOutput(base) {
+  const document = clone(base);
+  const beforeDigests = ["b", "c", "d", "e", "f"];
+  const afterDigests = ["0", "1", "2", "3", "4"];
+  const transformationEntryDigests = ["6", "7", "8", "9", "a"];
+  const transformations = beforeDigests.map((character, index) => {
+    const action = clone(declaredTransformationFor(base));
+    action.action_id = `transform-large-output-${index}`;
+    action.target.path = `container/generated-${index}.json`;
+    action.declaration.transformation_entry_digest =
+      `sha256:${transformationEntryDigests[index].repeat(64)}`;
+    action.before.digest =
+      `sha256:${character.repeat(64)}`;
+    action.before.byte_length = 0;
+    action.after.digest =
+      `sha256:${afterDigests[index].repeat(64)}`;
+    action.after.byte_length = 67_108_864;
+    action.declaration.allowed_output = {
+      target: clone(action.target),
+      before: clone(action.before),
+      after: clone(action.after),
+    };
+    action.rollback_source = {
+      kind: "captured_file",
+      digest: action.before.digest,
+      byte_length: action.before.byte_length,
+      mode: action.before.mode,
+      owner_identity_digest: action.before.owner_identity_digest,
+      group_identity_digest: action.before.group_identity_digest,
+    };
+    return action;
+  });
+  document.actions = [
+    ...document.actions.filter(
+      (action) => action.kind === "managed_entry",
+    ),
+    ...transformations,
+  ];
+  document.rollback_order = rollbackOrderForActions(document.actions);
+  document.result.effects = effectsForActions(document.actions);
+  refreshDerivedState(document);
+  return document;
+}
+
+function planWithExcessiveCapturedPreimages(base) {
+  const document = clone(base);
+  const beforeDigests = ["b", "c", "d", "e", "f"];
+  const afterDigests = ["0", "1", "2", "3", "4"];
+  const transformationEntryDigests = ["6", "7", "8", "9", "a"];
+  const transformations = beforeDigests.map((character, index) => {
+    const action = clone(declaredTransformationFor(base));
+    action.action_id = `transform-large-preimage-${index}`;
+    action.target.path = `container/preimage-${index}.json`;
+    action.declaration.transformation_entry_digest =
+      `sha256:${transformationEntryDigests[index].repeat(64)}`;
+    action.before.digest =
+      `sha256:${character.repeat(64)}`;
+    action.before.byte_length = 67_108_864;
+    action.after.digest =
+      `sha256:${afterDigests[index].repeat(64)}`;
+    action.after.byte_length = 1;
+    action.declaration.allowed_output = {
+      target: clone(action.target),
+      before: clone(action.before),
+      after: clone(action.after),
+    };
+    action.rollback_source = {
+      kind: "captured_file",
+      digest: action.before.digest,
+      byte_length: action.before.byte_length,
+      mode: action.before.mode,
+      owner_identity_digest: action.before.owner_identity_digest,
+      group_identity_digest: action.before.group_identity_digest,
+    };
+    return action;
+  });
+  document.actions = [
+    ...document.actions.filter(
+      (action) => action.kind === "managed_entry",
+    ),
+    ...transformations,
+  ];
+  document.rollback_order = rollbackOrderForActions(document.actions);
+  document.result.effects = effectsForActions(document.actions);
+  refreshDerivedState(document);
+  return document;
+}
+
+function planWithRepeatedCapturedPreimageWork(base) {
+  const document = clone(base);
+  const afterDigests = ["0", "1", "2", "3", "4"];
+  const transformationEntryDigests = ["6", "7", "8", "9", "a"];
+  const transformations = afterDigests.map((character, index) => {
+    const action = clone(declaredTransformationFor(base));
+    action.action_id = `transform-repeated-preimage-${index}`;
+    action.target.path = `container/repeated-preimage-${index}.json`;
+    action.declaration.transformation_entry_digest =
+      `sha256:${transformationEntryDigests[index].repeat(64)}`;
+    action.before.byte_length = 67_108_864;
+    action.after.digest = `sha256:${character.repeat(64)}`;
+    action.after.byte_length = 1;
+    action.declaration.allowed_output = {
+      target: clone(action.target),
+      before: clone(action.before),
+      after: clone(action.after),
+    };
+    action.rollback_source = {
+      kind: "captured_file",
+      digest: action.before.digest,
+      byte_length: action.before.byte_length,
+      mode: action.before.mode,
+      owner_identity_digest: action.before.owner_identity_digest,
+      group_identity_digest: action.before.group_identity_digest,
+    };
+    return action;
+  });
+  document.actions = [
+    ...document.actions.filter(
+      (action) => action.kind === "managed_entry",
+    ),
+    ...transformations,
+  ];
+  document.rollback_order = rollbackOrderForActions(document.actions);
+  document.result.effects = effectsForActions(document.actions);
+  refreshDerivedState(document);
+  return document;
+}
+
+function planWithAmbiguousCapturedPreimage(base) {
+  const document = clone(base);
+  const duplicate = clone(declaredTransformationFor(document));
+  duplicate.action_id = "transform-generated-config-second-capture";
+  duplicate.target.path = "container/generated-config-second.json";
+  duplicate.declaration.transformation_entry_digest =
+    `sha256:${"3".repeat(64)}`;
+  duplicate.before.byte_length += 1;
+  duplicate.after.digest = `sha256:${"4".repeat(64)}`;
+  duplicate.declaration.allowed_output = {
+    target: clone(duplicate.target),
+    before: clone(duplicate.before),
+    after: clone(duplicate.after),
+  };
+  duplicate.rollback_source = {
+    kind: "captured_file",
+    digest: duplicate.before.digest,
+    byte_length: duplicate.before.byte_length,
+    mode: duplicate.before.mode,
+    owner_identity_digest: duplicate.before.owner_identity_digest,
+    group_identity_digest: duplicate.before.group_identity_digest,
+  };
+  const transformationIndex = document.actions.findIndex(
+    (action) => action.kind === "declared_transformation",
+  );
+  document.actions.splice(transformationIndex, 0, duplicate);
+  document.rollback_order = rollbackOrderForActions(document.actions);
+  document.result.effects = effectsForActions(document.actions);
+  refreshDerivedState(document);
+  return document;
+}
+
+function adapterProfileFor(harness) {
+  const digest = (character) => `sha256:${character.repeat(64)}`;
+  if (harness === "openclaw") {
+    return {
+      kind: "openclaw",
+      scope_identity_digest: digest("1"),
+      skill_root_identity_digest: digest("7"),
+      skill_root_path: "skills",
+      reload_behavior: "none",
+    };
+  }
+  if (harness === "hermes") {
+    return {
+      kind: "hermes",
+      profile_identity_digest: digest("2"),
+      profile_config_digest: digest("3"),
+      skill_root_identity_digest: digest("7"),
+      native_install_status: "prototype_pending",
+      reload_behavior: "none",
+    };
+  }
+  if (harness === "picoclaw") {
+    return {
+      kind: "picoclaw",
+      home_identity_digest: digest("4"),
+      config_schema_version: "1",
+      config_digest: digest("5"),
+      skill_root_identity_digest: digest("7"),
+      native_install_status: "prototype_pending",
+      reload_behavior: "none",
+    };
+  }
+  return clone(readyFixture.adapter.profile);
+}
+
+function scopeRootIdentityForProfile(profile) {
+  if (profile.kind === "openclaw") {
+    return profile.scope_identity_digest;
+  }
+  if (profile.kind === "hermes") {
+    return profile.profile_identity_digest;
+  }
+  if (profile.kind === "picoclaw") {
+    return profile.home_identity_digest;
+  }
+  return profile.checkout_identity_digest;
+}
+
+function effectsForActions(actions) {
+  return actions.map((action) => {
+    const target = action.target.anchor === undefined
+      ? {
+          kind: "harness_resource",
+          value: action.target.value,
+        }
+      : {
+          kind: "relative_path",
+          value: action.target.path,
+        };
+    return {
+      effect_id: action.action_id,
+      state: "proposed",
+      target,
+      summary: `Propose ${action.operation} for ${target.value}.`,
+    };
+  }).sort((left, right) => left.effect_id.localeCompare(right.effect_id));
+}
+
+function rollbackOrderForActions(actions) {
+  return actions
+    .filter((action) => (
+      action.kind !== "native_operation"
+      || action.state_effect === "mutating"
+    ))
+    .map((action) => action.action_id)
+    .reverse();
+}
+
+function refreshDerivedState(document) {
+  Object.assign(
+    document.target_state,
+    computeInstallPlanStateBindings(document),
+  );
+  return document;
+}
+
+function setSubjectVersion(document, version) {
+  document.result.subject.component.version = version;
+  document.artifact.component.version = version;
+  if (document.apply_context !== null) {
+    document.apply_context.subject.component.version = version;
+  }
+}
+
+function setMetadataVersion(metadataBytes, version) {
+  const metadata = JSON.parse(metadataBytes);
+  metadata.version = version;
+  return encode(metadata);
+}
+
+function replaceSubjectRef(document, subjectRef) {
+  document.result.subject.component = clone(subjectRef);
+  document.artifact.component = clone(subjectRef);
+  document.apply_context.subject.component = clone(subjectRef);
+}
+
+function assertValid(result, label) {
+  assert.equal(
+    result.valid,
+    true,
+    `${label} failed: ${JSON.stringify(result.errors)}`,
+  );
+  assert.deepEqual(result.errors, [], `${label} returned diagnostics`);
+}
+
+function assertCode(result, code, label) {
+  assert.equal(
+    result.valid,
+    false,
+    `${label} unexpectedly passed`,
+  );
+  assert(
+    result.errors.some((entry) => entry.code === code),
+    `${label} did not report ${code}: ${JSON.stringify(result.errors)}`,
+  );
+}
+
+function assertBoundAssurance(result, label) {
+  assert.deepEqual(
+    {
+      binding: result.binding,
+      provenance: result.provenance,
+      catalog_authorization: result.catalog_authorization,
+      release_signature_authorization:
+        result.release_signature_authorization,
+      advisory_verification: result.advisory_verification,
+      operator_authorization: result.operator_authorization,
+      artifact_source_membership: result.artifact_source_membership,
+      action_state_derivation: result.action_state_derivation,
+      installation_authorization: result.installation_authorization,
+      execution: result.execution,
+      preconditions_at_apply_time: result.preconditions_at_apply_time,
+      warnings: result.warnings,
+    },
+    {
+      binding: "exact_plan_bytes_metadata_and_caller_inputs",
+      provenance: "unverified",
+      catalog_authorization: "unverified",
+      release_signature_authorization: "unverified",
+      advisory_verification: "unverified",
+      operator_authorization: "unverified",
+      artifact_source_membership: "unverified",
+      action_state_derivation: "verified_from_plan_actions",
+      installation_authorization: "not_granted",
+      execution: "not_executed",
+      preconditions_at_apply_time: "unverified",
+      warnings: [],
+    },
+    `${label} must preserve the assurance boundary`,
+  );
+}
+
+function encode(value) {
+  return Buffer.from(`${JSON.stringify(value)}\n`);
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}


### PR DESCRIPTION
# User description
## Purpose

Define the reviewable plan that a future `clawsec-core-<harness>` must produce **before** any skill installation is authorized or executed.

This is a contract-only PR. It does not add or change an installable skill.

## Stack

- Base: `davida-ps/result-envelope-contract-v1` / #321
- One commit ahead of base: `fdbadef`
- Depends transitively on the lifecycle SemVer and component-metadata contract drafts.
- No merge is requested while the contract language, SemVer lifecycle, and new skill architecture are still under review.

## Concrete behavior

- Adds `clawsec.install-plan/v1` for `core.plan-release`.
- A `ready` plan contains every proposed action, exact target, before/after state, expected effect, rollback source/order, artifact identity, staged-input identity, target-instance identity, and future `core.install-release` context.
- `ready` means complete enough to review. It does **not** grant operator authorization and it does not claim execution.
- A `blocked` plan contains at least one blocker and contains no actions, effects, rollback order, apply context, or confirmation challenge.
- Fresh installation only: managed entries require absent prestate. Update, remove, migration, receipt, apply, and interrupted-operation recovery are separate future contracts.
- All filesystem actions are POSIX, portable, scope-relative, and anchored to one explicit `scope_root`.
- Every installed directory and file is represented by an exact install-tree entry. Empty/intermediate directories are explicit. File digests, lengths, modes, action targets, reported effects, and rollback records must agree.
- Declared transformations reference an earlier exact managed source file and one release-manifest entry digest. This contract validates the binding shape but deliberately leaves manifest membership, signatures, catalog authorization, advisory verification, and provenance unverified.
- Plans are bounded to 1 MiB, 64 actions/outputs, 256 MiB planned output, and 256 MiB total rollback capture work. Repeated equal preimage digests still count once per transformed target.
- Caller-owned plan and referenced metadata bytes are copied through bounded fixed-length views. Oversized, shadowed-length, hostile-resolver, and concurrent-mutation cases fail closed or remain internally coherent.

## Harness adapters

- **OpenClaw:** may produce a ready exact-tree plan for one declared skill root and explicit reload behavior.
- **NanoClaw v2:** binds one selected checkout, checkout/ancestor/dependency-lock identity, additive skill placement, declared host transformations, immutable coding-harness identity, complete postimage/host/skill validation, and container/agent-runner validation when those areas are touched.
- **Hermes:** native installation remains `prototype_pending`; v1 can only produce a blocked `unsupported_native_operation` plan.
- **PicoClaw:** native installation remains `prototype_pending`; v1 can only produce a blocked `unsupported_native_operation` plan.

The NanoClaw fixture is pinned to the audited v2.1.17 contract surface. It is a contract fixture, not a blanket current-version support claim. No retired branch-merge, `/workspace/ipc`, or container-owned trust model is introduced.

## Deliberate non-goals

- No installer or apply executor.
- No operator-confirmation implementation.
- No install, bootstrap, attempt, removal, tombstone, or migration receipt.
- No catalog/root/signature authority.
- No advisory engine.
- No runtime core, suite, or guardian skill.
- No hook, scheduler, job, service, automatic remediation, or persistence change.
- No docs, release pipeline, tag, release, store publication, or catalog activation.

## Verification

Final clean-room lab preserved at:

`davida@20.14.133.241:/tmp/clawsec-install-plan-final.GvyF93/repo`

The lab was freshly cloned from `https://github.com/prompt-security/clawsec.git` and detached at exact base:

`47a63a0288ebd975a2287cf76b878e68a20f2565`

All 17 copied files matched the local candidate by SHA-256. Audit-critical final hashes:

- validator: `e5cc274c422ab510dd089ba43b3e73e7c26cdfe457cf2f2c98f557ead544b161`
- test: `4435578daa2da85d7387d2a9aee801732c97ceecba0b54fbf8cee6cbc1903d88`

Passed remotely:

- `npm ci`
- `node --check` for all changed/new `.mjs` files
- `npm run test:install-plan-contract`
- `npm run test:metadata-contracts`
- `npm run test:result-envelope-contract`
- `node scripts/test-skill-lifecycle-semver.mjs`
- `npx eslint . --ext .ts,.tsx,.js,.jsx,.mjs --max-warnings 0`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
- exact 17-path status audit

Two independent final read-only audits reported no P0, P1, or P2 findings against the exact hashes above.

`npm ci` also reported three dependency-audit findings (one moderate, two high). `package-lock.json` is unchanged, and dependency remediation is intentionally outside this contract PR.

## Review focus

- Is `ready` vs. `blocked` language sufficiently clear that no authorization or execution is implied?
- Are the common contract and four adapter boundaries correctly separated?
- Is the NanoClaw v2 checkout/transformation model faithful without overstating support?
- Are the v1 resource ceilings and exact-tree disclosure rules acceptable for the first core implementation?
- Does this unit fit the new lifecycle SemVer and `core -> suite -> optional guardian` design before any skill implementation starts?

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Define the <code>clawsec.install-plan/v1</code> contract and policy around <code>core.plan-release</code>, so <code>install-plan-v1.schema.json</code> and <code>install-plan-policy.json</code> can describe non-authorizing <code>ready</code> and <code>blocked</code> plans for exact-tree installation. Add adapter-specific validation for <code>openclaw</code>, <code>hermes</code>, <code>nanoclaw</code>, and <code>picoclaw</code> through the install-plan schemas, registry, and validator scripts that enforce future <code>core.install-release</code> bindings and rollback rules.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/322?tool=ast&topic=Adapter+checks>Adapter checks</a>
        </td><td>Add adapter-specific validation and contract tests for <code>openclaw</code>, <code>hermes</code>, <code>nanoclaw</code>, and <code>picoclaw</code> install flows.<details><summary>Modified files (13)</summary><ul><li>contracts/schemas/install/adapters/hermes-v1.schema.json</li>
<li>contracts/schemas/install/adapters/nanoclaw-v2.schema.json</li>
<li>contracts/schemas/install/adapters/openclaw-v1.schema.json</li>
<li>contracts/schemas/install/adapters/picoclaw-v1.schema.json</li>
<li>package.json</li>
<li>scripts/ci/install-plan-adapters/hermes.mjs</li>
<li>scripts/ci/install-plan-adapters/nanoclaw-v2.mjs</li>
<li>scripts/ci/install-plan-adapters/openclaw.mjs</li>
<li>scripts/ci/install-plan-adapters/picoclaw.mjs</li>
<li>scripts/ci/install-plan-adapters/registry.mjs</li>
<li>scripts/ci/validate_clawsec_install_plan.mjs</li>
<li>scripts/ci/validate_clawsec_result_envelope.mjs</li>
<li>scripts/test-skill-install-plan-contract.mjs</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>feat(contracts): defin...</td><td>July 24, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/322?tool=ast&topic=Plan+contract>Plan contract</a>
        </td><td>Define the non-authorizing install-plan schema, policy limits, and ready/blocked fixtures for <code>core.plan-release</code>.<details><summary>Modified files (4)</summary><ul><li>contracts/fixtures/install-plan-v1/valid/nanoclaw-v2-blocked-unowned-path.json</li>
<li>contracts/fixtures/install-plan-v1/valid/nanoclaw-v2-ready.json</li>
<li>contracts/install-plan-policy.json</li>
<li>contracts/schemas/install/install-plan-v1.schema.json</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>feat(contracts): defin...</td><td>July 24, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/322?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>