### PR TITLE
feat(security): add TruffleHog secret scanning

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,15 +17,19 @@
 
 set -euo pipefail
 
+# Before the tool check, not after: the guard below advertises this bypass in
+# its own error text, so testing it second made the advertised escape hatch
+# unreachable -- a machine without gitleaks could not commit at all. pre-push
+# has always had this order.
+if [[ "${CLAWSEC_SKIP_SECRET_SCAN:-0}" == "1" ]]; then
+  echo "pre-commit: secret scan skipped (CLAWSEC_SKIP_SECRET_SCAN=1)" >&2
+  exit 0
+fi
+
 if ! command -v gitleaks >/dev/null 2>&1; then
   echo "pre-commit: gitleaks not found; secrets were NOT checked." >&2
   echo "  brew install gitleaks   (or CLAWSEC_SKIP_SECRET_SCAN=1 to skip)" >&2
   exit 1
-fi
-
-if [[ "${CLAWSEC_SKIP_SECRET_SCAN:-0}" == "1" ]]; then
-  echo "pre-commit: secret scan skipped (CLAWSEC_SKIP_SECRET_SCAN=1)" >&2
-  exit 0
 fi
 
 exec gitleaks protect --staged --redact --no-banner

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Block secrets before they enter git history.
+#
+# gitleaks rather than trufflehog, for two reasons. Staged content is not in
+# git yet, and `trufflehog git file://.` only reads committed objects -- it
+# reports nothing for a staged key (verified). And trufflehog only emits a
+# PrivateKey finding when it can verify the key against a provider, so an
+# unverifiable one -- exactly the shape of CLAWSEC_SIGNING_PRIVATE_KEY --
+# produces no output at all. `gitleaks protect --staged` reads the staged blobs
+# and matches on pattern, so it catches both.
+#
+# TruffleHog runs in CI, where it does what it is good at: verifying candidate
+# credentials against the provider.
+#
+# Bypass: git commit --no-verify   (inherent to git; CI is the backstop)
+
+set -euo pipefail
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "pre-commit: gitleaks not found; secrets were NOT checked." >&2
+  echo "  brew install gitleaks   (or CLAWSEC_SKIP_SECRET_SCAN=1 to skip)" >&2
+  exit 1
+fi
+
+if [[ "${CLAWSEC_SKIP_SECRET_SCAN:-0}" == "1" ]]; then
+  echo "pre-commit: secret scan skipped (CLAWSEC_SKIP_SECRET_SCAN=1)" >&2
+  exit 0
+fi
+
+exec gitleaks protect --staged --redact --no-banner

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Last local gate before commits leave the machine. Backstop for
+# `git commit --no-verify` and for anything committed before the hooks were on.
+#
+# Both scanners run, because they fail in opposite directions:
+#   gitleaks   matches patterns offline -- catches private keys, which
+#              trufflehog cannot report at all (it only emits a PrivateKey
+#              finding for a key it can verify against a provider).
+#   trufflehog runs its detector set and, with `unverified` in --results,
+#              reports a credential whether or not it is still live.
+#
+# Dead or alive is deliberate: a rotated key is still a leak, and CI's
+# --results=verified,unknown would let it through. What makes that usable is
+# scanning only the commits being pushed. The same filter over full history
+# reports 140 findings on this repo -- the advisory feed cites upstream fix
+# commits as 40-char hex SHAs, which read as legacy GitHub PATs -- versus 0
+# for an ordinary push range.
+#
+# git passes <remote-name> <remote-url> as arguments and the ref updates on
+# stdin as "<local-ref> <local-sha> <remote-ref> <remote-sha>".
+#
+# Bypass:  git push --no-verify        (inherent to git; CI is the backstop)
+#          CLAWSEC_SKIP_SECRET_SCAN=1  skip both
+#          CLAWSEC_SKIP_TRUFFLEHOG=1   skip only trufflehog (it is the slow,
+#                                      network-bound one: ~5s vs ~0.3s)
+
+set -euo pipefail
+
+[[ "${CLAWSEC_SKIP_SECRET_SCAN:-0}" == "1" ]] && { echo "pre-push: secret scan skipped" >&2; exit 0; }
+
+command -v gitleaks >/dev/null 2>&1 || {
+  echo "pre-push: gitleaks not found; secrets were NOT checked." >&2
+  echo "  brew install gitleaks   (or CLAWSEC_SKIP_SECRET_SCAN=1 to skip)" >&2
+  exit 1
+}
+
+status=0
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [[ -n "${local_sha:-}" ]] || continue
+  [[ "$local_sha" =~ ^0+$ ]] && continue          # branch deletion pushes nothing
+
+  # Which commits are new to the remote. For a brand-new branch there is no
+  # remote sha, so ask git for everything not already on some remote.
+  if [[ "$remote_sha" =~ ^0+$ ]]; then
+    range_opts=("$local_sha" --not --remotes)
+    base="$(git rev-list "$local_sha" --not --remotes | tail -n 1)"
+    base="$(git rev-parse -q --verify "${base}^" 2>/dev/null || true)"
+  else
+    range_opts=("${remote_sha}..${local_sha}")
+    base="$remote_sha"
+  fi
+
+  git rev-list "${range_opts[@]}" | grep -q . || continue   # nothing new
+
+  gitleaks git --redact --no-banner --log-opts="${range_opts[*]}" || status=1
+
+  if [[ "${CLAWSEC_SKIP_TRUFFLEHOG:-0}" != "1" ]] && command -v trufflehog >/dev/null 2>&1; then
+    th=(git "file://$(git rev-parse --show-toplevel)")
+    th+=("--results=verified,unknown,unverified" --fail --no-update)
+    [[ -n "$base" ]] && th+=(--since-commit "$base")
+    trufflehog "${th[@]}" || status=1
+  fi
+done
+
+if [[ "$status" -ne 0 ]]; then
+  echo "" >&2
+  echo "pre-push: secrets detected in the commits you are pushing." >&2
+  echo "  Rotate the credential first -- removing it from git does not un-leak it." >&2
+  echo "  Suppress a genuine false positive with 'trufflehog:ignore' or" >&2
+  echo "  'gitleaks:allow' on the line, never a blanket rule." >&2
+fi
+exit "$status"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,10 @@ jobs:
   secret-scan:
     name: Secret Scan
     runs-on: ubuntu-latest
