### PR TITLE
fix(deps): resolve react-router dependabot alerts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { HashRouter as Router, Routes, Route } from 'react-router-dom';
+import { HashRouter as Router, Routes, Route } from 'react-router';
 import { Layout } from './components/Layout';
 import { Home } from './pages/Home';
 import { FeedSetup } from './pages/FeedSetup';

--- a/components/AdvisoryCard.tsx
+++ b/components/AdvisoryCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ExternalLink, Github } from 'lucide-react';
 import { Advisory } from '../types';
 import { AdvisoryPlatformBadge } from './AdvisoryPlatformBadge';

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 import { Menu, X, Terminal, Layers, Rss, Home, Github, BookOpenText, PlayCircle } from 'lucide-react';
 
 export const Header: React.FC = () => {

--- a/components/SkillCard.tsx
+++ b/components/SkillCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ArrowRight } from 'lucide-react';
 import type { SkillMetadata } from '../types';
 import { getPlatformDescriptor } from '../utils/advisoryPlatforms';

--- a/index.html
+++ b/index.html
@@ -127,11 +127,11 @@
   <script type="importmap">
 {
   "imports": {
-    "react-dom/": "https://esm.sh/react-dom@^19.2.4/",
-    "react/": "https://esm.sh/react@^19.2.4/",
-    "react": "https://esm.sh/react@^19.2.4",
+    "react-dom/": "https://esm.sh/react-dom@^19.2.8/",
+    "react/": "https://esm.sh/react@^19.2.8/",
+    "react": "https://esm.sh/react@^19.2.8",
     "lucide-react": "https://esm.sh/lucide-react@^0.563.0",
-    "react-router-dom": "https://esm.sh/react-router-dom@^7.13.0"
+    "react-router": "https://esm.sh/react-router@^8.3.0"
   }
 }
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1397,16 +1397,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -4226,9 +4225,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4488,9 +4487,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -4507,7 +4506,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "lucide-react": "^0.575.0",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.5",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.16.0",
+        "react-router": "^8.3.0",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -1601,18 +1601,10 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4577,24 +4569,22 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
-      "license": "MIT",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
-      "license": "MIT",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {
@@ -4628,41 +4618,23 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
-      "license": "MIT",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.16.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -4886,12 +4858,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -42,9 +42,10 @@
   "overrides": {
     "ajv": "6.14.0",
     "balanced-match": "4.0.3",
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.9",
     "js-yaml": "4.3.0",
     "minimatch": "10.2.5",
-    "picomatch": "4.0.4"
+    "picomatch": "4.0.4",
+    "postcss": "8.5.25"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   },
   "dependencies": {
     "lucide-react": "^0.575.0",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.5",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.16.0",
+    "react-router": "^8.3.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/pages/AdvisoryDetail.tsx
+++ b/pages/AdvisoryDetail.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import { ArrowLeft, ExternalLink, Shield, AlertTriangle, Github, User, Bot } from 'lucide-react';
 import { AdvisoryPlatformBadge } from '../components/AdvisoryPlatformBadge';
 import { Footer } from '../components/Footer';

--- a/pages/FeedSetup.tsx
+++ b/pages/FeedSetup.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Rss, RefreshCw, Loader2, AlertTriangle, ChevronLeft, ChevronRight, Download, Users, AlertCircle } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Footer } from '../components/Footer';
 import { AdvisoryCard } from '../components/AdvisoryCard';
 import { Advisory, AdvisoryFeed, AdvisoryPlatformFilter } from '../types';

--- a/pages/SkillDetail.tsx
+++ b/pages/SkillDetail.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import { ArrowLeft, Copy, Check, Download, ExternalLink, FileText, Shield } from 'lucide-react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';

--- a/pages/WikiBrowser.tsx
+++ b/pages/WikiBrowser.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { BookOpenText, ExternalLink, FileText } from 'lucide-react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import Markdown from 'react-markdown';
 import type { Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';


### PR DESCRIPTION
# User description
## Summary
- Replace `react-router-dom` with patched `react-router@^8.3.0` because the open Dependabot alerts target the transitive `react-router` package.
- Update router imports and the browser import map to use `react-router` directly.
- Bump `react` and `react-dom` to `^19.2.8` to satisfy React Router 8 peer requirements.
- Patch the CI audit follow-up findings by overriding `brace-expansion@5.0.9` and `postcss@8.5.25`.

## Dependabot alerts addressed
- GHSA-chx6-hx7r-mcp5 / CVE-2026-55685: patched by `react-router@8.3.0`.
- GHSA-qwww-vcr4-c8h2: patched by `react-router@8.3.0`.
- GHSA-wrjc-x8rr-h8h6 / CVE-2026-53669: patched by `react-router@8.3.0`.
- GHSA-337j-9hxr-rhxg / CVE-2026-53666: patched by `react-router@8.3.0`.
- GHSA-h8fp-f39c-q6mh / CVE-2026-53667: patched by `react-router@8.3.0`.

## Validation
- `npm_config_cache=/private/tmp/clawsec-npm-cache npm ci --prefer-offline` passed; npm warns that `react-router@8.3.0` declares Node `>=22.22.0` while local Node is `20.19.5`.
- `npx tsc --noEmit` passed.
- `npx eslint . --ext .ts,.tsx,.js,.jsx,.mjs --max-warnings 0` passed.
- `npm run build` passed with the existing large chunk warning.
- GitHub Actions: all PR checks passed, including `Dependency Audit`, CodeQL, Security Scan, TS/React lint on macOS/Ubuntu/Windows, Pages verify, wiki export verify, and skill-local checks.

## Notes
- Local `npm audit --audit-level=high --registry=https://registry.npmjs.org` could not complete because this environment received `ECONNRESET` from the public npm audit endpoint. The same audit passed in GitHub Actions after the override patch.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Upgrade the app’s routing stack from <code>react-router-dom</code> to <code>react-router</code> and refresh the React import map so <code>App</code>, the page views, and shared navigation/link components keep working with the patched router. Bump <code>react</code>/<code>react-dom</code> and lockfile overrides to satisfy React Router 8 peer requirements and clear the remaining audit findings.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/325?tool=ast&topic=Audit+fixes>Audit fixes</a>
        </td><td>Patch the remaining dependency findings by overriding <code>brace-expansion</code> and <code>postcss</code> in the package metadata and lockfile.<details><summary>Modified files (2)</summary><ul><li>package-lock.json</li>
<li>package.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(deps): patch npm a...</td><td>July 30, 2026</td></tr>
<tr><td>github-actions[bot]</td><td>chore: update NVD/GHSA...</td><td>July 21, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/325?tool=ast&topic=Router+migration>Router migration</a>
        </td><td>Switch the app shell, shared links, and detail/setup pages from <code>react-router-dom</code> to <code>react-router</code>, and update the browser import map for the new router and React versions.<details><summary>Modified files (11)</summary><ul><li>App.tsx</li>
<li>components/AdvisoryCard.tsx</li>
<li>components/Header.tsx</li>
<li>components/SkillCard.tsx</li>
<li>index.html</li>
<li>package-lock.json</li>
<li>package.json</li>
<li>pages/AdvisoryDetail.tsx</li>
<li>pages/FeedSetup.tsx</li>
<li>pages/SkillDetail.tsx</li>
<li>pages/WikiBrowser.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(deps): patch npm a...</td><td>July 30, 2026</td></tr>
<tr><td>github-actions[bot]</td><td>chore: update NVD/GHSA...</td><td>July 21, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/325?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>