### PR TITLE
fix(wiki): rewrite internal links in llms.txt exports

### DIFF
--- a/.github/workflows/wiki-export-verify.yml
+++ b/.github/workflows/wiki-export-verify.yml
@@ -11,6 +11,7 @@ on:
       - 'scripts/generate-wiki-llms.mjs'
       - 'scripts/test-wiki-llms-export.mjs'
       - 'utils/wikiPathHelpers.mjs'
+      - 'utils/markdownHelpers.mjs'
       - '.github/workflows/wiki-export-verify.yml'
       - '.github/workflows/wiki-sync.yml'
   workflow_dispatch:

--- a/.github/workflows/wiki-export-verify.yml
+++ b/.github/workflows/wiki-export-verify.yml
@@ -8,6 +8,8 @@ on:
       - 'pages/WikiBrowser.tsx'
       - 'scripts/build-github-wiki-export.mjs'
       - 'scripts/test-wiki-sync-export.mjs'
+      - 'scripts/generate-wiki-llms.mjs'
+      - 'scripts/test-wiki-llms-export.mjs'
       - 'utils/wikiPathHelpers.mjs'
       - '.github/workflows/wiki-export-verify.yml'
       - '.github/workflows/wiki-sync.yml'
@@ -34,6 +36,9 @@ jobs:
 
       - name: Test wiki export transform
         run: node scripts/test-wiki-sync-export.mjs
+
+      - name: Test wiki llms.txt export
+        run: node scripts/test-wiki-llms-export.mjs
 
       - name: Build flattened GitHub Wiki export
         run: |

--- a/scripts/generate-wiki-llms.mjs
+++ b/scripts/generate-wiki-llms.mjs
@@ -8,8 +8,9 @@ import {
   stripFrontmatter,
 } from '../utils/markdownHelpers.mjs';
 import {
+  isExternalHref,
   isWikiIndexSlug,
-  resolveWikiLinkTarget,
+  splitWikiHash,
   toWikiLlmsPath,
   toWikiRoute,
 } from '../utils/wikiPathHelpers.mjs';
@@ -19,22 +20,62 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 const WIKI_ROOT = path.join(REPO_ROOT, 'wiki');
 const PUBLIC_WIKI_ROOT = path.join(REPO_ROOT, 'public', 'wiki');
 
-const WEBSITE_BASE = 'https://clawsec.prompt.security';
-const REPO_BASE = 'https://github.com/prompt-security/clawsec';
-const RAW_BASE = 'https://raw.githubusercontent.com/prompt-security/clawsec/main';
+export const WEBSITE_BASE = 'https://clawsec.prompt.security';
+export const REPO_BASE = 'https://github.com/prompt-security/clawsec';
+export const RAW_BASE = 'https://raw.githubusercontent.com/prompt-security/clawsec/main';
 
 const toPosix = (inputPath) => inputPath.split(path.sep).join('/');
 const toLlmsPageUrl = (slug) => `${WEBSITE_BASE}${toWikiLlmsPath(slug)}`;