+    # Narrower than the workflow-wide read-all: this job runs third-party
+    # scanners over untrusted PR content and needs nothing but the checkout.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -102,7 +106,7 @@ jobs:
       # read as legacy GitHub PATs -- but a range scan sees only the diff, so an
       # ordinary PR reports 0.
       - name: TruffleHog
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@20652fbbdefffcdaa493a5bf57ab2ac6b1db715b # v3.97.1
         with:
           extra_args: --results=verified,unknown,unverified
       # Private keys and other deterministic patterns. TruffleHog only emits a
@@ -111,15 +115,30 @@ jobs:
       # produces no output at all. gitleaks matches on pattern and catches it.
       # Scoped to the PR range: pre-existing test fixtures on main are not this
       # PR's problem, and scanning the range is what a contributor can act on.
+      #
+      # Pinned by digest, not tag: a retagged image would change what this gate
+      # does with no commit to review. The other actions here are SHA-pinned for
+      # the same reason.
+      #
+      # workflow_dispatch has no pull_request payload, so it gets an explicit
+      # range instead of being skipped -- skipping left manual runs with no
+      # private-key detection at all, which is the one thing gitleaks is here
+      # for.
       - name: Gitleaks
-        if: github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          IMAGE: zricethezav/gitleaks@sha256:105ac66a57b2bb8afb61a3b8a5dcc4817773d03724a7e8a515214cfe58225556
         run: |
+          if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
+            RANGE="$BASE_SHA..$HEAD_SHA"
+          else
+            git fetch -q --no-tags origin "${GITHUB_BASE_REF:-main}"
+            RANGE="origin/${GITHUB_BASE_REF:-main}..HEAD"
+          fi
+          echo "scanning $RANGE"
           docker run --rm -v "$PWD:/repo" -w /repo \
