### PR TITLE
fix(deps): patch ClawHub undici alerts

### DIFF
--- a/.github/clawhub-cli/package-lock.json
+++ b/.github/clawhub-cli/package-lock.json
@@ -384,9 +384,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "engines": {
         "node": ">=20.18.1"
       }


### PR DESCRIPTION
# User description
## Summary
- Update `.github/clawhub-cli/package-lock.json` so the transitive `undici` dependency resolves to `7.29.0`.
- Keep the pinned `clawhub@0.7.0` package unchanged because its `undici` range already allows the patched version.
- Preserve `registry.npmjs.org` lockfile URLs for GitHub Actions, even though local validation uses the configured CodeArtifact proxy.

## Dependabot alerts addressed
- GHSA-4cwx-7wf7-3272 / CVE-2026-13697: patched by `undici@7.29.0`.
- GHSA-8xcm-r25x-g524 / CVE-2026-16728: patched by `undici@7.29.0`.
- GHSA-v3r7-h72x-cjcm / CVE-2026-16729: patched by `undici@7.29.0`.
- GHSA-jr45-8vmc-qm54 / CVE-2026-14643: patched by `undici@7.29.0`.
- GHSA-m8rv-5g2x-5cg5 / CVE-2026-15157: patched by `undici@7.29.0`.

## Validation
- Verified live Dependabot alerts through GitHub API before patching.
- `npm_config_cache=/private/tmp/clawsec-npm-cache npm view undici@7.29.0 version dist.tarball dist.integrity` passed through local CodeArtifact.
- `npm_config_cache=/private/tmp/clawsec-npm-cache npm ci --prefix .github/clawhub-cli --prefer-offline` passed through local CodeArtifact.
- `npm ls undici --prefix .github/clawhub-cli` shows `clawhub@0.7.0 -> undici@7.29.0`.
- `node scripts/test-skill-release-workflow.mjs` passed and confirms `.github/clawhub-cli/package-lock.json` keeps public npm resolved URLs.
- `git diff --check` passed.
- GitHub Actions: all PR checks passed, including `Dependency Audit`, CodeQL, Security Scan, TS/React lint on macOS/Ubuntu/Windows, Pages verify, and project tests.

## Notes
- Local `npm audit --prefix .github/clawhub-cli --audit-level=moderate --registry=https://registry.npmjs.org` could not complete because this environment received `ECONNRESET` from the public npm audit endpoint. The same public-npm audit path passed in GitHub Actions.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the ClawHub CLI dependency lockfile to resolve <code>undici</code> 7.29.0, addressing five Dependabot security alerts while keeping the pinned <code>clawhub@0.7.0</code> package unchanged. Preserve public npm tarball URLs and update the package integrity metadata for GitHub Actions compatibility.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(deps): patch clawh...</td><td>August 04, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(release): install ...</td><td>June 23, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/331?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>