+
+// Resolve a wiki-relative link, tracking how many `..` segments climb past the wiki root
+// (`aboveWikiRoot`). wikiPathHelpers' resolveWikiLinkTarget clamps `..` at the wiki root
+// instead of counting the overflow, so it can't tell "wiki/CONTRIBUTING.md" apart from
+// "../CONTRIBUTING.md" written from wiki/ itself — both normalize to the same string,
+// even though the wiki content actually lives one directory below the repo root and real
+// pages link out to root-level docs (e.g. wiki/exploitability-scoring.md -> CONTRIBUTING.md).
+// Losing that distinction here would point the raw-GitHub fallback at a `wiki/`-prefixed
+// path that doesn't exist.
+const resolveLinkPath = (docRelativePath, targetPath) => {
+  const baseDirParts = docRelativePath.includes('/')
+    ? docRelativePath.split('/').slice(0, -1)
+    : [];
+  const parts = [...baseDirParts];
+  let aboveWikiRoot = 0;
+
+  for (const segment of targetPath.split('/')) {
+    if (!segment || segment === '.') continue;
+    if (segment === '..') {
+      if (parts.length > 0) parts.pop();
+      else aboveWikiRoot += 1;
+      continue;
+    }
+    parts.push(segment);
+  }
+
+  return { path: parts.join('/'), aboveWikiRoot };
+};
 
 // Wiki markdown uses repo-relative links (`overview.md`, `../assets/x.svg`), which only resolve
 // inside the wiki/ tree. Exported llms.txt files are served from the website, so internal links
 // must be rewritten to absolute URLs or they 404 for anyone following them.
 const rewriteInternalLinks = (content, docRelativePath, slugSet) =>
   content.replace(/\]\(([^)\s]+)\)/g, (match, href) => {
-    const target = resolveWikiLinkTarget(docRelativePath, href);
-    if (!target) return match; // external, hash-only, or root-absolute — leave as-is
+    if (!href || isExternalHref(href) || href.startsWith('#') || href.startsWith('/')) {
+      return match; // external, hash-only, or root-absolute — leave as-is
+    }
 
-    const { path: resolvedPath, hash } = target;
+    const { path: rawTarget, hash } = splitWikiHash(href);
+    if (!rawTarget) return match;
+
+    const { path: resolvedPath, aboveWikiRoot } = resolveLinkPath(docRelativePath, rawTarget);
+    if (!resolvedPath) return match;
+
+    if (aboveWikiRoot > 0) {
+      // Escapes the wiki/ tree (e.g. `../CONTRIBUTING.md`) — resolve against the repo root,
+      // not `wiki/`. There is no website route for content outside the wiki tree.
+      return `](${RAW_BASE}/${resolvedPath}${hash})`;
+    }
+
     const targetSlug = resolvedPath.toLowerCase().endsWith('.md')
       ? resolvedPath.replace(/\.md$/i, '').toLowerCase()
       : null;

--- a/scripts/generate-wiki-llms.mjs
+++ b/scripts/generate-wiki-llms.mjs
@@ -18,7 +18,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
 const WIKI_ROOT = path.join(REPO_ROOT, 'wiki');
 const PUBLIC_WIKI_ROOT = path.join(REPO_ROOT, 'public', 'wiki');
-const LLM_INDEX_FILE = path.join(PUBLIC_WIKI_ROOT, 'llms.txt');
 
 const WEBSITE_BASE = 'https://clawsec.prompt.security';
 const REPO_BASE = 'https://github.com/prompt-security/clawsec';
@@ -119,50 +118,70 @@ const buildFallbackIndexBody = (docs) => {
   return `${lines.join('\n')}\n`;
 };
 
-const main = async () => {
+/**
+ * Generate llms.txt exports for every wiki page under `wikiRoot`, writing them to
+ * `publicWikiRoot`. Returns the list of generated output files (index included) so
+ * callers — including tests — can inspect exactly what was produced.
+ * @param {{ wikiRoot: string, publicWikiRoot: string }} options
+ * @returns {Promise<{ pageCount: number, outputFiles: string[] }>}
+ */
+export const generateWikiLlms = async ({ wikiRoot, publicWikiRoot }) => {
+  const wikiStat = await fs.stat(wikiRoot).catch(() => null);
+  if (!wikiStat || !wikiStat.isDirectory()) {
+    throw new Error(`wiki/ directory not found at ${wikiRoot}.`);
+  }
+
+  const markdownFiles = await walkMarkdownFiles(wikiRoot);
+  const docs = [];
+
+  for (const fullPath of markdownFiles) {
+    const relativePath = toPosix(path.relative(wikiRoot, fullPath));
+    const slug = relativePath.replace(/\.md$/i, '').toLowerCase();
+    const rawContent = await fs.readFile(fullPath, 'utf8');
+    const content = stripFrontmatter(rawContent);
+    const title = extractTitleFromMarkdown(rawContent, relativePath);
+    docs.push({ relativePath, slug, title, content });
+  }
+
+  docs.sort(sortDocs);
+  const pageDocs = docs.filter((doc) => !isWikiIndexSlug(doc.slug));
+  const indexDoc = docs.find((doc) => isWikiIndexSlug(doc.slug));
+  const slugSet = new Set(docs.map((doc) => doc.slug));
+
+  // `public/wiki/` is fully generated; wipe stale output before regenerating.
+  await fs.rm(publicWikiRoot, { recursive: true, force: true });
+  await fs.mkdir(publicWikiRoot, { recursive: true });
+
+  const outputFiles = [];
+
+  for (const doc of pageDocs) {
+    const outputFile = path.join(publicWikiRoot, doc.slug, 'llms.txt');
+    await fs.mkdir(path.dirname(outputFile), { recursive: true });
+    await fs.writeFile(outputFile, buildPageBody(doc, slugSet), 'utf8');
+    outputFiles.push(outputFile);
+  }
+
+  const indexFile = path.join(publicWikiRoot, 'llms.txt');
+  const indexBody = indexDoc ? buildPageBody(indexDoc, slugSet) : buildFallbackIndexBody(pageDocs);
+  await fs.writeFile(indexFile, indexBody, 'utf8');
+  outputFiles.push(indexFile);
+
+  return { pageCount: pageDocs.length, outputFiles };
+};
+
+const isDirectRun = () => {
+  if (!process.argv[1]) return false;
+  return fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+};
+
+if (isDirectRun()) {
   try {
-    const wikiStat = await fs.stat(WIKI_ROOT).catch(() => null);
-    if (!wikiStat || !wikiStat.isDirectory()) {
-      throw new Error('wiki/ directory not found.');
-    }
-
-    const markdownFiles = await walkMarkdownFiles(WIKI_ROOT);
-    const docs = [];
-
-    for (const fullPath of markdownFiles) {
-      const relativePath = toPosix(path.relative(WIKI_ROOT, fullPath));
-      const slug = relativePath.replace(/\.md$/i, '').toLowerCase();
-      const rawContent = await fs.readFile(fullPath, 'utf8');
-      const content = stripFrontmatter(rawContent);
-      const title = extractTitleFromMarkdown(rawContent, relativePath);
-      docs.push({ relativePath, slug, title, content });
-    }
-
-    docs.sort(sortDocs);
-    const pageDocs = docs.filter((doc) => !isWikiIndexSlug(doc.slug));
-    const indexDoc = docs.find((doc) => isWikiIndexSlug(doc.slug));
-    const slugSet = new Set(docs.map((doc) => doc.slug));
-
-    // `public/wiki/` is fully generated; wipe stale output before regenerating.
-    await fs.rm(PUBLIC_WIKI_ROOT, { recursive: true, force: true });
-    await fs.mkdir(PUBLIC_WIKI_ROOT, { recursive: true });
-
-    for (const doc of pageDocs) {
-      const outputFile = path.join(PUBLIC_WIKI_ROOT, doc.slug, 'llms.txt');
-      await fs.mkdir(path.dirname(outputFile), { recursive: true });
-      await fs.writeFile(outputFile, buildPageBody(doc, slugSet), 'utf8');
-    }
-
-    const indexBody = indexDoc ? buildPageBody(indexDoc, slugSet) : buildFallbackIndexBody(pageDocs);
-    await fs.writeFile(LLM_INDEX_FILE, indexBody, 'utf8');
-
+    const { pageCount } = await generateWikiLlms({ wikiRoot: WIKI_ROOT, publicWikiRoot: PUBLIC_WIKI_ROOT });
     // Keep logs short for CI readability.
-    console.log(`Generated ${pageDocs.length} page llms.txt exports and /wiki/llms.txt`);
+    console.log(`Generated ${pageCount} page llms.txt exports and /wiki/llms.txt`);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`Failed to generate wiki llms exports: ${message}`);
     process.exit(1);
   }
-};
-
-await main();
+}