-            zricethezav/gitleaks:v8.30.0 git --redact --no-banner \
-            --log-opts="$BASE_SHA..$HEAD_SHA"
+            "$IMAGE" git --redact --no-banner --log-opts="$RANGE"
 
   dependency-audit:
     name: Dependency Audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,12 @@ jobs:
         with:
           scandir: './scripts'
           severity: warning
+      - name: ShellCheck git hooks
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
+        with:
+          scandir: './.githooks'
+          additional_files: 'pre-commit'
+          severity: warning
 
   security-scan:
     name: Security Scan
@@ -77,6 +83,37 @@ jobs:
           scan-ref: '.'
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
+
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # TruffleHog needs both sides of the range it is asked to diff.
+          fetch-depth: 0
+      # Live credentials. TruffleHog verifies candidates against the provider,
+      # so --results=verified,unknown reports what is live (or unreachable) and
+      # drops the merely secret-shaped -- 140 findings on this repo become 2.
+      - name: TruffleHog
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --results=verified,unknown
+      # Private keys and other deterministic patterns. TruffleHog only emits a
+      # PrivateKey finding when it can verify the key against a provider, so an
+      # unverifiable one -- exactly the shape of CLAWSEC_SIGNING_PRIVATE_KEY --
+      # produces no output at all. gitleaks matches on pattern and catches it.
+      # Scoped to the PR range: pre-existing test fixtures on main are not this
+      # PR's problem, and scanning the range is what a contributor can act on.
+      - name: Gitleaks
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          docker run --rm -v "$PWD:/repo" -w /repo \
+            zricethezav/gitleaks:v8.30.0 git --redact --no-banner \
+            --log-opts="$BASE_SHA..$HEAD_SHA"
 
   dependency-audit:
     name: Dependency Audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           scandir: './.githooks'
-          additional_files: 'pre-commit'
+          additional_files: 'pre-commit pre-push'
           severity: warning
 
   security-scan:
@@ -92,13 +92,19 @@ jobs:
         with:
           # TruffleHog needs both sides of the range it is asked to diff.
           fetch-depth: 0
-      # Live credentials. TruffleHog verifies candidates against the provider,
-      # so --results=verified,unknown reports what is live (or unreachable) and
-      # drops the merely secret-shaped -- 140 findings on this repo become 2.
+      # Dead or alive: `unverified` is included deliberately, so a rotated or
+      # already-dead credential still fails. It is the same policy as
+      # .githooks/pre-push, so the local gate and CI cannot disagree.
+      #
+      # What keeps that usable is that the Action scans the PR range, not the
+      # whole repo. Over full history this filter reports 140 findings here --
+      # the advisory feed cites upstream fix commits as 40-char hex SHAs, which
+      # read as legacy GitHub PATs -- but a range scan sees only the diff, so an
+      # ordinary PR reports 0.
       - name: TruffleHog
         uses: trufflesecurity/trufflehog@main
         with:
-          extra_args: --results=verified,unknown
+          extra_args: --results=verified,unknown,unverified
       # Private keys and other deterministic patterns. TruffleHog only emits a
       # PrivateKey finding when it can verify the key against a provider, so an
       # unverifiable one -- exactly the shape of CLAWSEC_SIGNING_PRIVATE_KEY --

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,9 @@ source .venv/bin/activate
 uv pip install ruff bandit   # linters configured in pyproject.toml
 ```
 
-Required tools: Node 20+, Python 3.10+, openssl, jq, shellcheck, trufflehog
-(`brew install shellcheck trufflehog`).
+Required tools: Node 20+, Python 3.10+, openssl, jq, shellcheck, gitleaks,
+trufflehog (`brew install shellcheck gitleaks trufflehog`). The pre-commit hook
+exits 1 without gitleaks.
 
 `npm install` points `core.hooksPath` at `.githooks/` via the `prepare` script,
 which enables the secret-scanning pre-commit hook. See **Secret Scanning** below.
@@ -158,6 +159,16 @@ or `--exclude-paths` / `--exclude-detectors`; `gitleaks:allow` on the line, or
 
 **`--no-verify` cannot be disabled.** It is built into git's CLI. Client-side
 hooks are a fast feedback loop, not a boundary; CI is the backstop.
+
+**Worktrees that pin `core.hooksPath` get no hooks.** `prepare` sets
+`core.hooksPath=.githooks` in local scope, which every checkout inherits — the
+relative path resolves per worktree, so the main checkout and ordinary linked
+worktrees are all covered (verified). But worktree scope outranks local scope,
+so a worktree carrying its own `core.hooksPath` in `config.worktree` silently
+wins and no hook runs. Today that is 2 of 19 checkouts here, both agent
+sandboxes created by tooling that pins it. Check with
+`git config --get core.hooksPath` — anything other than `.githooks` means the
+local gates are off in that checkout and only CI is protecting you.
 
 **The control worth more than all of the above** is GitHub secret scanning
 **push protection** — it rejects the push itself, so the secret never lands on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,11 @@ source .venv/bin/activate
 uv pip install ruff bandit   # linters configured in pyproject.toml
 ```
 
