### PR TITLE
fix(pages): derive filter state instead of setting it in effects

### DIFF
--- a/pages/FeedSetup.tsx
+++ b/pages/FeedSetup.tsx
@@ -125,10 +125,6 @@ export const FeedSetup: React.FC = () => {
     [advisories, selectedSeverity, selectedPlatform],
   );
 
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [advisories, selectedSeverity, selectedPlatform]);
-
   const formatDate = (dateStr: string) => {
     try {
       return new Date(dateStr).toLocaleDateString('en-US', {
@@ -171,12 +167,18 @@ export const FeedSetup: React.FC = () => {
         <FilterTabs
           tabs={SEVERITY_TABS}
           selected={selectedSeverity}
-          onSelect={(value) => setSelectedSeverity(value as SeverityFilter)}
+          onSelect={(value) => {
+            setSelectedSeverity(value as SeverityFilter);
+            setCurrentPage(1);
+          }}
         />
         <FilterTabs
           tabs={PLATFORM_TABS}
           selected={selectedPlatform}
-          onSelect={(value) => setSelectedPlatform(value as AdvisoryPlatformFilter)}
+          onSelect={(value) => {
+            setSelectedPlatform(value as AdvisoryPlatformFilter);
+            setCurrentPage(1);
+          }}
         />
 
         {loading ? (

--- a/pages/SkillsCatalog.tsx
+++ b/pages/SkillsCatalog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Search as _Search, Filter as _Filter, Package, Sparkles, FileText, GitFork } from 'lucide-react';
 import { SkillCard } from '../components/SkillCard';
 import { Footer } from '../components/Footer';
@@ -27,7 +27,6 @@ const parseSkillsIndex = (raw: string): SkillsIndex | null => {
 
 export const SkillsCatalog: React.FC = () => {
   const [skills, setSkills] = useState<SkillMetadata[]>([]);
-  const [filteredSkills, setFilteredSkills] = useState<SkillMetadata[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [searchTerm, _setSearchTerm] = useState('');
@@ -43,7 +42,6 @@ export const SkillsCatalog: React.FC = () => {
         // Missing index file is a valid "empty catalog" state.
         if (response.status === 404) {
           setSkills([]);
-          setFilteredSkills([]);
           return;
         }
 
@@ -57,7 +55,6 @@ export const SkillsCatalog: React.FC = () => {
         // Some SPA setups return index.html with 200 for missing JSON files.
         if (!raw.trim() || contentType.includes('text/html') || isProbablyHtmlDocument(raw)) {
           setSkills([]);
-          setFilteredSkills([]);
           return;
         }
 
@@ -67,7 +64,6 @@ export const SkillsCatalog: React.FC = () => {
         }
 
         setSkills(data.skills);
-        setFilteredSkills(data.skills);
       } catch (err) {
         console.error('Failed to load skills index:', err);
         setError('Failed to load skills catalog');
@@ -79,7 +75,7 @@ export const SkillsCatalog: React.FC = () => {
     fetchSkills();
   }, []);
 
-  useEffect(() => {
+  const filteredSkills = useMemo(() => {
     let result = skills;
 
     // Apply search filter
@@ -97,7 +93,7 @@ export const SkillsCatalog: React.FC = () => {
       result = result.filter((skill) => skill.category === categoryFilter);
     }
 
-    setFilteredSkills(result);
+    return result;
   }, [searchTerm, categoryFilter, skills]);
 
   // Get unique categories from skills (used in commented filter UI)


### PR DESCRIPTION
# User description
Unblocks #222 (`eslint-plugin-react-hooks` 7.0.1 → 7.1.1).

## Why #222 fails

Nothing is wrong with the bump itself. 7.1.0 shipped ["improved `set-state-in-effect` validation with fewer false negatives"](https://github.com/facebook/react/releases), and the stricter rule catches two **pre-existing** violations that 7.0.1 missed:

```
pages/FeedSetup.tsx:129:5      setCurrentPage(1)      react-hooks/set-state-in-effect
pages/SkillsCatalog.tsx:100:5  setFilteredSkills(...) react-hooks/set-state-in-effect
```

`Lint TypeScript/React` fails on all three runners; every other check on #222 is green. Both violations are the classic ["you might not need an effect"](https://react.dev/learn/you-might-not-need-an-effect) pattern, so this fixes the code rather than pinning or suppressing the rule.

## Changes

**`pages/SkillsCatalog.tsx`** — `filteredSkills` was a `useState` mirrored from `skills` by an effect that re-filtered on every change. It is pure derived state, so it is now a `useMemo`. The redundant `setFilteredSkills` calls in the fetch effect go away with it.

**`pages/FeedSetup.tsx`** — the page reset ran in an effect keyed on `[advisories, selectedSeverity, selectedPlatform]`. It now resets in the two filter `onSelect` handlers. The `advisories` dependency was already inert: the feed resolves once while `loading` is true and the pagination controls are unmounted, so `currentPage` is necessarily 1 at that point.

No behavior change, and no `eslint-disable`.

## Verification

Ran locally against **both** plugin versions, since this lands before the bump:

| Check | 7.0.1 (current `main`) | 7.1.1 (after #222) |
|---|---|---|
| `eslint --max-warnings 0` | pass | pass |
| `tsc --noEmit` | pass | pass |
| `npm run build` | pass | pass |
| 3 × `*.test.mjs` (16 / 8 / 3 assertions) | pass | pass |

The 7.1.1 run used the same tarball dependabot resolved (integrity `sha512-f2I7Gw6Jb…`).

This PR carries **no dependency changes** — dependabot keeps ownership of the lockfile. Once this merges, #222 rebases onto `main` and its lint job goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Derive skill catalog results with <code>useMemo</code> and move feed pagination resets into filter selection handlers. Update <code>SkillsCatalog</code> and <code>FeedSetup</code> to avoid state updates inside effects while preserving filtering and pagination behavior.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/347?tool=ast&topic=Feed+Pagination>Feed Pagination</a>
        </td><td>Reset feed pagination directly when severity or platform filters change, replacing the effect-based <code>setCurrentPage</code> update.<details><summary>Modified files (1)</summary><ul><li>pages/FeedSetup.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(pages): derive fil...</td><td>August 20, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(deps): resolve rea...</td><td>August 02, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/347?tool=ast&topic=Skill+Filtering>Skill Filtering</a>
        </td><td>Derive filtered skills from catalog data and active search/category filters with <code>useMemo</code>, removing redundant synchronization state updates during fetching.<details><summary>Modified files (1)</summary><ul><li>pages/SkillsCatalog.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(pages): derive fil...</td><td>August 20, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>feat: enhance support ...</td><td>February 25, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/347?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>