### PR TITLE
fix(pages): back off production endpoint verification

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -431,4 +431,6 @@ jobs:
           node scripts/ci/advisory_pages_artifacts.mjs verify-url \
             --base-url https://clawsec.prompt.security \
             --attempts 12 \
-            --retry-delay-ms 10000
+            --retry-delay-ms 10000 \
+            --retry-backoff-factor 1.5 \
+            --max-retry-delay-ms 60000

--- a/scripts/ci/advisory_pages_artifacts.mjs
+++ b/scripts/ci/advisory_pages_artifacts.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 const CHECKSUM_ALIAS = "advisories/checksums.json";
 const CHECKSUM_SIGNATURE_ALIAS = "advisories/checksums.json.sig";
 const PUBLIC_KEY_ALIAS = "advisories/feed-signing-public.pem";
+const RELEASE_MIRROR_PROBE_PATH = "releases/latest/download/checksums.json";
 const DEFAULT_LIVE_ADVISORY_BASE_URL = "https://clawsec.prompt.security";
 
 export const ADVISORY_PUBLIC_CONTRACT = Object.freeze([
@@ -250,19 +251,27 @@ function endpointMismatchMessage(label, rootPath, aliasPath) {
   ].join("; ");
 }
 
-function normalizeBaseUrl(baseUrl) {
+function parseHttpBaseUrl(baseUrl) {
   try {
     const parsed = new URL(baseUrl);
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") throw new Error("unsupported protocol");
-    return parsed.origin;
+    return parsed;
   } catch {
     throw new Error("baseUrl must be a valid HTTP(S) URL");
   }
 }
 
+function normalizeBaseUrl(baseUrl) {
+  const parsed = parseHttpBaseUrl(baseUrl);
+  if (parsed.pathname !== "/") {
+    throw new Error("baseUrl must not include a path");
+  }
+  return parsed.origin;
+}
+
 function baseUrlForDiagnostics(baseUrl) {
   try {
-    return normalizeBaseUrl(baseUrl);
+    return parseHttpBaseUrl(baseUrl).origin;
   } catch {
     return "<invalid URL>";
   }
@@ -354,14 +363,10 @@ export async function smokeTestBuiltAdvisoryEndpoints({ distDir = "dist" } = {})
 }
 
 async function probeReleaseMirror(baseUrl) {
-  const probePath = "releases/latest/download/checksums.json";
-  const response = await globalThis.fetch(`${baseUrl.replace(/\/+$/, "")}/${probePath}`);
+  const response = await globalThis.fetch(`${baseUrl.replace(/\/+$/, "")}/${RELEASE_MIRROR_PROBE_PATH}`);
   if (response.ok) return true;
-  if (response.status === 404) {
-    process.stderr.write(`Release compatibility mirror is absent at /${probePath}; skipping mirror verification\n`);
-    return false;
-  }
-  throw new Error(`HTTP ${response.status} while probing /${probePath}`);
+  if (response.status === 404) return false;
+  throw new Error(`HTTP ${response.status} while probing /${RELEASE_MIRROR_PROBE_PATH}`);
 }
 
 export async function retryLiveAdvisoryEndpointVerification({
@@ -382,6 +387,18 @@ export async function retryLiveAdvisoryEndpointVerification({
   const initialDelayMs = Number(retryDelayMs);
   const backoffFactor = Number(retryBackoffFactor);
   const maxDelayMs = Number(maxRetryDelayMs);
+  if (!Number.isInteger(totalAttempts) || totalAttempts < 1) {
+    throw new Error("attempts must be a finite positive integer");
+  }
+  if (!Number.isFinite(initialDelayMs) || initialDelayMs < 0) {
+    throw new Error("retryDelayMs must be a finite non-negative number");
+  }
+  if (!Number.isFinite(backoffFactor) || backoffFactor < 1) {
+    throw new Error("retryBackoffFactor must be a finite number greater than or equal to 1");
+  }
+  if (!Number.isFinite(maxDelayMs) || maxDelayMs < 0) {
+    throw new Error("maxRetryDelayMs must be a finite non-negative number");
+  }
   for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {
     try {
       await verifyAttempt();
@@ -412,14 +429,26 @@ export async function retryLiveAdvisoryEndpointVerification({
 export async function verifyLiveAdvisoryEndpoints({
   baseUrl = DEFAULT_LIVE_ADVISORY_BASE_URL,
   includeGhsa = true,
+  writeStderr = (message) => process.stderr.write(message),
   ...retryOptions
 } = {}) {
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  let includeReleaseMirror = false;
   await retryLiveAdvisoryEndpointVerification({
     baseUrl: normalizedBaseUrl,
     ...retryOptions,
+    writeStderr,
     verifyAttempt: async () => {
-      const includeReleaseMirror = await probeReleaseMirror(normalizedBaseUrl);
+      const mirrorAvailable = await probeReleaseMirror(normalizedBaseUrl);
+      if (includeReleaseMirror && !mirrorAvailable) {
+        throw new Error("release compatibility mirror returned HTTP 404 after it was previously available");
+      }
+      if (!mirrorAvailable) {
+        writeStderr(
+          `Release compatibility mirror is absent at /${RELEASE_MIRROR_PROBE_PATH}; skipping mirror verification\n`,
+        );
+      }
+      includeReleaseMirror ||= mirrorAvailable;
       await verifyAdvisoryEndpoints({ baseUrl: normalizedBaseUrl, includeGhsa, includeReleaseMirror });
     },
   });

--- a/scripts/ci/advisory_pages_artifacts.mjs
+++ b/scripts/ci/advisory_pages_artifacts.mjs
@@ -231,8 +231,8 @@ async function stopServer(server) {
   await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
 }
 
-async function fetchArtifact(baseUrl, artifactPath, { fetchImpl = (url) => globalThis.fetch(url) } = {}) {
-  const response = await fetchImpl(`${baseUrl.replace(/\/+$/, "")}/${artifactPath}`);
+async function fetchArtifact(baseUrl, artifactPath) {
+  const response = await globalThis.fetch(`${baseUrl.replace(/\/+$/, "")}/${artifactPath}`);
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} for /${artifactPath}`);
   }
@@ -249,14 +249,14 @@ function endpointMismatchMessage(label, rootPath, aliasPath) {
   ].join("; ");
 }
 
-async function verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMirror, fetchImpl }) {
+async function verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMirror }) {
   const fetched = new Map();
   for (const artifactPath of ADVISORY_PUBLIC_CONTRACT) {
-    fetched.set(artifactPath, await fetchArtifact(baseUrl, artifactPath, { fetchImpl }));
+    fetched.set(artifactPath, await fetchArtifact(baseUrl, artifactPath));
   }
   if (includeGhsa) {
     for (const artifactPath of ["advisories/ghsa-without-cve.json", "advisories/ghsa-without-cve.json.sig"]) {
-      fetched.set(artifactPath, await fetchArtifact(baseUrl, artifactPath, { fetchImpl }));
+      fetched.set(artifactPath, await fetchArtifact(baseUrl, artifactPath));
     }
   }
 
@@ -310,8 +310,8 @@ async function verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMir
   if (includeReleaseMirror) {
     for (const [source, destination] of releaseMappings(includeGhsa)) {
       const [sourceArtifact, mirroredArtifact] = await Promise.all([
-        fetchArtifact(baseUrl, source, { fetchImpl }),
-        fetchArtifact(baseUrl, `releases/latest/download/${destination}`, { fetchImpl }),
+        fetchArtifact(baseUrl, source),
+        fetchArtifact(baseUrl, `releases/latest/download/${destination}`),
       ]);
       if (!sourceArtifact.body.equals(mirroredArtifact.body)) {
         throw new Error(`HTTP release mirror differs: ${destination}`);
@@ -334,31 +334,30 @@ export async function smokeTestBuiltAdvisoryEndpoints({ distDir = "dist" } = {})
   }
 }
 
-async function probeReleaseMirror(
-  baseUrl,
-  { fetchImpl = (url) => globalThis.fetch(url), writeStderr = (message) => process.stderr.write(message) } = {},
-) {
+async function probeReleaseMirror(baseUrl) {
   const probePath = "releases/latest/download/checksums.json";
-  const response = await fetchImpl(`${baseUrl.replace(/\/+$/, "")}/${probePath}`);
+  const response = await globalThis.fetch(`${baseUrl.replace(/\/+$/, "")}/${probePath}`);
   if (response.ok) return true;
   if (response.status === 404) {
-    writeStderr(`Release compatibility mirror is absent at /${probePath}; skipping mirror verification\n`);
+    process.stderr.write(`Release compatibility mirror is absent at /${probePath}; skipping mirror verification\n`);
     return false;
   }
   throw new Error(`HTTP ${response.status} while probing /${probePath}`);
 }
 
-export async function verifyLiveAdvisoryEndpoints({
+export async function retryLiveAdvisoryEndpointVerification({
   baseUrl = "https://clawsec.prompt.security",
+  verifyAttempt,
   attempts = 12,
   retryDelayMs = 10_000,
   retryBackoffFactor = 1.5,
   maxRetryDelayMs = 60_000,
-  includeGhsa = true,
-  fetchImpl = (url) => globalThis.fetch(url),
   sleep = (delayMs) => new Promise((resolve) => globalThis.setTimeout(resolve, delayMs)),
   writeStderr = (message) => process.stderr.write(message),
 } = {}) {
+  if (typeof verifyAttempt !== "function") {
+    throw new Error("verifyAttempt is required");
+  }
   let lastError;
   const totalAttempts = Number(attempts);
   const initialDelayMs = Number(retryDelayMs);
@@ -366,8 +365,7 @@ export async function verifyLiveAdvisoryEndpoints({
   const maxDelayMs = Number(maxRetryDelayMs);
   for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {
     try {
-      const includeReleaseMirror = await probeReleaseMirror(baseUrl, { fetchImpl, writeStderr });
-      await verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMirror, fetchImpl });
+      await verifyAttempt();
       return;
     } catch (error) {
       lastError = error;
@@ -389,6 +387,31 @@ export async function verifyLiveAdvisoryEndpoints({
       "to finish and rerun the job.",
     { cause: lastError },
   );
+}
+
+export async function verifyLiveAdvisoryEndpoints({
+  baseUrl = "https://clawsec.prompt.security",
+  attempts = 12,
+  retryDelayMs = 10_000,
+  retryBackoffFactor = 1.5,
+  maxRetryDelayMs = 60_000,
+  includeGhsa = true,
+  sleep,
+  writeStderr,
+} = {}) {
+  await retryLiveAdvisoryEndpointVerification({
+    baseUrl,
+    attempts,
+    retryDelayMs,
+    retryBackoffFactor,
+    maxRetryDelayMs,
+    sleep,
+    writeStderr,
+    verifyAttempt: async () => {
+      const includeReleaseMirror = await probeReleaseMirror(baseUrl);
+      await verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMirror });
+    },
+  });
 }
 
 function parseOptions(args) {

--- a/scripts/ci/advisory_pages_artifacts.mjs
+++ b/scripts/ci/advisory_pages_artifacts.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 const CHECKSUM_ALIAS = "advisories/checksums.json";
 const CHECKSUM_SIGNATURE_ALIAS = "advisories/checksums.json.sig";
 const PUBLIC_KEY_ALIAS = "advisories/feed-signing-public.pem";
+const DEFAULT_LIVE_ADVISORY_BASE_URL = "https://clawsec.prompt.security";
 
 export const ADVISORY_PUBLIC_CONTRACT = Object.freeze([
   "checksums.json",
@@ -346,7 +347,7 @@ async function probeReleaseMirror(baseUrl) {
 }
 
 export async function retryLiveAdvisoryEndpointVerification({
-  baseUrl = "https://clawsec.prompt.security",
+  baseUrl = DEFAULT_LIVE_ADVISORY_BASE_URL,
   verifyAttempt,
   attempts = 12,
   retryDelayMs = 10_000,
@@ -390,23 +391,13 @@ export async function retryLiveAdvisoryEndpointVerification({
 }
 
 export async function verifyLiveAdvisoryEndpoints({
-  baseUrl = "https://clawsec.prompt.security",
-  attempts = 12,
-  retryDelayMs = 10_000,
-  retryBackoffFactor = 1.5,
-  maxRetryDelayMs = 60_000,
+  baseUrl = DEFAULT_LIVE_ADVISORY_BASE_URL,
   includeGhsa = true,
-  sleep,
-  writeStderr,
+  ...retryOptions
 } = {}) {
   await retryLiveAdvisoryEndpointVerification({
     baseUrl,
-    attempts,
-    retryDelayMs,
-    retryBackoffFactor,
-    maxRetryDelayMs,
-    sleep,
-    writeStderr,
+    ...retryOptions,
     verifyAttempt: async () => {
       const includeReleaseMirror = await probeReleaseMirror(baseUrl);
       await verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMirror });

--- a/scripts/ci/advisory_pages_artifacts.mjs
+++ b/scripts/ci/advisory_pages_artifacts.mjs
@@ -250,6 +250,24 @@ function endpointMismatchMessage(label, rootPath, aliasPath) {
   ].join("; ");
 }
 
+function normalizeBaseUrl(baseUrl) {
+  try {
+    const parsed = new URL(baseUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") throw new Error("unsupported protocol");
+    return parsed.origin;
+  } catch {
+    throw new Error("baseUrl must be a valid HTTP(S) URL");
+  }
+}
+
+function baseUrlForDiagnostics(baseUrl) {
+  try {
+    return normalizeBaseUrl(baseUrl);
+  } catch {
+    return "<invalid URL>";
+  }
+}
+
 async function verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMirror }) {
   const fetched = new Map();
   for (const artifactPath of ADVISORY_PUBLIC_CONTRACT) {
@@ -381,8 +399,9 @@ export async function retryLiveAdvisoryEndpointVerification({
     }
   }
   const detail = lastError?.message || String(lastError);
+  const diagnosticBaseUrl = baseUrlForDiagnostics(baseUrl);
   throw new Error(
-    `Production advisory endpoint verification failed after ${totalAttempts} attempts for ${baseUrl}. ` +
+    `Production advisory endpoint verification failed after ${totalAttempts} attempts for ${diagnosticBaseUrl}. ` +
       `Final observed error: ${detail}. ` +
       "If this happened immediately after a successful Pages deploy, wait for GitHub Pages or CDN propagation " +
       "to finish and rerun the job.",
@@ -395,12 +414,13 @@ export async function verifyLiveAdvisoryEndpoints({
   includeGhsa = true,
   ...retryOptions
 } = {}) {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
   await retryLiveAdvisoryEndpointVerification({
-    baseUrl,
+    baseUrl: normalizedBaseUrl,
     ...retryOptions,
     verifyAttempt: async () => {
-      const includeReleaseMirror = await probeReleaseMirror(baseUrl);
-      await verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMirror });
+      const includeReleaseMirror = await probeReleaseMirror(normalizedBaseUrl);
+      await verifyAdvisoryEndpoints({ baseUrl: normalizedBaseUrl, includeGhsa, includeReleaseMirror });
     },
   });
 }
@@ -448,7 +468,9 @@ async function main() {
     process.stdout.write("Smoke-tested built advisory endpoints over HTTP\n");
   } else if (command === "verify-url") {
     await verifyLiveAdvisoryEndpoints(options);
-    process.stdout.write(`Verified deployed advisory endpoints at ${options.baseUrl}\n`);
+    process.stdout.write(
+      `Verified deployed advisory endpoints at ${baseUrlForDiagnostics(options.baseUrl ?? DEFAULT_LIVE_ADVISORY_BASE_URL)}\n`,
+    );
   } else {
     throw new Error(
       "usage: advisory_pages_artifacts.mjs <generate|publish-aliases|publish-release-mirror|verify-built|smoke-http|verify-url> [options]",

--- a/scripts/ci/advisory_pages_artifacts.mjs
+++ b/scripts/ci/advisory_pages_artifacts.mjs
@@ -231,8 +231,8 @@ async function stopServer(server) {
   await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
 }
 
-async function fetchArtifact(baseUrl, artifactPath) {
-  const response = await globalThis.fetch(`${baseUrl.replace(/\/+$/, "")}/${artifactPath}`);
+async function fetchArtifact(baseUrl, artifactPath, { fetchImpl = (url) => globalThis.fetch(url) } = {}) {
+  const response = await fetchImpl(`${baseUrl.replace(/\/+$/, "")}/${artifactPath}`);
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} for /${artifactPath}`);
   }
@@ -242,14 +242,21 @@ async function fetchArtifact(baseUrl, artifactPath) {
   };
 }
 
-async function verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMirror }) {
+function endpointMismatchMessage(label, rootPath, aliasPath) {
+  return [
+    `${label}: /${rootPath} and /${aliasPath} served different content`,
+    "this usually means GitHub Pages or CDN propagation is serving mixed deploy artifacts",
+  ].join("; ");
+}
+
+async function verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMirror, fetchImpl }) {
   const fetched = new Map();
   for (const artifactPath of ADVISORY_PUBLIC_CONTRACT) {
-    fetched.set(artifactPath, await fetchArtifact(baseUrl, artifactPath));
+    fetched.set(artifactPath, await fetchArtifact(baseUrl, artifactPath, { fetchImpl }));
   }
   if (includeGhsa) {
     for (const artifactPath of ["advisories/ghsa-without-cve.json", "advisories/ghsa-without-cve.json.sig"]) {
-      fetched.set(artifactPath, await fetchArtifact(baseUrl, artifactPath));
+      fetched.set(artifactPath, await fetchArtifact(baseUrl, artifactPath, { fetchImpl }));
     }
   }
 
@@ -290,17 +297,21 @@ async function verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMir
     );
   }
 
-  if (!checksums.equals(fetched.get(CHECKSUM_ALIAS).body)) throw new Error("HTTP checksum alias differs from root");
-  if (!checksumsSignature.equals(fetched.get(CHECKSUM_SIGNATURE_ALIAS).body)) {
-    throw new Error("HTTP checksum signature alias differs from root");
+  if (!checksums.equals(fetched.get(CHECKSUM_ALIAS).body)) {
+    throw new Error(endpointMismatchMessage("HTTP checksum alias mismatch", "checksums.json", CHECKSUM_ALIAS));
   }
-  if (!publicKey.equals(fetched.get(PUBLIC_KEY_ALIAS).body)) throw new Error("HTTP signing-key alias differs from root");
+  if (!checksumsSignature.equals(fetched.get(CHECKSUM_SIGNATURE_ALIAS).body)) {
+    throw new Error(endpointMismatchMessage("HTTP checksum signature alias mismatch", "checksums.sig", CHECKSUM_SIGNATURE_ALIAS));
+  }
+  if (!publicKey.equals(fetched.get(PUBLIC_KEY_ALIAS).body)) {
+    throw new Error(endpointMismatchMessage("HTTP signing-key alias mismatch", "signing-public.pem", PUBLIC_KEY_ALIAS));
+  }
 
   if (includeReleaseMirror) {
     for (const [source, destination] of releaseMappings(includeGhsa)) {
       const [sourceArtifact, mirroredArtifact] = await Promise.all([
-        fetchArtifact(baseUrl, source),
-        fetchArtifact(baseUrl, `releases/latest/download/${destination}`),
+        fetchArtifact(baseUrl, source, { fetchImpl }),
+        fetchArtifact(baseUrl, `releases/latest/download/${destination}`, { fetchImpl }),
       ]);
       if (!sourceArtifact.body.equals(mirroredArtifact.body)) {
         throw new Error(`HTTP release mirror differs: ${destination}`);
@@ -323,12 +334,15 @@ export async function smokeTestBuiltAdvisoryEndpoints({ distDir = "dist" } = {})
   }
 }
 
-async function probeReleaseMirror(baseUrl) {
+async function probeReleaseMirror(
+  baseUrl,
+  { fetchImpl = (url) => globalThis.fetch(url), writeStderr = (message) => process.stderr.write(message) } = {},
+) {
   const probePath = "releases/latest/download/checksums.json";
-  const response = await globalThis.fetch(`${baseUrl.replace(/\/+$/, "")}/${probePath}`);
+  const response = await fetchImpl(`${baseUrl.replace(/\/+$/, "")}/${probePath}`);
   if (response.ok) return true;
   if (response.status === 404) {
-    process.stderr.write(`Release compatibility mirror is absent at /${probePath}; skipping mirror verification\n`);
+    writeStderr(`Release compatibility mirror is absent at /${probePath}; skipping mirror verification\n`);
     return false;
   }
   throw new Error(`HTTP ${response.status} while probing /${probePath}`);
@@ -338,23 +352,43 @@ export async function verifyLiveAdvisoryEndpoints({
   baseUrl = "https://clawsec.prompt.security",
   attempts = 12,
   retryDelayMs = 10_000,
+  retryBackoffFactor = 1.5,
+  maxRetryDelayMs = 60_000,
   includeGhsa = true,
+  fetchImpl = (url) => globalThis.fetch(url),
+  sleep = (delayMs) => new Promise((resolve) => globalThis.setTimeout(resolve, delayMs)),
+  writeStderr = (message) => process.stderr.write(message),
 } = {}) {
   let lastError;
-  for (let attempt = 1; attempt <= Number(attempts); attempt += 1) {
+  const totalAttempts = Number(attempts);
+  const initialDelayMs = Number(retryDelayMs);
+  const backoffFactor = Number(retryBackoffFactor);
+  const maxDelayMs = Number(maxRetryDelayMs);
+  for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {
     try {
-      const includeReleaseMirror = await probeReleaseMirror(baseUrl);
-      await verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMirror });
+      const includeReleaseMirror = await probeReleaseMirror(baseUrl, { fetchImpl, writeStderr });
+      await verifyAdvisoryEndpoints({ baseUrl, includeGhsa, includeReleaseMirror, fetchImpl });
       return;
     } catch (error) {
       lastError = error;
-      if (attempt < Number(attempts)) {
-        process.stderr.write(`Production verification attempt ${attempt} failed: ${error.message}; retrying\n`);
-        await new Promise((resolve) => globalThis.setTimeout(resolve, Number(retryDelayMs)));
+      if (attempt < totalAttempts) {
+        const delayMs = Math.min(Math.round(initialDelayMs * (backoffFactor ** (attempt - 1))), maxDelayMs);
+        writeStderr(
+          `Production verification attempt ${attempt}/${totalAttempts} failed: ${error.message}; ` +
+            `waiting ${delayMs}ms before retry\n`,
+        );
+        await sleep(delayMs);
       }
     }
   }
-  throw lastError;
+  const detail = lastError?.message || String(lastError);
+  throw new Error(
+    `Production advisory endpoint verification failed after ${totalAttempts} attempts for ${baseUrl}. ` +
+      `Final observed error: ${detail}. ` +
+      "If this happened immediately after a successful Pages deploy, wait for GitHub Pages or CDN propagation " +
+      "to finish and rerun the job.",
+    { cause: lastError },
+  );
 }
 
 function parseOptions(args) {
@@ -372,6 +406,8 @@ function parseOptions(args) {
     else if (option === "--base-url") options.baseUrl = value;
     else if (option === "--attempts") options.attempts = Number(value);
     else if (option === "--retry-delay-ms") options.retryDelayMs = Number(value);
+    else if (option === "--retry-backoff-factor") options.retryBackoffFactor = Number(value);
+    else if (option === "--max-retry-delay-ms") options.maxRetryDelayMs = Number(value);
     else throw new Error(`unknown option: ${option}`);
     index += 1;
   }

--- a/scripts/test-deploy-pages-checksums.mjs
+++ b/scripts/test-deploy-pages-checksums.mjs
@@ -11,9 +11,9 @@ import {
   generateAdvisoryChecksums,
   publishAdvisoryAliases,
   publishReleaseCompatibilityMirror,
+  retryLiveAdvisoryEndpointVerification,
   smokeTestBuiltAdvisoryEndpoints,
   verifyBuiltAdvisoryArtifacts,
-  verifyLiveAdvisoryEndpoints,
 } from "./ci/advisory_pages_artifacts.mjs";
 
 const workflow = await fs.readFile(new URL("../.github/workflows/deploy-pages.yml", import.meta.url), "utf8");
@@ -176,107 +176,30 @@ assert.deepEqual(
   "release compatibility mirror must preserve the documented root and nested artifacts",
 );
 
-function sha256(content) {
-  return crypto.createHash("sha256").update(content).digest("hex");
-}
-
-function httpResponse(content, contentType = "text/plain", status = 200) {
-  const body = Buffer.from(content);
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    headers: {
-      get(name) {
-        return name.toLowerCase() === "content-type" ? contentType : "";
-      },
-    },
-    async arrayBuffer() {
-      return body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength);
-    },
-  };
-}
-
-function buildEndpointBodies({ aliasMismatch }) {
-  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
-  const sign = (content) => `${crypto.sign(null, Buffer.from(content), privateKey).toString("base64")}\n`;
-  const feedRaw = "{\"advisories\":[]}\n";
-  const feedSig = sign(feedRaw);
-  const manifestRaw = `${JSON.stringify(
-    {
-      schema_version: "1",
-      algorithm: "sha256",
-      version: "1.1.0",
-      generated_at: "2026-08-18T00:00:00Z",
-      repository: "prompt-security/clawsec-test",
-      files: {
-        "advisories/feed.json": {
-          sha256: sha256(feedRaw),
-          size: Buffer.byteLength(feedRaw),
-          path: "advisories/feed.json",
-          url: "https://clawsec.prompt.security/advisories/feed.json",
-        },
-        "advisories/feed.json.sig": {
-          sha256: sha256(feedSig),
-          size: Buffer.byteLength(feedSig),
-          path: "advisories/feed.json.sig",
-          url: "https://clawsec.prompt.security/advisories/feed.json.sig",
-        },
-      },
-    },
-    null,
-    2,
-  )}\n`;
-  const checksumsSig = sign(manifestRaw);
-  const publicKeyPem = publicKey.export({ type: "spki", format: "pem" });
-  return new Map([
-    ["checksums.json", manifestRaw],
-    ["checksums.sig", checksumsSig],
-    ["signing-public.pem", publicKeyPem],
-    ["advisories/feed.json", feedRaw],
-    ["advisories/feed.json.sig", feedSig],
-    ["advisories/checksums.json", aliasMismatch ? "stale checksum manifest\n" : manifestRaw],
-    ["advisories/checksums.json.sig", checksumsSig],
-    ["advisories/feed-signing-public.pem", publicKeyPem],
-  ]);
-}
-
-function createEndpointFetch({ mismatchedAttempts }) {
-  let verificationAttempt = 0;
-  const mismatchedBodies = buildEndpointBodies({ aliasMismatch: true });
-  const convergedBodies = buildEndpointBodies({ aliasMismatch: false });
+function createVerificationAttempt({ failuresBeforeSuccess, error = new Error("temporary endpoint mismatch") }) {
+  let attempts = 0;
   return {
     attempts() {
-      return verificationAttempt;
+      return attempts;
     },
-    async fetchImpl(url) {
-      const artifactPath = new URL(url).pathname.replace(/^\/+/, "");
-      if (artifactPath === "releases/latest/download/checksums.json") {
-        return httpResponse("missing\n", "text/plain", 404);
-      }
-      if (artifactPath === "checksums.json") {
-        verificationAttempt += 1;
-      }
-      const bodies = verificationAttempt <= mismatchedAttempts ? mismatchedBodies : convergedBodies;
-      const content = bodies.get(artifactPath);
-      if (content === undefined) return httpResponse("missing\n", "text/plain", 404);
-      const contentType = artifactPath.endsWith(".json") ? "application/json" : "text/plain";
-      return httpResponse(content, contentType);
+    async verifyAttempt() {
+      attempts += 1;
+      if (attempts <= failuresBeforeSuccess) throw error;
     },
   };
 }
 
 {
-  const endpoint = createEndpointFetch({ mismatchedAttempts: 2 });
+  const verification = createVerificationAttempt({ failuresBeforeSuccess: 2 });
   const delays = [];
   const logs = [];
-  await verifyLiveAdvisoryEndpoints({
+  await retryLiveAdvisoryEndpointVerification({
     baseUrl: "https://example.test",
+    verifyAttempt: verification.verifyAttempt,
     attempts: 3,
     retryDelayMs: 1000,
     retryBackoffFactor: 2,
     maxRetryDelayMs: 5000,
-    includeGhsa: false,
-    fetchImpl: endpoint.fetchImpl,
     sleep: async (delayMs) => {
       delays.push(delayMs);
     },
@@ -284,24 +207,27 @@ function createEndpointFetch({ mismatchedAttempts }) {
       logs.push(message);
     },
   });
-  assert.equal(endpoint.attempts(), 3, "temporary checksum alias drift must be retried until endpoints converge");
+  assert.equal(verification.attempts(), 3, "temporary production verification failures must be retried");
   assert.deepEqual(delays, [1000, 2000], "post-deploy retries must use exponential backoff");
   assert.match(logs.join(""), /waiting 1000ms before retry/, "retry logs must include the first backoff wait");
   assert.match(logs.join(""), /waiting 2000ms before retry/, "retry logs must include the second backoff wait");
 }
 
 {
-  const endpoint = createEndpointFetch({ mismatchedAttempts: 3 });
+  const mismatchError = new Error(
+    "HTTP checksum alias mismatch: /checksums.json and /advisories/checksums.json served different content; " +
+      "this usually means GitHub Pages or CDN propagation is serving mixed deploy artifacts",
+  );
+  const verification = createVerificationAttempt({ failuresBeforeSuccess: 3, error: mismatchError });
   const delays = [];
   await assert.rejects(
-    verifyLiveAdvisoryEndpoints({
+    retryLiveAdvisoryEndpointVerification({
       baseUrl: "https://example.test",
+      verifyAttempt: verification.verifyAttempt,
       attempts: 3,
       retryDelayMs: 1000,
       retryBackoffFactor: 2,
       maxRetryDelayMs: 5000,
-      includeGhsa: false,
-      fetchImpl: endpoint.fetchImpl,
       sleep: async (delayMs) => {
         delays.push(delayMs);
       },
@@ -312,10 +238,12 @@ function createEndpointFetch({ mismatchedAttempts }) {
       assert.match(error.message, /\/checksums\.json/);
       assert.match(error.message, /\/advisories\/checksums\.json/);
       assert.match(error.message, /GitHub Pages or CDN propagation/);
+      assert.equal(error.cause, mismatchError);
       return true;
     },
-    "persistent alias drift must fail with an actionable production propagation message",
+    "persistent production verification failures must keep the actionable propagation message",
   );
+  assert.equal(verification.attempts(), 3, "persistent production verification failures must use all attempts");
   assert.deepEqual(delays, [1000, 2000], "failed post-deploy retries must preserve exponential backoff");
 }
 

--- a/scripts/test-deploy-pages-checksums.mjs
+++ b/scripts/test-deploy-pages-checksums.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -190,6 +191,103 @@ function createVerificationAttempt({ failuresBeforeSuccess, error = new Error("t
   };
 }
 
+async function startArtifactFixtureServer(rootDir) {
+  const root = path.resolve(rootDir);
+  const server = http.createServer((request, response) => {
+    void (async () => {
+      const pathname = decodeURIComponent(new URL(request.url || "/", "http://127.0.0.1").pathname);
+      const filePath = path.resolve(root, pathname.replace(/^\/+/, ""));
+      if (filePath !== root && !filePath.startsWith(`${root}${path.sep}`)) {
+        response.writeHead(400).end("invalid path");
+        return;
+      }
+      const content = await fs.readFile(filePath);
+      response
+        .writeHead(200, { "content-type": filePath.endsWith(".json") ? "application/json" : "text/plain" })
+        .end(content);
+    })().catch((error) => {
+      response.writeHead(error?.code === "ENOENT" ? 404 : 500).end(error?.message || String(error));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("failed to start artifact fixture server");
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    async stop() {
+      await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    },
+  };
+}
+
+for (const { label, options, expectedMessage } of [
+  {
+    label: "NaN attempts",
+    options: { attempts: Number.NaN },
+    expectedMessage: /attempts must be a finite positive integer/,
+  },
+  {
+    label: "fractional attempts",
+    options: { attempts: 1.5 },
+    expectedMessage: /attempts must be a finite positive integer/,
+  },
+  {
+    label: "zero attempts",
+    options: { attempts: 0 },
+    expectedMessage: /attempts must be a finite positive integer/,
+  },
+  {
+    label: "negative retry delay",
+    options: { retryDelayMs: -1 },
+    expectedMessage: /retryDelayMs must be a finite non-negative number/,
+  },
+  {
+    label: "infinite retry delay",
+    options: { retryDelayMs: Number.POSITIVE_INFINITY },
+    expectedMessage: /retryDelayMs must be a finite non-negative number/,
+  },
+  {
+    label: "shrinking retry factor",
+    options: { retryBackoffFactor: 0.5 },
+    expectedMessage: /retryBackoffFactor must be a finite number greater than or equal to 1/,
+  },
+  {
+    label: "infinite retry factor",
+    options: { retryBackoffFactor: Number.POSITIVE_INFINITY },
+    expectedMessage: /retryBackoffFactor must be a finite number greater than or equal to 1/,
+  },
+  {
+    label: "negative retry cap",
+    options: { maxRetryDelayMs: -1 },
+    expectedMessage: /maxRetryDelayMs must be a finite non-negative number/,
+  },
+  {
+    label: "NaN retry cap",
+    options: { maxRetryDelayMs: Number.NaN },
+    expectedMessage: /maxRetryDelayMs must be a finite non-negative number/,
+  },
+]) {
+  let verificationAttempts = 0;
+  let sleepCalls = 0;
+  await assert.rejects(
+    retryLiveAdvisoryEndpointVerification({
+      baseUrl: "https://example.test",
+      verifyAttempt: async () => {
+        verificationAttempts += 1;
+      },
+      sleep: async () => {
+        sleepCalls += 1;
+      },
+      writeStderr: () => {},
+      ...options,
+    }),
+    expectedMessage,
+    `${label} must be rejected before verification starts`,
+  );
+  assert.equal(verificationAttempts, 0, `${label} must not run a verification attempt`);
+  assert.equal(sleepCalls, 0, `${label} must not schedule a retry timer`);
+}
+
 {
   const verification = createVerificationAttempt({ failuresBeforeSuccess: 2 });
   const delays = [];
@@ -285,6 +383,24 @@ function createVerificationAttempt({ failuresBeforeSuccess, error = new Error("t
   );
 }
 
+{
+  const pathPrefixedBaseUrl = "http://127.0.0.1:1/project-prefix?token=secret#fragment";
+  await assert.rejects(
+    verifyLiveAdvisoryEndpoints({
+      baseUrl: pathPrefixedBaseUrl,
+      attempts: 1,
+      retryDelayMs: 0,
+      writeStderr: () => {},
+    }),
+    (error) => {
+      assert.match(error.message, /baseUrl must not include a path/);
+      assert.doesNotMatch(error.message, /project-prefix|token=secret|fragment/);
+      return true;
+    },
+    "live verification must reject unsupported path-prefixed base URLs without exposing their contents",
+  );
+}
+
 const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "clawsec-pages-checksums-"));
 try {
   const publicDir = path.join(tempRoot, "public");
@@ -339,6 +455,87 @@ try {
   await fs.cp(publicDir, distDir, { recursive: true });
   await verifyBuiltAdvisoryArtifacts({ publicDir, distDir });
   await smokeTestBuiltAdvisoryEndpoints({ distDir });
+
+  const fixture = await startArtifactFixtureServer(distDir);
+  try {
+    const observedRequests = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input, init) => {
+      observedRequests.push(new URL(String(input)));
+      return originalFetch(input, init);
+    };
+    try {
+      const sensitiveBaseUrl =
+        fixture.origin.replace("://", "://ci-user:ci-password@") + "/?token=secret#fragment";
+      await verifyLiveAdvisoryEndpoints({
+        baseUrl: sensitiveBaseUrl,
+        attempts: 1,
+        retryDelayMs: 0,
+        includeGhsa: true,
+        writeStderr: () => {},
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const requestedPaths = observedRequests.map((requestUrl) => requestUrl.pathname);
+    assert.ok(
+      requestedPaths.includes("/releases/latest/download/checksums.json"),
+      "full live verification must probe the normalized release-mirror path",
+    );
+    assert.ok(requestedPaths.includes("/checksums.json"), "full live verification must request the root manifest");
+    assert.ok(
+      requestedPaths.includes("/advisories/checksums.json"),
+      "full live verification must request the checksum alias",
+    );
+    for (const requestUrl of observedRequests) {
+      assert.equal(requestUrl.origin, fixture.origin, "normalization must preserve the intended HTTP origin");
+      assert.equal(requestUrl.username, "", "normalized requests must not include a username");
+      assert.equal(requestUrl.password, "", "normalized requests must not include a password");
+      assert.equal(requestUrl.search, "", "normalized requests must not include a query string");
+      assert.equal(requestUrl.hash, "", "normalized requests must not include a fragment");
+    }
+
+    let mirrorChecksumRequests = 0;
+    let rootChecksumRequests = 0;
+    const retryLogs = [];
+    globalThis.fetch = async (input, init) => {
+      const requestUrl = new URL(String(input));
+      if (requestUrl.pathname === "/releases/latest/download/checksums.json") {
+        mirrorChecksumRequests += 1;
+        if (mirrorChecksumRequests === 2) return new Response("missing\n", { status: 404 });
+      }
+      if (requestUrl.pathname === "/checksums.json") {
+        rootChecksumRequests += 1;
+        if (rootChecksumRequests === 1) return new Response("temporarily unavailable\n", { status: 503 });
+      }
+      return originalFetch(input, init);
+    };
+    try {
+      await verifyLiveAdvisoryEndpoints({
+        baseUrl: fixture.origin,
+        attempts: 3,
+        retryDelayMs: 0,
+        retryBackoffFactor: 1,
+        maxRetryDelayMs: 0,
+        includeGhsa: true,
+        sleep: async () => {},
+        writeStderr: (message) => {
+          retryLogs.push(message);
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+    assert.equal(mirrorChecksumRequests, 4, "mirror verification must remain required after a transient 404");
+    assert.match(
+      retryLogs.join(""),
+      /release compatibility mirror returned HTTP 404 after it was previously available/,
+      "mirror propagation failures must explain why verification is still required",
+    );
+  } finally {
+    await fixture.stop();
+  }
 
   await fs.writeFile(path.join(distDir, "advisories/checksums.json"), "tampered\n");
   await assert.rejects(

--- a/scripts/test-deploy-pages-checksums.mjs
+++ b/scripts/test-deploy-pages-checksums.mjs
@@ -265,13 +265,13 @@ for (const [label, options, expectedMessage] of [
 }
 
 {
-  const verification = createVerificationAttempt({ failuresBeforeSuccess: 2 });
+  const verification = createVerificationAttempt({ failuresBeforeSuccess: 4 });
   const delays = [];
   const logs = [];
   await retryLiveAdvisoryEndpointVerification({
     baseUrl: "https://example.test",
     verifyAttempt: verification.verifyAttempt,
-    attempts: 3,
+    attempts: 5,
     retryDelayMs: 1000,
     retryBackoffFactor: 2,
     maxRetryDelayMs: 5000,
@@ -282,10 +282,11 @@ for (const [label, options, expectedMessage] of [
       logs.push(message);
     },
   });
-  assert.equal(verification.attempts(), 3, "temporary production verification failures must be retried");
-  assert.deepEqual(delays, [1000, 2000], "post-deploy retries must use exponential backoff");
+  assert.equal(verification.attempts(), 5, "temporary production verification failures must be retried");
+  assert.deepEqual(delays, [1000, 2000, 4000, 5000], "post-deploy retries must use capped exponential backoff");
   assert.match(logs.join(""), /waiting 1000ms before retry/, "retry logs must include the first backoff wait");
   assert.match(logs.join(""), /waiting 2000ms before retry/, "retry logs must include the second backoff wait");
+  assert.match(logs.join(""), /waiting 5000ms before retry/, "retry logs must include the capped backoff wait");
 }
 
 {

--- a/scripts/test-deploy-pages-checksums.mjs
+++ b/scripts/test-deploy-pages-checksums.mjs
@@ -14,6 +14,7 @@ import {
   retryLiveAdvisoryEndpointVerification,
   smokeTestBuiltAdvisoryEndpoints,
   verifyBuiltAdvisoryArtifacts,
+  verifyLiveAdvisoryEndpoints,
 } from "./ci/advisory_pages_artifacts.mjs";
 
 const workflow = await fs.readFile(new URL("../.github/workflows/deploy-pages.yml", import.meta.url), "utf8");
@@ -245,6 +246,43 @@ function createVerificationAttempt({ failuresBeforeSuccess, error = new Error("t
   );
   assert.equal(verification.attempts(), 3, "persistent production verification failures must use all attempts");
   assert.deepEqual(delays, [1000, 2000], "failed post-deploy retries must preserve exponential backoff");
+}
+
+{
+  const sensitiveBaseUrl = "https://ci-user:ci-password@example.test/private/path?token=secret#fragment";
+  await assert.rejects(
+    retryLiveAdvisoryEndpointVerification({
+      baseUrl: sensitiveBaseUrl,
+      verifyAttempt: async () => {
+        throw new Error("persistent endpoint mismatch");
+      },
+      attempts: 1,
+      writeStderr: () => {},
+    }),
+    (error) => {
+      assert.match(error.message, /for https:\/\/example\.test\./);
+      assert.doesNotMatch(error.message, /ci-user|ci-password|private\/path|token=secret|fragment/);
+      return true;
+    },
+    "production verification diagnostics must not expose URL credentials or request details",
+  );
+}
+
+{
+  const invalidBaseUrl = "not-a-url?token=secret#fragment";
+  await assert.rejects(
+    verifyLiveAdvisoryEndpoints({
+      baseUrl: invalidBaseUrl,
+      attempts: 1,
+      writeStderr: () => {},
+    }),
+    (error) => {
+      assert.match(error.message, /baseUrl must be a valid HTTP\(S\) URL/);
+      assert.doesNotMatch(error.message, /token=secret|fragment/);
+      return true;
+    },
+    "live verification must reject invalid base URLs without exposing their contents",
+  );
 }
 
 const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "clawsec-pages-checksums-"));

--- a/scripts/test-deploy-pages-checksums.mjs
+++ b/scripts/test-deploy-pages-checksums.mjs
@@ -220,52 +220,28 @@ async function startArtifactFixtureServer(rootDir) {
   };
 }
 
-for (const { label, options, expectedMessage } of [
-  {
-    label: "NaN attempts",
-    options: { attempts: Number.NaN },
-    expectedMessage: /attempts must be a finite positive integer/,
-  },
-  {
-    label: "fractional attempts",
-    options: { attempts: 1.5 },
-    expectedMessage: /attempts must be a finite positive integer/,
-  },
-  {
-    label: "zero attempts",
-    options: { attempts: 0 },
-    expectedMessage: /attempts must be a finite positive integer/,
-  },
-  {
-    label: "negative retry delay",
-    options: { retryDelayMs: -1 },
-    expectedMessage: /retryDelayMs must be a finite non-negative number/,
-  },
-  {
-    label: "infinite retry delay",
-    options: { retryDelayMs: Number.POSITIVE_INFINITY },
-    expectedMessage: /retryDelayMs must be a finite non-negative number/,
-  },
-  {
-    label: "shrinking retry factor",
-    options: { retryBackoffFactor: 0.5 },
-    expectedMessage: /retryBackoffFactor must be a finite number greater than or equal to 1/,
-  },
-  {
-    label: "infinite retry factor",
-    options: { retryBackoffFactor: Number.POSITIVE_INFINITY },
-    expectedMessage: /retryBackoffFactor must be a finite number greater than or equal to 1/,
-  },
-  {
-    label: "negative retry cap",
-    options: { maxRetryDelayMs: -1 },
-    expectedMessage: /maxRetryDelayMs must be a finite non-negative number/,
-  },
-  {
-    label: "NaN retry cap",
-    options: { maxRetryDelayMs: Number.NaN },
-    expectedMessage: /maxRetryDelayMs must be a finite non-negative number/,
-  },
+for (const [label, options, expectedMessage] of [
+  ["NaN attempts", { attempts: Number.NaN }, /attempts must be a finite positive integer/],
+  ["fractional attempts", { attempts: 1.5 }, /attempts must be a finite positive integer/],
+  ["zero attempts", { attempts: 0 }, /attempts must be a finite positive integer/],
+  ["negative retry delay", { retryDelayMs: -1 }, /retryDelayMs must be a finite non-negative number/],
+  [
+    "infinite retry delay",
+    { retryDelayMs: Number.POSITIVE_INFINITY },
+    /retryDelayMs must be a finite non-negative number/,
+  ],
+  [
+    "shrinking retry factor",
+    { retryBackoffFactor: 0.5 },
+    /retryBackoffFactor must be a finite number greater than or equal to 1/,
+  ],
+  [
+    "infinite retry factor",
+    { retryBackoffFactor: Number.POSITIVE_INFINITY },
+    /retryBackoffFactor must be a finite number greater than or equal to 1/,
+  ],
+  ["negative retry cap", { maxRetryDelayMs: -1 }, /maxRetryDelayMs must be a finite non-negative number/],
+  ["NaN retry cap", { maxRetryDelayMs: Number.NaN }, /maxRetryDelayMs must be a finite non-negative number/],
 ]) {
   let verificationAttempts = 0;
   let sleepCalls = 0;

--- a/scripts/test-deploy-pages-checksums.mjs
+++ b/scripts/test-deploy-pages-checksums.mjs
@@ -13,6 +13,7 @@ import {
   publishReleaseCompatibilityMirror,
   smokeTestBuiltAdvisoryEndpoints,
   verifyBuiltAdvisoryArtifacts,
+  verifyLiveAdvisoryEndpoints,
 } from "./ci/advisory_pages_artifacts.mjs";
 
 const workflow = await fs.readFile(new URL("../.github/workflows/deploy-pages.yml", import.meta.url), "utf8");
@@ -116,6 +117,16 @@ assert.match(
   /--base-url https:\/\/clawsec\.prompt\.security/,
   "post-deploy verification must target the production custom domain",
 );
+assert.match(
+  stepBody(workflow, "Verify deployed advisory endpoints"),
+  /--retry-backoff-factor 1\.5/,
+  "post-deploy verification must use exponential backoff for GitHub Pages propagation",
+);
+assert.match(
+  stepBody(workflow, "Verify deployed advisory endpoints"),
+  /--max-retry-delay-ms 60000/,
+  "post-deploy verification must cap retry backoff waits",
+);
 
 async function collectContractSources(entryPath) {
   const stat = await fs.stat(entryPath);
@@ -164,6 +175,149 @@ assert.deepEqual(
   ],
   "release compatibility mirror must preserve the documented root and nested artifacts",
 );
+
+function sha256(content) {
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+function httpResponse(content, contentType = "text/plain", status = 200) {
+  const body = Buffer.from(content);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get(name) {
+        return name.toLowerCase() === "content-type" ? contentType : "";
+      },
+    },
+    async arrayBuffer() {
+      return body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength);
+    },
+  };
+}
+
+function buildEndpointBodies({ aliasMismatch }) {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const sign = (content) => `${crypto.sign(null, Buffer.from(content), privateKey).toString("base64")}\n`;
+  const feedRaw = "{\"advisories\":[]}\n";
+  const feedSig = sign(feedRaw);
+  const manifestRaw = `${JSON.stringify(
+    {
+      schema_version: "1",
+      algorithm: "sha256",
+      version: "1.1.0",
+      generated_at: "2026-08-18T00:00:00Z",
+      repository: "prompt-security/clawsec-test",
+      files: {
+        "advisories/feed.json": {
+          sha256: sha256(feedRaw),
+          size: Buffer.byteLength(feedRaw),
+          path: "advisories/feed.json",
+          url: "https://clawsec.prompt.security/advisories/feed.json",
+        },
+        "advisories/feed.json.sig": {
+          sha256: sha256(feedSig),
+          size: Buffer.byteLength(feedSig),
+          path: "advisories/feed.json.sig",
+          url: "https://clawsec.prompt.security/advisories/feed.json.sig",
+        },
+      },
+    },
+    null,
+    2,
+  )}\n`;
+  const checksumsSig = sign(manifestRaw);
+  const publicKeyPem = publicKey.export({ type: "spki", format: "pem" });
+  return new Map([
+    ["checksums.json", manifestRaw],
+    ["checksums.sig", checksumsSig],
+    ["signing-public.pem", publicKeyPem],
+    ["advisories/feed.json", feedRaw],
+    ["advisories/feed.json.sig", feedSig],
+    ["advisories/checksums.json", aliasMismatch ? "stale checksum manifest\n" : manifestRaw],
+    ["advisories/checksums.json.sig", checksumsSig],
+    ["advisories/feed-signing-public.pem", publicKeyPem],
+  ]);
+}
+
+function createEndpointFetch({ mismatchedAttempts }) {
+  let verificationAttempt = 0;
+  const mismatchedBodies = buildEndpointBodies({ aliasMismatch: true });
+  const convergedBodies = buildEndpointBodies({ aliasMismatch: false });
+  return {
+    attempts() {
+      return verificationAttempt;
+    },
+    async fetchImpl(url) {
+      const artifactPath = new URL(url).pathname.replace(/^\/+/, "");
+      if (artifactPath === "releases/latest/download/checksums.json") {
+        return httpResponse("missing\n", "text/plain", 404);
+      }
+      if (artifactPath === "checksums.json") {
+        verificationAttempt += 1;
+      }
+      const bodies = verificationAttempt <= mismatchedAttempts ? mismatchedBodies : convergedBodies;
+      const content = bodies.get(artifactPath);
+      if (content === undefined) return httpResponse("missing\n", "text/plain", 404);
+      const contentType = artifactPath.endsWith(".json") ? "application/json" : "text/plain";
+      return httpResponse(content, contentType);
+    },
+  };
+}
+
+{
+  const endpoint = createEndpointFetch({ mismatchedAttempts: 2 });
+  const delays = [];
+  const logs = [];
+  await verifyLiveAdvisoryEndpoints({
+    baseUrl: "https://example.test",
+    attempts: 3,
+    retryDelayMs: 1000,
+    retryBackoffFactor: 2,
+    maxRetryDelayMs: 5000,
+    includeGhsa: false,
+    fetchImpl: endpoint.fetchImpl,
+    sleep: async (delayMs) => {
+      delays.push(delayMs);
+    },
+    writeStderr: (message) => {
+      logs.push(message);
+    },
+  });
+  assert.equal(endpoint.attempts(), 3, "temporary checksum alias drift must be retried until endpoints converge");
+  assert.deepEqual(delays, [1000, 2000], "post-deploy retries must use exponential backoff");
+  assert.match(logs.join(""), /waiting 1000ms before retry/, "retry logs must include the first backoff wait");
+  assert.match(logs.join(""), /waiting 2000ms before retry/, "retry logs must include the second backoff wait");
+}
+
+{
+  const endpoint = createEndpointFetch({ mismatchedAttempts: 3 });
+  const delays = [];
+  await assert.rejects(
+    verifyLiveAdvisoryEndpoints({
+      baseUrl: "https://example.test",
+      attempts: 3,
+      retryDelayMs: 1000,
+      retryBackoffFactor: 2,
+      maxRetryDelayMs: 5000,
+      includeGhsa: false,
+      fetchImpl: endpoint.fetchImpl,
+      sleep: async (delayMs) => {
+        delays.push(delayMs);
+      },
+      writeStderr: () => {},
+    }),
+    (error) => {
+      assert.match(error.message, /Production advisory endpoint verification failed after 3 attempts/);
+      assert.match(error.message, /\/checksums\.json/);
+      assert.match(error.message, /\/advisories\/checksums\.json/);
+      assert.match(error.message, /GitHub Pages or CDN propagation/);
+      return true;
+    },
+    "persistent alias drift must fail with an actionable production propagation message",
+  );
+  assert.deepEqual(delays, [1000, 2000], "failed post-deploy retries must preserve exponential backoff");
+}
 
 const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "clawsec-pages-checksums-"));
 try {

--- a/scripts/test-deploy-pages-checksums.mjs
+++ b/scripts/test-deploy-pages-checksums.mjs
@@ -479,11 +479,13 @@ try {
       const requestUrl = new URL(String(input));
       if (requestUrl.pathname === "/releases/latest/download/checksums.json") {
         mirrorChecksumRequests += 1;
-        if (mirrorChecksumRequests === 2) return new Response("missing\n", { status: 404 });
+        if (mirrorChecksumRequests === 2) return new globalThis.Response("missing\n", { status: 404 });
       }
       if (requestUrl.pathname === "/checksums.json") {
         rootChecksumRequests += 1;
-        if (rootChecksumRequests === 1) return new Response("temporarily unavailable\n", { status: 503 });
+        if (rootChecksumRequests === 1) {
+          return new globalThis.Response("temporarily unavailable\n", { status: 503 });
+        }
       }
       return originalFetch(input, init);
     };

--- a/wiki/i18n/translation-tracker.md
+++ b/wiki/i18n/translation-tracker.md
@@ -2,7 +2,7 @@
 
 Track translation coverage and freshness versus English source docs.
 
-_Last updated: 2026-08-02_
+_Last updated: 2026-08-18_
 
 ## README Coverage
 
@@ -44,6 +44,7 @@ The English matrix at `wiki/skill-feature-matrix.md` is canonical. Localized mat
 
 | Date | Changed pages | Translation impact |
 | --- | --- | --- |
+| 2026-08-18 | `wiki/workflow.md` | Documented PR-local Pages validation and post-deploy production endpoint verification, including retry/backoff behavior and trigger scope. Translation refresh pending. |
 | 2026-06-14 | `wiki/workflow.md`, `wiki/modules/automation-release.md`, `wiki/security-signing-runbook.md`, `wiki/dependencies.md`, `wiki/glossary.md` | Added SkillSpector release-pipeline documentation, signed-report behavior, and PR comment behavior. Translation refresh pending. |
 
 ## Wiki Coverage (KO)

--- a/wiki/workflow.md
+++ b/wiki/workflow.md
@@ -12,13 +12,27 @@
 ## Primary Workflow Map
 | Workflow | Trigger | Main Steps |
 | --- | --- | --- |
-| CI | PR/push to `main` | Lint, typecheck, build, Python checks, security scans, skill tests. |
+| CI | PRs to `main` + manual dispatch | Lint, typecheck, build, Python checks, security scans, skill tests. |
 | Pages Verify | PRs to `main` | Build Pages artifact and validate signing outputs (no publish). |
 | Poll NVD CVEs | Daily cron + manual dispatch | Fetch CVEs, transform/dedupe, update feed, sign artifacts, PR changes. |
 | Process Community Advisory | Issue label `advisory-approved` | Parse issue form, create advisory, sign feed, open PR, comment issue. |
 | Skill Release | Skill tags + metadata PR changes | PR: version-parity + dry-run checks; tags: package/sign/publish release assets. |
-| Deploy Pages | Successful CI/Release or manual dispatch | Discover releases, mirror assets, sign public advisories/checksums, deploy site. |
+| Deploy Pages | Push to `main` + successful non-PR Skill Release + manual dispatch | Discover releases, mirror assets, sign public advisories/checksums, deploy site. |
 | Sync Wiki | Pushes to `main` touching `wiki/**` + manual dispatch | Sync `wiki/` into `<repo>.wiki.git` and generate `Home.md` from `INDEX.md`. |
+
+## Pages Validation Layers
+
+Pages advisory validation runs at three different stages:
+
+| Layer | Trigger | Validation scope |
+| --- | --- | --- |
+| Deploy Pages Advisory Checksums Tests | Every CI run for a PR to `main`, or a manual CI dispatch | Runs `scripts/test-deploy-pages-checksums.mjs` against local fixtures and generated artifacts. It covers artifact contracts, workflow wiring, retry timing, backoff, and final error reporting without contacting production. |
+| Pages Verify | Every PR to `main` | Uses an ephemeral signing key to build the production-shaped Pages artifact, verifies copied files and aliases, and smoke-tests the built endpoints locally. It does not publish or contact the production site. |
+| Verify Production Advisory Endpoints | After every successful Pages deployment | Requests the real custom-domain endpoints and verifies that root files, advisory aliases, signatures, signing keys, and the available release mirror agree. |
+
+The production check runs after deployments triggered by a push to `main`, a successful non-PR Skill Release, or a manual dispatch. It is not limited by changed paths because every Pages deployment can temporarily expose mixed artifacts while GitHub Pages or its CDN propagates the new deployment.
+
+Production verification makes up to 12 attempts. The first attempt is immediate; the first retry waits 10 seconds, later waits use a 1.5 exponential backoff factor, and each wait is capped at 60 seconds. A persistent mismatch fails with the final observed endpoint error and guidance to rerun after Pages or CDN propagation completes.
 
 ## Local Operator Workflow
 | Step | Command | Outcome |


### PR DESCRIPTION
# User description
## Summary
- add exponential backoff support to the live advisory endpoint verifier
- make root/alias mismatch failures name the inconsistent paths and explain likely GitHub Pages/CDN propagation
- configure the Pages production verification job to use capped backoff
- add regression coverage for transient alias drift, persistent propagation failure messaging, and workflow backoff flags

## Root cause
Run 32131503007 built and deployed successfully, then failed in `Verify Production Advisory Endpoints` while GitHub Pages served mixed versions of `/checksums.json` and `/advisories/checksums.json`. The previous verifier retried with a fixed delay and ended with a terse alias mismatch message.

## Testing
- `node scripts/test-deploy-pages-checksums.mjs` *(passes with local loopback allowed; the existing smoke test binds 127.0.0.1)*
- `node --check scripts/ci/advisory_pages_artifacts.mjs`
- `node --check scripts/test-deploy-pages-checksums.mjs`
- `git diff --check`
- `node scripts/ci/advisory_pages_artifacts.mjs verify-url --base-url https://clawsec.prompt.security --attempts 1 --retry-delay-ms 0`

## Not run locally
- `npx eslint . --ext .ts,.tsx,.js,.jsx,.mjs --max-warnings 0`
- `npx tsc --noEmit`
- `npm run build`

These require installing npm dependencies. Local `npm ci` reached CodeArtifact but failed because the configured AWS credentials/token are invalid (`UnrecognizedClientException` / npm `E401`). GitHub Actions should provide the dependency-backed validation.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add capped exponential backoff to <code>verifyLiveAdvisoryEndpoints</code> and configure production Pages verification to tolerate GitHub Pages/CDN propagation delays. Improve alias mismatch and final failure diagnostics, while expanding regression coverage and documenting Pages validation layers and triggers.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/344?tool=ast&topic=Production+verification>Production verification</a>
        </td><td>Configure live advisory endpoint verification to retry with capped exponential backoff, preserve release-mirror validation across transient drift, and report inconsistent paths plus propagation guidance.<details><summary>Modified files (3)</summary><ul><li>.github/workflows/deploy-pages.yml</li>
<li>scripts/ci/advisory_pages_artifacts.mjs</li>
<li>scripts/test-deploy-pages-checksums.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>test(pages): cover ret...</td><td>August 19, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(advisories): publi...</td><td>July 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/344?tool=ast&topic=Pages+validation+docs>Pages validation docs</a>
        </td><td>Document Pages workflow triggers and distinguish local artifact checks, PR verification, and post-deployment production endpoint validation, including retry behavior.<details><summary>Modified files (2)</summary><ul><li>wiki/i18n/translation-tracker.md</li>
<li>wiki/workflow.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>docs(workflow): docume...</td><td>August 18, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>docs(readme): refresh ...</td><td>August 03, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/344?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>