-Required tools: Node 20+, Python 3.10+, openssl, jq, shellcheck (`brew install shellcheck`).
+Required tools: Node 20+, Python 3.10+, openssl, jq, shellcheck, trufflehog
+(`brew install shellcheck trufflehog`).
+
+`npm install` points `core.hooksPath` at `.githooks/` via the `prepare` script,
+which enables the secret-scanning pre-commit hook. See **Secret Scanning** below.
 
 ## Common Commands
 
@@ -49,6 +53,15 @@ node skills/clawsec-suite/test/skill_catalog_discovery.test.mjs
 
 ```bash
 python utils/validate_skill.py skills/<skill-name>
+```
+
+**Secret scanning** (same engine as the hooks and CI):
+
+```bash
+gitleaks protect --staged --redact          # staged blobs, as pre-commit sees them
+gitleaks git --redact                       # every commit
+trufflehog git "file://$(pwd)" --results=verified,unknown --fail
+git config core.hooksPath .githooks         # (re)enable the hook
 ```
 
 **Signing key consistency check:**
@@ -100,11 +113,51 @@ python utils/validate_skill.py skills/<skill-name>
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `ci.yml` | PR / push to main | Lint (TS, Python, shell), Trivy security scan, npm audit, tests, build |
+| `ci.yml` | PR to main / manual | Lint (TS, Python, shell), Trivy security scan, TruffleHog secret scan, npm audit, tests, build. No `push` trigger, so direct commits to main are not CI-scanned — accepted risk: the only direct-to-main writer is the NVD/GHSA poller, whose input is public advisory data. |
 | `skill-release.yml` | Tag `*-v*.*.*` or PR touching skill files | Sign checksums, publish to GitHub Releases, supersede old versions |
 | `deploy-pages.yml` | After CI or release succeeds | Build web frontend + skills catalog, deploy to GitHub Pages |
 | `poll-nvd-cves.yml` | Daily 06:00 UTC | Poll NVD for CVEs, update `advisories/feed.json` + signature |
 | `community-advisory.yml` | Issue labeled `advisory-approved` | Process community report into `CLAW-YYYY-NNNN` advisory |
+
+## Secret Scanning
+
+Two tools, split by what each is actually good at.
+
+| Gate | Runs | Tool | Scope |
+|---|---|---|---|
+| `.githooks/pre-commit` | on commit | `gitleaks protect --staged` | staged blobs |
+| `ci.yml` / `secret-scan` | on PR | TruffleHog Action + gitleaks | the PR's commit range |
+
+**Why both.** TruffleHog verifies candidate credentials against the provider,
+which is what makes `--results=verified,unknown` usable: it reports what is live
+(or what it could not reach) and drops the merely secret-shaped. On this repo
+that is the difference between 140 findings and 2 — the advisory feed cites
+upstream fix commits as 40-char hex SHAs, which read as legacy GitHub PATs.
+
+But TruffleHog only emits a **PrivateKey** finding when it can verify the key
+against a provider. An unverifiable key produces no output at all — confirmed
+against RSA-2048, EC prime256v1, PKCS#8 Ed25519 and OpenSSH Ed25519. That is
+exactly the shape of `CLAWSEC_SIGNING_PRIVATE_KEY`, so gitleaks covers it: its
+built-in `private-key` rule matches on pattern and needs no network.
+
+**Why gitleaks in the hook.** Staged content is not in git yet, and
+`trufflehog git file://.` only reads committed objects — it reports nothing for
+a staged key. `gitleaks protect --staged` reads the staged blobs directly.
+
+**Tuning.** Use each tool's native mechanism — `trufflehog:ignore` on the line,
+or `--exclude-paths` / `--exclude-detectors`; `gitleaks:allow` on the line, or
+`.gitleaksignore`. Do not add a custom suppression layer.
+
+**`--no-verify` cannot be disabled.** It is built into git's CLI. Client-side
+hooks are a fast feedback loop, not a boundary; CI is the backstop.
+
+**The control worth more than all of the above** is GitHub secret scanning
+**push protection** — it rejects the push itself, so the secret never lands on
+any branch. Free for public repositories, and currently **disabled** on this
+repo. Enable it at Settings → Code security.
+
+Note that TruffleHog verifies by calling the provider's API, so the CI scan
+makes outbound network requests.
 
 ## Key Conventions
 
