### PR TITLE
fix(deps): patch js-yaml alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4225,9 +4225,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3097,9 +3097,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "brace-expansion": "5.0.9",
     "js-yaml": "4.3.1",
     "minimatch": "10.2.5",
+    "nanoid": "3.3.18",
     "picomatch": "4.0.4",
     "postcss": "8.5.25"
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ajv": "6.14.0",
     "balanced-match": "4.0.3",
     "brace-expansion": "5.0.9",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "minimatch": "10.2.5",
     "picomatch": "4.0.4",
     "postcss": "8.5.25"


### PR DESCRIPTION
# User description
## Summary
- Remediates Dependabot alert #45 / GHSA-5p4m-2wfm-xmqj by moving the root npm override for `js-yaml` from `4.3.0` to patched `4.3.1`.
- Updates the root `package-lock.json` to the matching public npm tarball URL and integrity metadata.
- Adds a `nanoid@3.3.18` override because GitHub Actions' dependency audit exposed GHSA-2v37-7h3g-55p8 after the `js-yaml` fix.
- Keeps committed lockfile URLs on `registry.npmjs.org` for GitHub Actions; local CodeArtifact is only for local resolution.

## Security benefit
- Addresses the high-severity `js-yaml` advisory for quadratic CPU consumption in `!!omap` resolution affecting `>= 4.0.0, < 4.3.1`.
- Keeps the PR's clean install/audit gate green by also patching the transitive `nanoid <3.3.18` finding from `postcss`.

## Testing
- `gh api repos/prompt-security/clawsec/dependabot/alerts/45` confirmed the live alert targets root `package-lock.json`, `js-yaml`, patched version `4.3.1`.
- `git diff --check`
- `npx tsc --noEmit`
- `npx eslint . --ext .ts,.tsx,.js,.jsx,.mjs --max-warnings 0`
- `npm run build`
- GitHub Actions on PR #343: all checks passed, including `Dependency Audit`, `Security Scan`, TypeScript/React lint on macOS/Ubuntu/Windows, CodeQL, advisory feed tests, suite verification, Hermes tests, OpenClaw watchdog tests, Python lint, shell lint, and Pages build verification.

## Local install note
- Local `npm view` / lockfile regeneration through CodeArtifact is currently blocked by expired auth (`E401`) and invalid AWS STS credentials.
- GitHub Actions ran a clean `npm ci` and public-registry `npm audit --audit-level=high --registry=https://registry.npmjs.org` successfully on this PR.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Patch the root npm overrides for <code>js-yaml</code> and <code>nanoid</code> to remediate security advisories and keep dependency audits passing. Update the package manifest and lockfile metadata to use the patched versions and public npm registry URLs.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/343?tool=ast&topic=js-yaml+Security+Fix>js-yaml Security Fix</a>
        </td><td>Patch <code>js-yaml</code> to 4.3.1 to address the quadratic CPU consumption advisory and update its lockfile resolution metadata.<details><summary>Modified files (2)</summary><ul><li>package-lock.json</li>
<li>package.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(deps): patch nanoi...</td><td>August 18, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>docs(readme): refresh ...</td><td>August 03, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/343?tool=ast&topic=nanoid+Security+Fix>nanoid Security Fix</a>
        </td><td>Override <code>nanoid</code> to 3.3.18 to remediate the transitive advisory discovered through <code>postcss</code> and maintain a clean audit.<details><summary>Modified files (2)</summary><ul><li>package-lock.json</li>
<li>package.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(deps): patch nanoi...</td><td>August 18, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>docs(readme): refresh ...</td><td>August 03, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/343?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>