--- a/scripts/generate-wiki-llms.mjs
+++ b/scripts/generate-wiki-llms.mjs
@@ -9,6 +9,7 @@ import {
 } from '../utils/markdownHelpers.mjs';
 import {
   isWikiIndexSlug,
+  resolveWikiLinkTarget,
   toWikiLlmsPath,
   toWikiRoute,
 } from '../utils/wikiPathHelpers.mjs';
@@ -25,6 +26,26 @@ const RAW_BASE = 'https://raw.githubusercontent.com/prompt-security/clawsec/main
 
 const toPosix = (inputPath) => inputPath.split(path.sep).join('/');
 const toLlmsPageUrl = (slug) => `${WEBSITE_BASE}${toWikiLlmsPath(slug)}`;
+
+// Wiki markdown uses repo-relative links (`overview.md`, `../assets/x.svg`), which only resolve
+// inside the wiki/ tree. Exported llms.txt files are served from the website, so internal links
+// must be rewritten to absolute URLs or they 404 for anyone following them.
+const rewriteInternalLinks = (content, docRelativePath, slugSet) =>
+  content.replace(/\]\(([^)\s]+)\)/g, (match, href) => {
+    const target = resolveWikiLinkTarget(docRelativePath, href);
+    if (!target) return match; // external, hash-only, or root-absolute — leave as-is
+
+    const { path: resolvedPath, hash } = target;
+    const targetSlug = resolvedPath.toLowerCase().endsWith('.md')
+      ? resolvedPath.replace(/\.md$/i, '').toLowerCase()
+      : null;
+
+    if (!targetSlug || !slugSet.has(targetSlug)) {
+      return `](${RAW_BASE}/wiki/${resolvedPath}${hash})`;
+    }
+
+    return `](${WEBSITE_BASE}/#${toWikiRoute(targetSlug)}${hash})`;
+  });
 
 const walkMarkdownFiles = async (dir) => {
   const entries = await fs.readdir(dir, { withFileTypes: true });
@@ -51,11 +72,12 @@ const sortDocs = (a, b) => {
   return a.slug.localeCompare(b.slug, 'en', { sensitivity: 'base' });
 };
 
-const buildPageBody = (doc) => {
+const buildPageBody = (doc, slugSet) => {
   const pageRoute = toWikiRoute(doc.slug);
   const pageUrl = `${WEBSITE_BASE}/#${pageRoute}`;
   const sourceUrl = `${RAW_BASE}/wiki/${doc.relativePath}`;
   const llmsUrl = toLlmsPageUrl(doc.slug);
+  const content = rewriteInternalLinks(doc.content, doc.relativePath, slugSet).trim();
 
   return [
     `# ClawSec Wiki · ${doc.title}`,
@@ -69,7 +91,7 @@ const buildPageBody = (doc) => {
     '',
     '## Markdown',
     '',
-    doc.content.trim(),
+    content,
     '',
   ].join('\n');
 };
@@ -119,6 +141,7 @@ const main = async () => {
     docs.sort(sortDocs);
     const pageDocs = docs.filter((doc) => !isWikiIndexSlug(doc.slug));
     const indexDoc = docs.find((doc) => isWikiIndexSlug(doc.slug));
+    const slugSet = new Set(docs.map((doc) => doc.slug));
 
     // `public/wiki/` is fully generated; wipe stale output before regenerating.
     await fs.rm(PUBLIC_WIKI_ROOT, { recursive: true, force: true });
@@ -127,10 +150,10 @@ const main = async () => {
     for (const doc of pageDocs) {
       const outputFile = path.join(PUBLIC_WIKI_ROOT, doc.slug, 'llms.txt');
       await fs.mkdir(path.dirname(outputFile), { recursive: true });
-      await fs.writeFile(outputFile, buildPageBody(doc), 'utf8');
+      await fs.writeFile(outputFile, buildPageBody(doc, slugSet), 'utf8');
     }
 
-    const indexBody = indexDoc ? buildPageBody(indexDoc) : buildFallbackIndexBody(pageDocs);
+    const indexBody = indexDoc ? buildPageBody(indexDoc, slugSet) : buildFallbackIndexBody(pageDocs);
     await fs.writeFile(LLM_INDEX_FILE, indexBody, 'utf8');
 
     // Keep logs short for CI readability.

--- a/scripts/test-wiki-llms-export.mjs
+++ b/scripts/test-wiki-llms-export.mjs
@@ -1,11 +1,14 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, writeFile, mkdir, rm } from 'node:fs/promises';
+import { access, mkdtemp, readFile, writeFile, mkdir, rm } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
-import { generateWikiLlms } from './generate-wiki-llms.mjs';
+import { generateWikiLlms, RAW_BASE, WEBSITE_BASE } from './generate-wiki-llms.mjs';
+import { toWikiRoute } from '../utils/wikiPathHelpers.mjs';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 const writeFixture = async (root, relativePath, content) => {
   const fullPath = path.join(root, relativePath);
@@ -13,13 +16,16 @@ const writeFixture = async (root, relativePath, content) => {
   await writeFile(fullPath, content, 'utf8');
 };
 
-// Any `](something)` whose target isn't absolute (http(s)://, mailto:, a bare `#hash`,
-// or root-absolute `/...`) is a link that only resolved inside the wiki/ source tree.
-// Once exported into llms.txt and served from the website, that link is dead.
-const findDeadRelativeLinks = (content) =>
-  [...content.matchAll(/\]\(([^)\s]+)\)/g)]
-    .map(([, target]) => target)
-    .filter((target) => !/^([a-zA-Z][a-zA-Z0-9+.-]*:|\/|#)/.test(target));
+const extractLinkTargets = (content) =>
+  [...content.matchAll(/\]\(([^)\s]+)\)/g)].map(([, target]) => target);
+
+const isAbsoluteHref = (target) =>
+  /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target) || target.startsWith('/') || target.startsWith('#');
+
+const toSlug = (outputFile, publicWikiRoot) => {
+  const relDir = path.relative(publicWikiRoot, path.dirname(outputFile));
+  return relDir === '' ? 'index' : relDir.split(path.sep).join('/');
+};
 
 test('generateWikiLlms rewrites internal wiki links to absolute URLs', async () => {
   const tmpRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-llms-'));
@@ -57,7 +63,7 @@ test('generateWikiLlms rewrites internal wiki links to absolute URLs', async () 
   assert.match(index, /\[External\]\(https:\/\/example\.com\/docs\)/);
   assert.match(index, /\[Same-page section\]\(#summary\)/);
   assert.match(index, /\[Root absolute\]\(\/wiki\/overview\)/);
-  assert.deepEqual(findDeadRelativeLinks(index), []);
+  assert.ok(extractLinkTargets(index).every(isAbsoluteHref));
 
   const overview = await readFile(path.join(publicWikiRoot, 'overview', 'llms.txt'), 'utf8');
   assert.match(
@@ -68,32 +74,108 @@ test('generateWikiLlms rewrites internal wiki links to absolute URLs', async () 
     overview,
     /!\[Logo\]\(https:\/\/raw\.githubusercontent\.com\/prompt-security\/clawsec\/main\/wiki\/assets\/logo\.svg\)/,
   );
-  assert.deepEqual(findDeadRelativeLinks(overview), []);
+  assert.ok(extractLinkTargets(overview).every(isAbsoluteHref));
 
   await rm(tmpRoot, { recursive: true, force: true });
 });
 
-test('generateWikiLlms ships no dead relative links across the real wiki/ export', async () => {
-  const wikiRoot = fileURLToPath(new URL('../wiki', import.meta.url));
+test('generateWikiLlms resolves links that climb above the wiki root against the repo root, not wiki/', async () => {
+  // Regression fixture for a real defect: wiki content lives one directory below the repo
+  // root, and real pages link out to root-level docs (e.g. wiki/exploitability-scoring.md's
+  // `../CONTRIBUTING.md`, or wiki/de/exploitability-scoring.md's `../../CONTRIBUTING.md` —
+  // both name the same repo-root file from different nesting depths). A resolver that clamps
+  // `..` at the wiki root instead of counting the overflow can't tell that apart from an
+  // in-wiki reference, and ends up emitting a `wiki/`-prefixed raw URL that 404s.
+  const tmpRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-llms-escape-'));
+  const wikiRoot = path.join(tmpRoot, 'wiki');
+  const publicWikiRoot = path.join(tmpRoot, 'public-wiki');
+
+  await writeFixture(tmpRoot, 'CONTRIBUTING.md', '# Contributing\n');
+  await writeFixture(wikiRoot, 'top-level.md', [
+    '# Top Level',
+    '',
+    'See [CONTRIBUTING](../CONTRIBUTING.md).',
+    '',
+  ].join('\n'));
+  await writeFixture(wikiRoot, 'de/nested.md', [
+    '# Nested',
+    '',
+    'See [CONTRIBUTING](../../CONTRIBUTING.md).',
+    '',
+  ].join('\n'));
+
+  await generateWikiLlms({ wikiRoot, publicWikiRoot });
+
+  const expectedLink = `[CONTRIBUTING](${RAW_BASE}/CONTRIBUTING.md)`;
+  const wrongLink = `${RAW_BASE}/wiki/CONTRIBUTING.md`;
+
+  const topLevel = await readFile(path.join(publicWikiRoot, 'top-level', 'llms.txt'), 'utf8');
+  assert.ok(topLevel.includes(expectedLink), `expected ${expectedLink} in top-level export`);
+  assert.ok(!topLevel.includes(wrongLink), `must not resolve into a nonexistent wiki/-prefixed path`);
+
+  const nested = await readFile(path.join(publicWikiRoot, 'de', 'nested', 'llms.txt'), 'utf8');
+  assert.ok(nested.includes(expectedLink), `expected ${expectedLink} in nested export`);
+  assert.ok(!nested.includes(wrongLink), `must not resolve into a nonexistent wiki/-prefixed path`);
+
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+test('generateWikiLlms only emits internal links that resolve to a real target, across the actual wiki/', async () => {
+  const wikiRoot = path.join(REPO_ROOT, 'wiki');
   const publicWikiRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-llms-real-'));
 
   const { pageCount, outputFiles } = await generateWikiLlms({ wikiRoot, publicWikiRoot });
-
   assert.ok(pageCount > 0, 'expected at least one wiki page to be exported');
-  assert.ok(outputFiles.length > 0);
 
-  const deadLinksByFile = new Map();
+  const knownRoutes = new Set(outputFiles.map((file) => toWikiRoute(toSlug(file, publicWikiRoot))));
+  const websitePrefix = `${WEBSITE_BASE}/#`;
+  const rawPrefix = `${RAW_BASE}/`;
+
+  const brokenLinksByFile = new Map();
+
   for (const outputFile of outputFiles) {
     const content = await readFile(outputFile, 'utf8');
-    const dead = findDeadRelativeLinks(content);
-    if (dead.length > 0) deadLinksByFile.set(path.relative(publicWikiRoot, outputFile), dead);
+    const broken = [];
+
+    for (const target of extractLinkTargets(content)) {
+      if (target.startsWith('#')) continue; // same-page anchor
+
+      if (!isAbsoluteHref(target)) {
+        broken.push(`relative link left unrewritten: ${target}`);
+        continue;
+      }
+
+      if (target.startsWith(rawPrefix)) {
+        // The one check that actually catches a wrong-but-absolute URL: does the path this
+        // points at exist in the repo? A `wiki/`-prefixed path for a repo-root file passes
+        // every "is it absolute" check and still 404s — only an existence check catches it.
+        const repoRelativePath = target.slice(rawPrefix.length).split('#')[0];
+        const exists = await access(path.join(REPO_ROOT, repoRelativePath))
+          .then(() => true)
+          .catch(() => false);
+        if (!exists) broken.push(`raw link points at a path that does not exist in the repo: ${target}`);
+        continue;
+      }
+
+      if (target.startsWith(websitePrefix)) {
+        const route = target.slice(websitePrefix.length).split('#')[0];
+        if (!knownRoutes.has(route)) {
+          broken.push(`website link points at a route with no generated export: ${target}`);
+        }
+      }
+    }
+
+    if (broken.length > 0) {
+      brokenLinksByFile.set(path.relative(publicWikiRoot, outputFile), broken);
+    }
   }
 
   assert.deepEqual(
-    [...deadLinksByFile.entries()],
+    [...brokenLinksByFile.entries()],
     [],
-    'every internal wiki link must be rewritten to an absolute URL before export — a relative ' +
-      'link here 404s once served from the website (see issue #349)',
+    'every internal wiki link must resolve to something that actually exists — a relative link, ' +
+      'or an absolute URL pointing at a nonexistent path, 404s once served from the website ' +
+      '(see issue #349)',
   );
 
   await rm(publicWikiRoot, { recursive: true, force: true });

--- a/scripts/test-wiki-llms-export.mjs
+++ b/scripts/test-wiki-llms-export.mjs
@@ -19,6 +19,31 @@ const writeFixture = async (root, relativePath, content) => {
 const extractLinkTargets = (content) =>
   [...content.matchAll(/\]\(([^)\s]+)\)/g)].map(([, target]) => target);
 
+// The rewriter parses the plain `](dest)` form only. That covers all wiki content today,
+// but CommonMark also allows titles (`](a.md "t")`), angle-bracket destinations
+// (`](<a b.md>)`), and parenthesized paths — forms the rewriter would silently pass
+// through (leaving a dead relative link) or truncate. The danger is that a validator
+// using the same grammar is blind to exactly those cases and reports success.
+//
+// So rather than teaching both sides full CommonMark for forms no page uses, flag any
+// `](` the rewriter cannot faithfully handle and fail loudly. If someone adds one later,
+// CI says so instead of shipping another dead link.
+const findUnparseableLinkForms = (content) => {
+  const problems = [];
+
+  for (const [snippet] of content.matchAll(/\]\((?![^)\s]+\))[^\n]{0,60}/g)) {
+    problems.push(`unsupported link form (title / angle-bracket / spaced destination): ${snippet}`);
+  }
+
+  for (const [, target] of content.matchAll(/\]\(([^)\s]+)\)/g)) {
+    if (target.includes('(')) {
+      problems.push(`destination truncated at an unbalanced parenthesis: ${target}`);
+    }
+  }
+
+  return problems;
+};
+
 const isAbsoluteHref = (target) =>
   /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target) || target.startsWith('/') || target.startsWith('#');
 
@@ -120,6 +145,39 @@ test('generateWikiLlms resolves links that climb above the wiki root against the
   await rm(tmpRoot, { recursive: true, force: true });
 });
 
+test('the export gate rejects link forms the rewriter cannot faithfully handle', async () => {
+  // No wiki page uses these CommonMark forms today, and the rewriter does not parse them.
+  // What must not happen is the validator sharing that blind spot and reporting success —
+  // that is how a dead link ships unnoticed (the #349 failure mode). Assert it fails loudly.
+  const tmpRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-llms-forms-'));
+  const wikiRoot = path.join(tmpRoot, 'wiki');
+  const publicWikiRoot = path.join(tmpRoot, 'public-wiki');
+
+  await writeFixture(wikiRoot, 'INDEX.md', [
+    '# Wiki Index',
+    '',
+    '- [Titled](overview.md "page title")',
+    '- [Angled](<assets/my image.svg>)',
+    '- [Parenthesized](spec_(v2).md)',
+    '',
+  ].join('\n'));
+  await writeFixture(wikiRoot, 'overview.md', '# Overview\n');
+
+  await generateWikiLlms({ wikiRoot, publicWikiRoot });
+  const index = await readFile(path.join(publicWikiRoot, 'llms.txt'), 'utf8');
+
+  const problems = findUnparseableLinkForms(index);
+  assert.equal(problems.length, 3, `expected all three unsupported forms flagged, got: ${problems}`);
+  assert.ok(problems.some((p) => p.includes('page title')));
+  assert.ok(problems.some((p) => p.includes('my image.svg')));
+  assert.ok(problems.some((p) => p.includes('spec_(v2')));
+
+  // A plain link alongside them still rewrites correctly and is not flagged.
+  assert.ok(findUnparseableLinkForms('[Overview](overview.md)').length === 0);
+
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
 test('generateWikiLlms only emits internal links that resolve to a real target, across the actual wiki/', async () => {
   const wikiRoot = path.join(REPO_ROOT, 'wiki');
   const publicWikiRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-llms-real-'));
@@ -135,7 +193,7 @@ test('generateWikiLlms only emits internal links that resolve to a real target, 
 
   for (const outputFile of outputFiles) {
     const content = await readFile(outputFile, 'utf8');
-    const broken = [];
+    const broken = findUnparseableLinkForms(content);
 
     for (const target of extractLinkTargets(content)) {
       if (target.startsWith('#')) continue; // same-page anchor

--- a/scripts/test-wiki-llms-export.mjs
+++ b/scripts/test-wiki-llms-export.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, writeFile, mkdir, rm } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { generateWikiLlms } from './generate-wiki-llms.mjs';
+
+const writeFixture = async (root, relativePath, content) => {
+  const fullPath = path.join(root, relativePath);
+  await mkdir(path.dirname(fullPath), { recursive: true });
+  await writeFile(fullPath, content, 'utf8');
+};
+
+// Any `](something)` whose target isn't absolute (http(s)://, mailto:, a bare `#hash`,
+// or root-absolute `/...`) is a link that only resolved inside the wiki/ source tree.
+// Once exported into llms.txt and served from the website, that link is dead.
+const findDeadRelativeLinks = (content) =>
+  [...content.matchAll(/\]\(([^)\s]+)\)/g)]
+    .map(([, target]) => target)
+    .filter((target) => !/^([a-zA-Z][a-zA-Z0-9+.-]*:|\/|#)/.test(target));
+
+test('generateWikiLlms rewrites internal wiki links to absolute URLs', async () => {
+  const tmpRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-llms-'));
+  const wikiRoot = path.join(tmpRoot, 'wiki');
+  const publicWikiRoot = path.join(tmpRoot, 'public-wiki');
+
+  await writeFixture(wikiRoot, 'INDEX.md', [
+    '# Wiki Index',
+    '',
+    '- [Overview](overview.md)',
+    '- [Missing page](missing-page.md)',
+    '- [External](https://example.com/docs)',
+    '- [Same-page section](#summary)',
+    '- [Root absolute](/wiki/overview)',
+    '',
+  ].join('\n'));
+  await writeFixture(wikiRoot, 'overview.md', [
+    '# Overview',
+    '',
+    'See [Automation](modules/automation.md#dry-run).',
+    '',
+    '![Logo](assets/logo.svg)',
+    '',
+  ].join('\n'));
+  await writeFixture(wikiRoot, 'modules/automation.md', '# Automation\n');
+
+  await generateWikiLlms({ wikiRoot, publicWikiRoot });
+
+  const index = await readFile(path.join(publicWikiRoot, 'llms.txt'), 'utf8');
+  assert.match(index, /\[Overview\]\(https:\/\/clawsec\.prompt\.security\/#\/wiki\/overview\)/);
+  assert.match(
+    index,
+    /\[Missing page\]\(https:\/\/raw\.githubusercontent\.com\/prompt-security\/clawsec\/main\/wiki\/missing-page\.md\)/,
+  );
+  assert.match(index, /\[External\]\(https:\/\/example\.com\/docs\)/);
+  assert.match(index, /\[Same-page section\]\(#summary\)/);
+  assert.match(index, /\[Root absolute\]\(\/wiki\/overview\)/);
+  assert.deepEqual(findDeadRelativeLinks(index), []);
+
+  const overview = await readFile(path.join(publicWikiRoot, 'overview', 'llms.txt'), 'utf8');
+  assert.match(
+    overview,
+    /\[Automation\]\(https:\/\/clawsec\.prompt\.security\/#\/wiki\/modules\/automation#dry-run\)/,
+  );
+  assert.match(
+    overview,
+    /!\[Logo\]\(https:\/\/raw\.githubusercontent\.com\/prompt-security\/clawsec\/main\/wiki\/assets\/logo\.svg\)/,
+  );
+  assert.deepEqual(findDeadRelativeLinks(overview), []);
+
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+test('generateWikiLlms ships no dead relative links across the real wiki/ export', async () => {
+  const wikiRoot = fileURLToPath(new URL('../wiki', import.meta.url));
+  const publicWikiRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-llms-real-'));
+
+  const { pageCount, outputFiles } = await generateWikiLlms({ wikiRoot, publicWikiRoot });
+
+  assert.ok(pageCount > 0, 'expected at least one wiki page to be exported');
+  assert.ok(outputFiles.length > 0);
+
+  const deadLinksByFile = new Map();
+  for (const outputFile of outputFiles) {
+    const content = await readFile(outputFile, 'utf8');
+    const dead = findDeadRelativeLinks(content);
+    if (dead.length > 0) deadLinksByFile.set(path.relative(publicWikiRoot, outputFile), dead);
+  }
+
+  assert.deepEqual(
+    [...deadLinksByFile.entries()],
+    [],
+    'every internal wiki link must be rewritten to an absolute URL before export — a relative ' +
+      'link here 404s once served from the website (see issue #349)',
+  );
+
+  await rm(publicWikiRoot, { recursive: true, force: true });
+});
+
+test('wiki export verification workflow covers the llms.txt generator', async () => {
+  const verifyWorkflow = await readFile(
+    new URL('../.github/workflows/wiki-export-verify.yml', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(
+    verifyWorkflow,
+    /paths:[\s\S]*scripts\/generate-wiki-llms\.mjs/,
+    'wiki export verification workflow must run when the llms.txt generator changes',
+  );
+  assert.match(
+    verifyWorkflow,
+    /paths:[\s\S]*scripts\/test-wiki-llms-export\.mjs/,
+    'wiki export verification workflow must run when this test file changes',
+  );
+  assert.match(
+    verifyWorkflow,
+    /name: Test wiki llms\.txt export[\s\S]*node scripts\/test-wiki-llms-export\.mjs/,
+    'wiki export verification workflow must run the llms.txt export test before merge',
+  );
+});


### PR DESCRIPTION
## Summary

- `scripts/generate-wiki-llms.mjs` embedded wiki markdown verbatim into the `llms.txt` exports served at `/wiki/<slug>/llms.txt`, so every repo-relative link (`overview.md`, `es/INDEX.md`, `assets/*.svg`) shipped as a dead URL — 34 in the root index alone, repeated across all 121 page exports.
- Two sibling consumers of the same wiki source (`pages/WikiBrowser.tsx` and `scripts/build-github-wiki-export.mjs`) already resolve internal links correctly via the shared `resolveWikiLinkTarget` helper in `utils/wikiPathHelpers.mjs` — this generator just never adopted it.
- **Fix:** rewrite internal links at export time. Known wiki pages resolve to their absolute website route (`https://clawsec.prompt.security/#/wiki/<slug>`); everything else resolves to a `raw.githubusercontent.com` URL. External links, hash-only links, and root-absolute links are left untouched.
- **Correctness fix on top of that (caught in review):** the first pass hardcoded a `/wiki/` prefix for any non-page target, which is wrong for links that climb *above* the wiki root — wiki content lives one directory below the repo root, and real pages link out to root docs (`wiki/exploitability-scoring.md`'s `../CONTRIBUTING.md`, and the same file's 5 translated copies using `../../CONTRIBUTING.md`). `resolveWikiLinkTarget` clamps `..` at the wiki root instead of counting the overflow, so both normalized to the same string as an in-wiki reference and got rewritten to `.../main/wiki/CONTRIBUTING.md` — confirmed 404 (the file is at the repo root). Replaced that resolution with a local resolver that tracks how many `..` segments escape the wiki root and, when they do, resolves against the repo root instead. Confirmed live: the old URL 404s, the new one returns 200.
- **CI gate:** refactored the generator to export `generateWikiLlms()` (`isDirectRun()` pattern, matching `build-github-wiki-export.mjs`) and added `scripts/test-wiki-llms-export.mjs`, wired into `wiki-export-verify.yml`'s PR gate.

## Why the original bug shipped, and why the first gate wasn't enough

`wiki-export-verify.yml`'s path filter and test step only covered the GitHub Wiki mirror pipeline (`build-github-wiki-export.mjs`) — `generate-wiki-llms.mjs` had zero coverage and wasn't even in the path triggers. `gen:wiki-llms` runs as a `prebuild` step (so CI/deploy do execute it), but it only checked that `wiki/` exists, never that emitted links resolve, so a build with dead links still exited 0.

The first version of the new test only asserted links were *absolute* — which the `wiki/CONTRIBUTING.md` bug would have sailed straight through, since a wrong-but-absolute URL still looks absolute. Rewrote the real-wiki integration test to instead check that every `raw.githubusercontent.com` link resolves to a file that **actually exists in the repo**, and added a fixture test reproducing the exact escape-above-root scenario. Verified both catch the regression by reintroducing the bug (2 of 4 subtests go red), then restored the fix.

## Scope / blast-radius check

- **Website:** ran a full `npm run build` and inspected `dist/wiki/**` directly — the exact directory `deploy-pages.yml` uploads and deploys. Spot-checked every `raw.githubusercontent.com` link in the built output resolves to a real file on disk (0 missing) and confirmed the previously-broken `CONTRIBUTING.md` link is now live via `curl` (200, was 404).
- **GitHub Wiki mirror** (`build-github-wiki-export.mjs`, `wikiPathHelpers.mjs`, `wiki-sync.yml`): untouched by this PR. Its own test suite still passes 4/4 unmodified.

## Verification

- Regenerated all 121 exports + root index: **0** relative links remaining, all 6 real `CONTRIBUTING.md` references now resolve to the correct, live repo-root URL.
- `node scripts/test-wiki-sync-export.mjs` — 4/4 pass (GitHub Wiki pipeline, unaffected).
- `node scripts/test-wiki-llms-export.mjs` — 4/4 pass (new gate, confirmed to catch the regression when reintroduced).
- `npx eslint . --ext .ts,.tsx,.js,.jsx,.mjs --max-warnings 0` — clean.
- `npx tsc --noEmit` — clean.
- `npm run build` — succeeds end-to-end; verified `dist/wiki/**` output directly, including live-URL spot checks.

Fixes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)