@@ -112,5 +165,6 @@ python utils/validate_skill.py skills/<skill-name>
 - **Python:** ruff + bandit, configured in `pyproject.toml`, line-length 120
 - **Shell:** shellcheck on `scripts/*.sh`
 - **Tests:** each `.test.mjs` is a standalone Node.js script with its own pass/fail counters and `process.exit(1)` on failure. Tests generate ephemeral Ed25519 keys — they don't use the repo signing keys.
+- **Secret scanning:** suppress a false positive with the scanner's own mechanism (`trufflehog:ignore` / `gitleaks:allow` on the line), scoped to that value. Never add a custom suppression layer.
 - **Advisory feed:** fail-closed signature verification by default. `CLAWSEC_ALLOW_UNSIGNED_FEED=1` is a temporary migration bypass only.
 - **Hook event model:** hooks mutate `event.messages` array in-place (not return values). Rate-limited to 300s by default (`CLAWSEC_HOOK_INTERVAL_SECONDS`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,13 +126,18 @@ Two tools, split by what each is actually good at.
 | Gate | Runs | Tool | Scope |
 |---|---|---|---|
 | `.githooks/pre-commit` | on commit | `gitleaks protect --staged` | staged blobs |
+| `.githooks/pre-push` | on push | gitleaks **+** TruffleHog | the commits being pushed |
 | `ci.yml` / `secret-scan` | on PR | TruffleHog Action + gitleaks | the PR's commit range |
 
-**Why both.** TruffleHog verifies candidate credentials against the provider,
-which is what makes `--results=verified,unknown` usable: it reports what is live
-(or what it could not reach) and drops the merely secret-shaped. On this repo
-that is the difference between 140 findings and 2 — the advisory feed cites
-upstream fix commits as 40-char hex SHAs, which read as legacy GitHub PATs.
+**Dead or alive.** pre-push and CI both pass `unverified` in `--results`, so a
+rotated or already-dead credential still fails — a leaked key is a leak whether
+or not it still works. CI's default (`verified,unknown`) would let it through.
+
+What makes that policy usable is that **every gate scans a range, never full
+history**. Over the whole repo this filter reports 140 findings — the advisory
+feed cites upstream fix commits as 40-char hex SHAs, which read as legacy GitHub
+PATs — but a range scan sees only the diff, so an ordinary push or PR reports 0.
+Never widen a gate to full history without re-checking that.
 
 But TruffleHog only emits a **PrivateKey** finding when it can verify the key
 against a provider. An unverifiable key produces no output at all — confirmed
@@ -140,9 +145,12 @@ against RSA-2048, EC prime256v1, PKCS#8 Ed25519 and OpenSSH Ed25519. That is
 exactly the shape of `CLAWSEC_SIGNING_PRIVATE_KEY`, so gitleaks covers it: its
 built-in `private-key` rule matches on pattern and needs no network.
 
-**Why gitleaks in the hook.** Staged content is not in git yet, and
+**Why gitleaks in the hooks.** Staged content is not in git yet, and
 `trufflehog git file://.` only reads committed objects — it reports nothing for
-a staged key. `gitleaks protect --staged` reads the staged blobs directly.
+a staged key. `gitleaks protect --staged` reads the staged blobs directly. At
+pre-push both run: gitleaks is offline and ~0.3s, TruffleHog adds its detector
+set for ~5s on a 20-commit range. `CLAWSEC_SKIP_TRUFFLEHOG=1` drops the slow
+half when you are offline; `CLAWSEC_SKIP_SECRET_SCAN=1` skips both.
 
 **Tuning.** Use each tool's native mechanism — `trufflehog:ignore` on the line,
 or `--exclude-paths` / `--exclude-detectors`; `gitleaks:allow` on the line, or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,9 +52,11 @@ brew install gitleaks trufflehog
 git checkout -b skill/my-new-skill
 ```
 
-A pre-commit hook scans staged changes for credentials. If it fires, rotate the
-credential before removing it from git — deleting it from the branch does not
-un-leak it.
+A pre-commit hook scans staged changes for credentials, and a pre-push hook
+scans the commits you are about to push with both gitleaks and TruffleHog —
+including credentials that are already dead, since a leaked key is a leak
+either way. If one fires, rotate the credential before removing it from git —
+deleting it from the branch does not un-leak it.
 See the Secret Scanning section of `CLAUDE.md` for how to tune false positives.
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,12 +41,21 @@ cd clawsec
 # Add upstream remote to sync with main repo
 git remote add upstream https://github.com/prompt-security/clawsec.git
 
-# Install dependencies (if any)
+# Install dependencies. This also installs the secret-scanning git hooks
+# via the "prepare" script.
 npm install
+
+# The pre-commit hook needs gitleaks on PATH, and fails closed without it.
+brew install gitleaks trufflehog
 
 # Create a new branch for your skill
 git checkout -b skill/my-new-skill
 ```
+
+A pre-commit hook scans staged changes for credentials. If it fires, rotate the
+credential before removing it from git — deleting it from the branch does not
+un-leak it.
+See the Secret Scanning section of `CLAUDE.md` for how to tune false positives.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "prepare": "git config core.hooksPath .githooks || true",
     "gen:wiki-llms": "node scripts/generate-wiki-llms.mjs",
     "readme:heroes:check": "node --test assets/readme/source/hero-manifest.test.mjs && node assets/readme/source/generate-localized-hero-svgs.mjs --check && node assets/readme/source/verify-localized-heroes.mjs",
     "populate-local-wiki": "./scripts/populate-local-wiki.sh",

--- a/scripts/prepare-to-push.sh
+++ b/scripts/prepare-to-push.sh
@@ -212,10 +212,10 @@ fi
 # against the provider, gitleaks matches deterministic patterns (private keys).
 echo -e "\n${YELLOW}Running TruffleHog secret scan...${NC}"
 if command -v trufflehog &> /dev/null; then
-  if trufflehog git "file://$(pwd)" --results=verified,unknown --fail --no-update; then
+  if trufflehog git "file://$(pwd)" --results=verified,unknown,unverified --fail --no-update; then
     check_pass "TruffleHog secret scan"
   else
-    check_fail "TruffleHog found live credentials"
+    check_fail "TruffleHog found credential material"
   fi
 else
   check_skip "TruffleHog"

--- a/scripts/prepare-to-push.sh
+++ b/scripts/prepare-to-push.sh
@@ -208,10 +208,23 @@ else
   echo "  Install with: brew install trivy"
 fi
 
-# Gitleaks (scans git history to match CI)
+# Secret scanning, same split as CI: trufflehog verifies live credentials
+# against the provider, gitleaks matches deterministic patterns (private keys).
+echo -e "\n${YELLOW}Running TruffleHog secret scan...${NC}"
+if command -v trufflehog &> /dev/null; then
+  if trufflehog git "file://$(pwd)" --results=verified,unknown --fail --no-update; then
+    check_pass "TruffleHog secret scan"
+  else
+    check_fail "TruffleHog found live credentials"
+  fi
+else
+  check_skip "TruffleHog"
+  echo "  Install with: brew install trufflehog"
+fi
+
+echo -e "\n${YELLOW}Running Gitleaks secrets scan...${NC}"
 if command -v gitleaks &> /dev/null; then
-  echo -e "\n${YELLOW}Running Gitleaks secrets scan...${NC}"
-  if gitleaks detect --source . --verbose; then
+  if gitleaks git --redact --no-banner; then
     check_pass "Gitleaks secrets scan"
   else
     check_fail "Gitleaks found potential secrets"
@@ -219,6 +232,7 @@ if command -v gitleaks &> /dev/null; then
 else
   check_skip "Gitleaks"
   echo "  Install with: brew install gitleaks"
+  echo "  Note: the pre-commit hook fails closed without it."
 fi
 
 # npm audit (use public registry since private registries like CodeArtifact don't support audit)

--- a/scripts/test-deploy-pages-checksums.mjs
+++ b/scripts/test-deploy-pages-checksums.mjs
@@ -324,7 +324,7 @@ for (const [label, options, expectedMessage] of [
 }
 
 {
-  const sensitiveBaseUrl = "https://ci-user:ci-password@example.test/private/path?token=secret#fragment";
+  const sensitiveBaseUrl = "https://ci-user:ci-password@example.test/private/path?token=secret#fragment"; // trufflehog:ignore -- synthetic fixture; example.test is RFC 6761 reserved and cannot resolve
   await assert.rejects(
     retryLiveAdvisoryEndpointVerification({
       baseUrl: sensitiveBaseUrl,
@@ -443,7 +443,7 @@ try {
     };
     try {
       const sensitiveBaseUrl =
-        fixture.origin.replace("://", "://ci-user:ci-password@") + "/?token=secret#fragment";
+        fixture.origin.replace("://", "://ci-user:ci-password@") + "/?token=secret#fragment"; // trufflehog:ignore -- synthetic fixture
       await verifyLiveAdvisoryEndpoints({
         baseUrl: sensitiveBaseUrl,
         attempts: 1,


### PR DESCRIPTION
# User description
## What this adds

Secret scanning at three gates, using two tools split by what each is actually
good at.

| Gate | Runs | Tool | Scope |
|---|---|---|---|
| `.githooks/pre-commit` | on commit | gitleaks | staged blobs |
| `.githooks/pre-push` | on push | gitleaks **+** TruffleHog | the commits being pushed |
| `ci.yml` / `secret-scan` | on PR | TruffleHog Action **+** gitleaks | the PR's commit range |

CI uses the official `trufflesecurity/trufflehog` Action. The hooks use each
tool's documented invocation. There is no bespoke scanner, no custom allowlist
format, and no hook installer — `prepare` sets `core.hooksPath` and that is the
whole installation.

**277 lines across 8 files.**

## Why two tools

Two properties of TruffleHog, both verified rather than assumed, decide the shape
of this:

**It cannot see our signing key.** TruffleHog only emits a `PrivateKey` finding
when it can verify the key against a provider. An unverifiable key produces *no
output at all* — tested against RSA-2048, EC prime256v1, PKCS#8 Ed25519 and
OpenSSH Ed25519, zero findings for each, even with `--no-verification`. That is
exactly the shape of `CLAWSEC_SIGNING_PRIVATE_KEY`, this project's release-signing
key. gitleaks' built-in `private-key` rule matches on pattern and catches all
four.

**It cannot see staged content.** `trufflehog git file://.` reads committed
objects, so it reports nothing for a staged key. That rules it out as the
pre-commit gate entirely. `gitleaks protect --staged` reads the staged blobs
directly.

So gitleaks is the deterministic gate, and TruffleHog adds the thing gitleaks
cannot do: telling you a credential is *live right now*.

## Dead or alive

pre-push and CI both pass `unverified` in `--results`, so a rotated or
already-dead credential still fails. A leaked key is a leak whether or not it
still works — the leak is that it is in the history, and "we rotated it" is a
claim nobody re-checks. TruffleHog's documented default (`verified,unknown`)
would let it through.

What makes that policy affordable is that **every gate scans a range, never full
history**:

| scope | findings |
|---|---|
| `verified,unknown,unverified` over full history | **140** |
| same filter over an ordinary push/PR range | **0** |
| same, over a range touching `advisories/feed.json` | **0** |

The 140 are the advisory feed's upstream fix-commit SHAs — 40-char hex, the same
shape as a legacy GitHub PAT. A range scan sees the diff, not the accumulated
corpus. **Do not widen any gate to full history without re-checking that number.**

## False positives

Handled with each tool's own mechanism, scoped to the value: two
`trufflehog:ignore` comments on the deliberate basic-auth fixture in
`scripts/test-deploy-pages-checksums.mjs` (`example.test` is RFC 6761 reserved and
cannot resolve). No custom suppression layer — which also means there is no
allowlist file a PR can widen to hide a secret it is introducing.

## Verification

Exercised against a real bare remote, pushing for real:

| case | result |
|---|---|
| dead (fake) GitHub token, committed `--no-verify` | **blocked** — both scanners fired |
| Ed25519 private key | **blocked** — gitleaks; TruffleHog silent, as expected |
| brand-new branch + Slack token, no remote SHA | **blocked** |
| ordinary clean commit | pushed, remote advanced |

Also verified: `CLAWSEC_SKIP_SECRET_SCAN=1` reaches the bypass with gitleaks off
`PATH`; the repo's own history is clean (3,221 blobs, zero private keys).

Cost on a 20-commit push: gitleaks ~0.3s, TruffleHog ~5.4s (it calls provider
APIs). `CLAWSEC_SKIP_TRUFFLEHOG=1` drops the slow half when offline;
`CLAWSEC_SKIP_SECRET_SCAN=1` skips both.

## What this does not do

**`--no-verify` cannot be disabled.** It is built into git's CLI. Client-side
hooks are a fast feedback loop, not a boundary.

**Hooks do not run in a worktree that pins `core.hooksPath`.** `prepare` sets it
in local scope and the relative path resolves per worktree, so the main checkout
and ordinary linked worktrees are covered (verified by committing in both). But
worktree scope outranks local scope. Today that is 2 of 19 checkouts here, both
agent sandboxes created by tooling that pins it. Check with
`git config --get core.hooksPath`; anything but `.githooks` means only CI is
protecting that checkout.

**A secret can still reach a feature branch.** Only server-side push protection
prevents that, and it is unavailable — GitHub Secret Protection is blocked by
org policy on this repo, so this is not a stopgap until we enable that. What *is*
now enforced: `Secret Scan` was added as a **required status check** on the `main`
ruleset, so a PR with a failing scan cannot be merged. That gate is not
bypassable with `--no-verify`.

## Note on the history

This branch previously carried a 3,209-line bespoke implementation — a
hand-rolled `git cat-file --batch` parser, a custom allowlist format with its own
validator, a hook shim with a `.git`-resident snapshot fallback, and two test
suites. It took ten fix commits, eight of them closing fail-open paths where the
gate printed "clean" over a live key. It was replaced in `8062d47` after checking
what the tools do natively: `--results` filtering removed the need for the
allowlist, and the `core.hooksPath` limitation it was built around turned out to
apply to 2 of 19 checkouts, not the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add staged, pre-push, and CI secret scanning through <code>gitleaks</code> and <code>TruffleHog</code>, covering deterministic private-key patterns and verified or unverified credentials. Update hook installation, developer guidance, CI permissions, and validation scripts to enforce consistent scanning and scoped false-positive handling.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/348?tool=ast&topic=Secret+Scanning+Gates>Secret Scanning Gates</a>
        </td><td>Protect commits and pull requests by scanning staged content and pushed or PR commit ranges with <code>gitleaks</code> and <code>TruffleHog</code>, while documenting bypasses, suppression rules, and tool requirements.<details><summary>Modified files (5)</summary><ul><li>.githooks/pre-commit</li>
<li>.githooks/pre-push</li>
<li>.github/workflows/ci.yml</li>
<li>scripts/prepare-to-push.sh</li>
<li>scripts/test-deploy-pages-checksums.mjs</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/348?tool=ast&topic=Hook+Integration+Docs>Hook Integration Docs</a>
        </td><td>Enable the hooks through the npm <code>prepare</code> script and explain installation, scanner behavior, CI coverage, worktree limitations, and contributor workflows.<details><summary>Modified files (3)</summary><ul><li>CLAUDE.md</li>
<li>CONTRIBUTING.md</li>
<li>package.json</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/348?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>
