### PR TITLE
feat(wiki): align llms.txt exports with the llms.txt v2 spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ dist-ssr
 public/advisories
 public/skills
 public/wiki/
+public/llms.txt
 
 # Python bytecode
 __pycache__/

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
     <title>ClawSec | Agent Hardening | Prompt Security, SentinelOne </title>
     <link rel="icon" type="image/x-icon" href="/img/favicon.ico" />
+    <!-- llms.txt v2 discovery: points agents at the LLM-readable index for this site. -->
+    <link rel="describedby" type="text/plain" href="/llms.txt" />
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
       @font-face {

--- a/pages/WikiBrowser.tsx
+++ b/pages/WikiBrowser.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { BookOpenText, ExternalLink, FileText } from 'lucide-react';
 import { Link, useParams } from 'react-router';
 import Markdown from 'react-markdown';
@@ -185,6 +185,24 @@ export const WikiBrowser: React.FC = () => {
         ),
       }));
   }, []);
+
+  // llms.txt v2 discovery: advertise the markdown alternate for the page being viewed, so
+  // an agent that lands on the rendered HTML can find the LLM-friendly version. Kept in
+  // sync with the route rather than rendered once, because this is a single-page app.
+  const markdownAlternateSlug = selectedDoc?.slug.toLowerCase();
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+
+    const link = document.createElement('link');
+    link.rel = 'alternate';
+    link.type = 'text/markdown';
+    link.href = markdownAlternateSlug ? `/wiki/${markdownAlternateSlug}.md` : '/wiki/llms.txt';
+    document.head.appendChild(link);
+
+    return () => {
+      link.remove();
+    };
+  }, [markdownAlternateSlug]);
 
   if (!selectedDoc) {
     return (

--- a/scripts/generate-wiki-llms.mjs
+++ b/scripts/generate-wiki-llms.mjs
@@ -18,7 +18,8 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
 const WIKI_ROOT = path.join(REPO_ROOT, 'wiki');
-const PUBLIC_WIKI_ROOT = path.join(REPO_ROOT, 'public', 'wiki');
+const PUBLIC_ROOT = path.join(REPO_ROOT, 'public');
+const PUBLIC_WIKI_ROOT = path.join(PUBLIC_ROOT, 'wiki');
 
 export const WEBSITE_BASE = 'https://clawsec.prompt.security';
 export const REPO_BASE = 'https://github.com/prompt-security/clawsec';
@@ -26,6 +27,14 @@ export const RAW_BASE = 'https://raw.githubusercontent.com/prompt-security/claws
 
 const toPosix = (inputPath) => inputPath.split(path.sep).join('/');
 const toLlmsPageUrl = (slug) => `${WEBSITE_BASE}${toWikiLlmsPath(slug)}`;
+
+// llms.txt v2: "The links in an llms.txt file should therefore point to LLM-friendly
+// content, such as the markdown versions of pages." We publish a clean `.md` alternate
+// per page and point every generated link at that, not at the SPA route — a `#/wiki/...`
+// fragment is never sent to the server, so an agent following it receives the app shell
+// with none of the page content.
+export const toWikiMarkdownPath = (slug) => `/wiki/${slug}.md`;
+const toWikiMarkdownUrl = (slug) => `${WEBSITE_BASE}${toWikiMarkdownPath(slug)}`;
 
 // Resolve a wiki-relative link, tracking how many `..` segments climb past the wiki root
 // (`aboveWikiRoot`). wikiPathHelpers' resolveWikiLinkTarget clamps `..` at the wiki root
@@ -84,7 +93,7 @@ const rewriteInternalLinks = (content, docRelativePath, slugSet) =>
       return `](${RAW_BASE}/wiki/${resolvedPath}${hash})`;
     }
 
-    return `](${WEBSITE_BASE}/#${toWikiRoute(targetSlug)}${hash})`;
+    return `](${toWikiMarkdownUrl(targetSlug)}${hash})`;
   });
 
 const walkMarkdownFiles = async (dir) => {
@@ -136,28 +145,70 @@ const buildPageBody = (doc, slugSet) => {
   ].join('\n');
 };
 
-const buildFallbackIndexBody = (docs) => {
-  const lines = [
-    '# ClawSec Wiki llms.txt',
-    '',
-    'LLM-readable index for wiki pages.',
-    '',
-    `Website wiki root: ${WEBSITE_BASE}/#/wiki`,
-    `GitHub wiki mirror: ${REPO_BASE}/wiki`,
-    `Canonical source of truth: ${REPO_BASE}/tree/main/wiki`,
-    '',
-    '## Generated Page Exports',
-  ];
+// Group the wiki's own INDEX.md link lists by their H2 heading, so the generated index
+// mirrors the curated ordering maintained in wiki/INDEX.md rather than inventing one.
+// Only list items that resolve to a real wiki page are kept; prose sections (Summary,
+// Update Notes, Source References) yield no entries and are dropped.
+const extractIndexSections = (indexDoc, docsBySlug) => {
+  if (!indexDoc) return [];
 
-  for (const doc of docs) {
-    const pageRoute = toWikiRoute(doc.slug);
-    const pageUrl = `${WEBSITE_BASE}/#${pageRoute}`;
-    const llmsUrl = toLlmsPageUrl(doc.slug);
-    lines.push(`- ${doc.title}: ${llmsUrl} (page: ${pageUrl})`);
+  const sections = [];
+  let current = null;
+
+  for (const line of indexDoc.content.split(/\r?\n/)) {
+    const heading = /^##\s+(.+?)\s*$/.exec(line);
+    if (heading) {
+      current = { title: heading[1], entries: [] };
+      sections.push(current);
+      continue;
+    }
+
+    const item = /^\s*-\s+\[([^\]]+)\]\(([^)\s]+)\)/.exec(line);
+    if (!current || !item) continue;
+
+    const [, label, href] = item;
+    const { path: resolvedPath, aboveWikiRoot } = resolveLinkPath(indexDoc.relativePath, splitWikiHash(href).path);
+    if (aboveWikiRoot > 0 || !resolvedPath.toLowerCase().endsWith('.md')) continue;
+
+    const slug = resolvedPath.replace(/\.md$/i, '').toLowerCase();
+    const doc = docsBySlug.get(slug);
+    if (doc) current.entries.push({ label, doc });
   }
 
-  return `${lines.join('\n')}\n`;
+  return sections.filter((section) => section.entries.length > 0);
 };
+
+// llms.txt v2 structure: a single H1, a blockquote summary, optional prose, then H2
+// sections whose bodies are link lists. Anything else (notably a second H1, or an entire
+// page body inlined under an H2) breaks the format agents are told to expect.
+const buildLlmsIndex = ({ h1, summary, notes, sections, extraSections = [] }) => {
+  const lines = [`# ${h1}`, '', `> ${summary}`, ''];
+
+  for (const note of notes) lines.push(note, '');
+
+  for (const section of sections) {
+    lines.push(`## ${section.title}`);
+    for (const entry of section.entries) {
+      lines.push(`- [${entry.label}](${toWikiMarkdownUrl(entry.doc.slug)})`);
+    }
+    lines.push('');
+  }
+
+  for (const section of extraSections) {
+    lines.push(`## ${section.title}`);
+    for (const entry of section.entries) {
+      lines.push(entry.note ? `- [${entry.label}](${entry.url}): ${entry.note}` : `- [${entry.label}](${entry.url})`);
+    }
+    lines.push('');
+  }
+
+  return `${lines.join('\n').trimEnd()}\n`;
+};
+
+// Fallback when wiki/INDEX.md is missing: one flat section listing every page.
+const buildFallbackSections = (docs) => [
+  { title: 'Pages', entries: docs.map((doc) => ({ label: doc.title, doc })) },
+];
 
 /**
  * Generate llms.txt exports for every wiki page under `wikiRoot`, writing them to
@@ -166,7 +217,7 @@ const buildFallbackIndexBody = (docs) => {
  * @param {{ wikiRoot: string, publicWikiRoot: string }} options
  * @returns {Promise<{ pageCount: number, outputFiles: string[] }>}
  */
-export const generateWikiLlms = async ({ wikiRoot, publicWikiRoot }) => {
+export const generateWikiLlms = async ({ wikiRoot, publicWikiRoot, publicRoot }) => {
   const wikiStat = await fs.stat(wikiRoot).catch(() => null);
   if (!wikiStat || !wikiStat.isDirectory()) {
     throw new Error(`wiki/ directory not found at ${wikiRoot}.`);
@@ -194,20 +245,80 @@ export const generateWikiLlms = async ({ wikiRoot, publicWikiRoot }) => {
   await fs.mkdir(publicWikiRoot, { recursive: true });
 
   const outputFiles = [];
+  const markdownFilesWritten = [];
 
-  for (const doc of pageDocs) {
+  for (const doc of docs) {
+    // The `.md` alternate is the LLM-friendly content surface the index links to.
+    const markdownFile = path.join(publicWikiRoot, `${doc.slug}.md`);
+    await fs.mkdir(path.dirname(markdownFile), { recursive: true });
+    await fs.writeFile(markdownFile, `${rewriteInternalLinks(doc.content, doc.relativePath, slugSet).trim()}\n`, 'utf8');
+    markdownFilesWritten.push(markdownFile);
+
+    // Retained unchanged so anything already consuming /wiki/<slug>/llms.txt keeps working.
+    if (isWikiIndexSlug(doc.slug)) continue;
     const outputFile = path.join(publicWikiRoot, doc.slug, 'llms.txt');
     await fs.mkdir(path.dirname(outputFile), { recursive: true });
     await fs.writeFile(outputFile, buildPageBody(doc, slugSet), 'utf8');
     outputFiles.push(outputFile);
   }
 
-  const indexFile = path.join(publicWikiRoot, 'llms.txt');
-  const indexBody = indexDoc ? buildPageBody(indexDoc, slugSet) : buildFallbackIndexBody(pageDocs);
-  await fs.writeFile(indexFile, indexBody, 'utf8');
-  outputFiles.push(indexFile);
+  const docsBySlug = new Map(docs.map((doc) => [doc.slug, doc]));
+  const sections = indexDoc
+    ? extractIndexSections(indexDoc, docsBySlug)
+    : buildFallbackSections(pageDocs);
 
-  return { pageCount: pageDocs.length, outputFiles };
+  const wikiIndexBody = buildLlmsIndex({
+    h1: 'ClawSec Wiki',
+    summary:
+      'Full repository wiki for ClawSec, a security skill suite for AI agents covering the web '
+      + 'catalog, signed advisory feed, and per-skill release packaging. Every link below points to '
+      + 'the markdown version of a page.',
+    notes: [
+      `Canonical source of truth: ${REPO_BASE}/tree/main/wiki`,
+      `Human-readable wiki: ${WEBSITE_BASE}/#/wiki`,
+    ],
+    sections,
+  });
+  const wikiIndexFile = path.join(publicWikiRoot, 'llms.txt');
+  await fs.writeFile(wikiIndexFile, wikiIndexBody, 'utf8');
+  outputFiles.push(wikiIndexFile);
+
+  // Site-root index. Spec: a file "covers the pages under its path, and the most specific
+  // file applies", so this points at the wiki index rather than duplicating its entries.
+  let rootIndexFile = null;
+  if (publicRoot) {
+    const rootIndexBody = buildLlmsIndex({
+      h1: 'ClawSec',
+      summary:
+        'Security skill suite for AI agents: integrity checks, drift detection, and a signed '
+        + 'advisory feed, distributed as installable skills for OpenClaw and NanoClaw.',
+      notes: [`Repository: ${REPO_BASE}`],
+      sections: [],
+      extraSections: [
+        {
+          title: 'Docs',
+          entries: [
+            {
+              label: 'ClawSec Wiki',
+              url: `${WEBSITE_BASE}/wiki/llms.txt`,
+              note: 'index of every wiki page, in markdown',
+            },
+          ],
+        },
+      ],
+    });
+    rootIndexFile = path.join(publicRoot, 'llms.txt');
+    await fs.mkdir(publicRoot, { recursive: true });
+    await fs.writeFile(rootIndexFile, rootIndexBody, 'utf8');
+    outputFiles.push(rootIndexFile);
+  }
+
+  return {
+    pageCount: pageDocs.length,
+    outputFiles,
+    markdownFiles: markdownFilesWritten,
+    rootIndexFile,
+  };
 };
 
 const isDirectRun = () => {
@@ -217,9 +328,15 @@ const isDirectRun = () => {
 
 if (isDirectRun()) {
   try {
-    const { pageCount } = await generateWikiLlms({ wikiRoot: WIKI_ROOT, publicWikiRoot: PUBLIC_WIKI_ROOT });
+    const { pageCount, markdownFiles } = await generateWikiLlms({
+      wikiRoot: WIKI_ROOT,
+      publicWikiRoot: PUBLIC_WIKI_ROOT,
+      publicRoot: PUBLIC_ROOT,
+    });
     // Keep logs short for CI readability.
-    console.log(`Generated ${pageCount} page llms.txt exports and /wiki/llms.txt`);
+    console.log(
+      `Generated ${markdownFiles.length} wiki .md alternates, ${pageCount} page llms.txt exports, /wiki/llms.txt and /llms.txt`,
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`Failed to generate wiki llms exports: ${message}`);

--- a/scripts/test-wiki-llms-export.mjs
+++ b/scripts/test-wiki-llms-export.mjs
@@ -6,7 +6,6 @@ import path from 'node:path';
 import test from 'node:test';
 
 import { generateWikiLlms, RAW_BASE, WEBSITE_BASE } from './generate-wiki-llms.mjs';
-import { toWikiRoute } from '../utils/wikiPathHelpers.mjs';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
@@ -18,6 +17,9 @@ const writeFixture = async (root, relativePath, content) => {
 
 const extractLinkTargets = (content) =>
   [...content.matchAll(/\]\(([^)\s]+)\)/g)].map(([, target]) => target);
+
+const isAbsoluteHref = (target) =>
+  /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target) || target.startsWith('/') || target.startsWith('#');
 
 // The rewriter parses the plain `](dest)` form only. That covers all wiki content today,
 // but CommonMark also allows titles (`](a.md "t")`), angle-bracket destinations
@@ -44,27 +46,21 @@ const findUnparseableLinkForms = (content) => {
   return problems;
 };
 
-const isAbsoluteHref = (target) =>
-  /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target) || target.startsWith('/') || target.startsWith('#');
-
-const toSlug = (outputFile, publicWikiRoot) => {
-  const relDir = path.relative(publicWikiRoot, path.dirname(outputFile));
-  return relDir === '' ? 'index' : relDir.split(path.sep).join('/');
-};
-
-test('generateWikiLlms rewrites internal wiki links to absolute URLs', async () => {
+test('wiki links resolve to the markdown alternate, not the SPA route', async () => {
+  // llms.txt v2: "The links in an llms.txt file should therefore point to LLM-friendly
+  // content, such as the markdown versions of pages." A `#/wiki/...` fragment is never
+  // sent to the server, so linking there hands an agent the app shell and no content.
   const tmpRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-llms-'));
   const wikiRoot = path.join(tmpRoot, 'wiki');
-  const publicWikiRoot = path.join(tmpRoot, 'public-wiki');
+  const publicWikiRoot = path.join(tmpRoot, 'public', 'wiki');
 
   await writeFixture(wikiRoot, 'INDEX.md', [
     '# Wiki Index',
     '',
+    '## Start Here',
     '- [Overview](overview.md)',
     '- [Missing page](missing-page.md)',
     '- [External](https://example.com/docs)',
-    '- [Same-page section](#summary)',
-    '- [Root absolute](/wiki/overview)',
     '',
   ].join('\n'));
   await writeFixture(wikiRoot, 'overview.md', [
@@ -79,27 +75,82 @@ test('generateWikiLlms rewrites internal wiki links to absolute URLs', async () 
 
   await generateWikiLlms({ wikiRoot, publicWikiRoot });
 
-  const index = await readFile(path.join(publicWikiRoot, 'llms.txt'), 'utf8');
-  assert.match(index, /\[Overview\]\(https:\/\/clawsec\.prompt\.security\/#\/wiki\/overview\)/);
+  const overviewMd = await readFile(path.join(publicWikiRoot, 'overview.md'), 'utf8');
   assert.match(
-    index,
-    /\[Missing page\]\(https:\/\/raw\.githubusercontent\.com\/prompt-security\/clawsec\/main\/wiki\/missing-page\.md\)/,
+    overviewMd,
+    /\[Automation\]\(https:\/\/clawsec\.prompt\.security\/wiki\/modules\/automation\.md#dry-run\)/,
+    'in-wiki link must point at the .md alternate, preserving the hash',
   );
-  assert.match(index, /\[External\]\(https:\/\/example\.com\/docs\)/);
-  assert.match(index, /\[Same-page section\]\(#summary\)/);
-  assert.match(index, /\[Root absolute\]\(\/wiki\/overview\)/);
-  assert.ok(extractLinkTargets(index).every(isAbsoluteHref));
-
-  const overview = await readFile(path.join(publicWikiRoot, 'overview', 'llms.txt'), 'utf8');
+  assert.doesNotMatch(overviewMd, /\/#\/wiki\//, 'must not emit SPA hash routes as link targets');
   assert.match(
-    overview,
-    /\[Automation\]\(https:\/\/clawsec\.prompt\.security\/#\/wiki\/modules\/automation#dry-run\)/,
-  );
-  assert.match(
-    overview,
+    overviewMd,
     /!\[Logo\]\(https:\/\/raw\.githubusercontent\.com\/prompt-security\/clawsec\/main\/wiki\/assets\/logo\.svg\)/,
+    'assets have no .md alternate and fall back to raw source',
   );
-  assert.ok(extractLinkTargets(overview).every(isAbsoluteHref));
+
+  const index = await readFile(path.join(publicWikiRoot, 'llms.txt'), 'utf8');
+  assert.match(index, /- \[Overview\]\(https:\/\/clawsec\.prompt\.security\/wiki\/overview\.md\)/);
+  assert.doesNotMatch(index, /\/#\/wiki\/overview/);
+  // Entries that resolve to no wiki page are dropped from the index rather than shipped dead.
+  assert.doesNotMatch(index, /Missing page/);
+
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+test('generated llms.txt files follow the v2 structure', async () => {
+  const tmpRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-llms-v2-'));
+  const wikiRoot = path.join(tmpRoot, 'wiki');
+  const publicRoot = path.join(tmpRoot, 'public');
+  const publicWikiRoot = path.join(publicRoot, 'wiki');
+
+  await writeFixture(wikiRoot, 'INDEX.md', [
+    '# Wiki Index',
+    '',
+    '## Summary',
+    '- Prose only, no links, so this section is dropped.',
+    '',
+    '## Start Here',
+    '- [Overview](overview.md)',
+    '',
+  ].join('\n'));
+  await writeFixture(wikiRoot, 'overview.md', '# Overview\n\nBody.\n');
+
+  const { rootIndexFile } = await generateWikiLlms({ wikiRoot, publicWikiRoot, publicRoot });
+  assert.ok(rootIndexFile, 'a site-root /llms.txt must be generated');
+
+  for (const file of [rootIndexFile, path.join(publicWikiRoot, 'llms.txt')]) {
+    const body = await readFile(file, 'utf8');
+    const lines = body.split('\n');
+
+    // "An H1 with the name of the project or site. This is the only required section."
+    const h1s = lines.filter((line) => /^# /.test(line));
+    assert.equal(h1s.length, 1, `${path.basename(file)} must contain exactly one H1, got ${h1s.length}`);
+    assert.match(lines[0], /^# /, 'the H1 must be the first line');
+
+    // "A blockquote with a short summary of the project."
+    assert.ok(
+      lines.some((line) => line.startsWith('> ')),
+      `${path.basename(file)} must contain a blockquote summary`,
+    );
+
+    // "Zero or more markdown sections delimited by H2 headers, containing file lists of URLs."
+    // Every line under an H2 must be a link list item — never an inlined page body.
+    let inSection = false;
+    for (const line of lines) {
+      if (/^## /.test(line)) { inSection = true; continue; }
+      if (!inSection || line.trim() === '') continue;
+      assert.match(
+        line,
+        /^- \[[^\]]+\]\([^)]+\)/,
+        `${path.basename(file)}: content under an H2 must be a link list item, got: ${line}`,
+      );
+    }
+  }
+
+  // A prose-only section contributes no links and must not be emitted as an empty H2.
+  const wikiIndex = await readFile(path.join(publicWikiRoot, 'llms.txt'), 'utf8');
+  assert.doesNotMatch(wikiIndex, /^## Summary$/m);
+  assert.match(wikiIndex, /^## Start Here$/m);
 
   await rm(tmpRoot, { recursive: true, force: true });
 });
@@ -113,7 +164,7 @@ test('generateWikiLlms resolves links that climb above the wiki root against the
   // in-wiki reference, and ends up emitting a `wiki/`-prefixed raw URL that 404s.
   const tmpRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-llms-escape-'));
   const wikiRoot = path.join(tmpRoot, 'wiki');
-  const publicWikiRoot = path.join(tmpRoot, 'public-wiki');
+  const publicWikiRoot = path.join(tmpRoot, 'public', 'wiki');
 
   await writeFixture(tmpRoot, 'CONTRIBUTING.md', '# Contributing\n');
   await writeFixture(wikiRoot, 'top-level.md', [
@@ -134,13 +185,11 @@ test('generateWikiLlms resolves links that climb above the wiki root against the
   const expectedLink = `[CONTRIBUTING](${RAW_BASE}/CONTRIBUTING.md)`;
   const wrongLink = `${RAW_BASE}/wiki/CONTRIBUTING.md`;
 
-  const topLevel = await readFile(path.join(publicWikiRoot, 'top-level', 'llms.txt'), 'utf8');
-  assert.ok(topLevel.includes(expectedLink), `expected ${expectedLink} in top-level export`);
-  assert.ok(!topLevel.includes(wrongLink), `must not resolve into a nonexistent wiki/-prefixed path`);
-
-  const nested = await readFile(path.join(publicWikiRoot, 'de', 'nested', 'llms.txt'), 'utf8');
-  assert.ok(nested.includes(expectedLink), `expected ${expectedLink} in nested export`);
-  assert.ok(!nested.includes(wrongLink), `must not resolve into a nonexistent wiki/-prefixed path`);
+  for (const relativePath of ['top-level.md', path.join('de', 'nested.md')]) {
+    const body = await readFile(path.join(publicWikiRoot, relativePath), 'utf8');
+    assert.ok(body.includes(expectedLink), `expected ${expectedLink} in ${relativePath}`);
+    assert.ok(!body.includes(wrongLink), `${relativePath} must not resolve into a wiki/-prefixed path`);
+  }
 
   await rm(tmpRoot, { recursive: true, force: true });
 });
@@ -151,10 +200,11 @@ test('the export gate rejects link forms the rewriter cannot faithfully handle',
   // that is how a dead link ships unnoticed (the #349 failure mode). Assert it fails loudly.
   const tmpRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-llms-forms-'));
   const wikiRoot = path.join(tmpRoot, 'wiki');
-  const publicWikiRoot = path.join(tmpRoot, 'public-wiki');
+  const publicWikiRoot = path.join(tmpRoot, 'public', 'wiki');
 
-  await writeFixture(wikiRoot, 'INDEX.md', [
-    '# Wiki Index',
+  await writeFixture(wikiRoot, 'INDEX.md', '# Wiki Index\n');
+  await writeFixture(wikiRoot, 'page.md', [
+    '# Page',
     '',
     '- [Titled](overview.md "page title")',
     '- [Angled](<assets/my image.svg>)',
@@ -164,49 +214,60 @@ test('the export gate rejects link forms the rewriter cannot faithfully handle',
   await writeFixture(wikiRoot, 'overview.md', '# Overview\n');
 
   await generateWikiLlms({ wikiRoot, publicWikiRoot });
-  const index = await readFile(path.join(publicWikiRoot, 'llms.txt'), 'utf8');
+  const page = await readFile(path.join(publicWikiRoot, 'page.md'), 'utf8');
 
-  const problems = findUnparseableLinkForms(index);
+  const problems = findUnparseableLinkForms(page);
   assert.equal(problems.length, 3, `expected all three unsupported forms flagged, got: ${problems}`);
   assert.ok(problems.some((p) => p.includes('page title')));
   assert.ok(problems.some((p) => p.includes('my image.svg')));
   assert.ok(problems.some((p) => p.includes('spec_(v2')));
 
-  // A plain link alongside them still rewrites correctly and is not flagged.
-  assert.ok(findUnparseableLinkForms('[Overview](overview.md)').length === 0);
+  assert.equal(findUnparseableLinkForms('[Overview](overview.md)').length, 0);
 
   await rm(tmpRoot, { recursive: true, force: true });
 });
 
-test('generateWikiLlms only emits internal links that resolve to a real target, across the actual wiki/', async () => {
+test('every emitted link resolves to a real target, across the actual wiki/', async () => {
   const wikiRoot = path.join(REPO_ROOT, 'wiki');
-  const publicWikiRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-llms-real-'));
+  const publicRoot = await mkdtemp(path.join(os.tmpdir(), 'clawsec-wiki-llms-real-'));
+  const publicWikiRoot = path.join(publicRoot, 'wiki');
 
-  const { pageCount, outputFiles } = await generateWikiLlms({ wikiRoot, publicWikiRoot });
+  const { pageCount, outputFiles, markdownFiles } = await generateWikiLlms({
+    wikiRoot,
+    publicWikiRoot,
+    publicRoot,
+  });
   assert.ok(pageCount > 0, 'expected at least one wiki page to be exported');
+  assert.ok(markdownFiles.length > 0, 'expected .md alternates to be generated');
 
-  const knownRoutes = new Set(outputFiles.map((file) => toWikiRoute(toSlug(file, publicWikiRoot))));
-  const websitePrefix = `${WEBSITE_BASE}/#`;
+  // Every markdown alternate the generator produced, addressable as the index links it.
+  const publishedMarkdown = new Set(
+    markdownFiles.map((file) => `/wiki/${path.relative(publicWikiRoot, file).split(path.sep).join('/')}`),
+  );
+
   const rawPrefix = `${RAW_BASE}/`;
-
   const brokenLinksByFile = new Map();
 
-  for (const outputFile of outputFiles) {
+  for (const outputFile of [...outputFiles, ...markdownFiles]) {
     const content = await readFile(outputFile, 'utf8');
     const broken = findUnparseableLinkForms(content);
 
     for (const target of extractLinkTargets(content)) {
-      if (target.startsWith('#')) continue; // same-page anchor
+      if (target.startsWith('#')) continue;
 
       if (!isAbsoluteHref(target)) {
         broken.push(`relative link left unrewritten: ${target}`);
         continue;
       }
 
+      if (target.includes('/#/wiki/')) {
+        broken.push(`links to an SPA hash route, which serves no content to agents: ${target}`);
+        continue;
+      }
+
       if (target.startsWith(rawPrefix)) {
-        // The one check that actually catches a wrong-but-absolute URL: does the path this
-        // points at exist in the repo? A `wiki/`-prefixed path for a repo-root file passes
-        // every "is it absolute" check and still 404s — only an existence check catches it.
+        // Catches a wrong-but-absolute URL: a `wiki/`-prefixed path for a repo-root file
+        // passes every "is it absolute" check and still 404s.
         const repoRelativePath = target.slice(rawPrefix.length).split('#')[0];
         const exists = await access(path.join(REPO_ROOT, repoRelativePath))
           .then(() => true)
@@ -215,28 +276,30 @@ test('generateWikiLlms only emits internal links that resolve to a real target, 
         continue;
       }
 
-      if (target.startsWith(websitePrefix)) {
-        const route = target.slice(websitePrefix.length).split('#')[0];
-        if (!knownRoutes.has(route)) {
-          broken.push(`website link points at a route with no generated export: ${target}`);
+      if (target.startsWith(WEBSITE_BASE)) {
+        const sitePath = target.slice(WEBSITE_BASE.length).split('#')[0];
+        // The wiki index is a generated artifact, not a markdown alternate.
+        if (sitePath === '/wiki/llms.txt') continue;
+        if (!publishedMarkdown.has(sitePath)) {
+          broken.push(`site link points at a file that is not generated: ${target}`);
         }
       }
     }
 
     if (broken.length > 0) {
-      brokenLinksByFile.set(path.relative(publicWikiRoot, outputFile), broken);
+      brokenLinksByFile.set(path.relative(publicRoot, outputFile), broken);
     }
   }
 
   assert.deepEqual(
     [...brokenLinksByFile.entries()],
     [],
-    'every internal wiki link must resolve to something that actually exists — a relative link, ' +
-      'or an absolute URL pointing at a nonexistent path, 404s once served from the website ' +
-      '(see issue #349)',
+    'every emitted link must resolve to something that actually exists — a relative link, an '
+      + 'SPA hash route, or an absolute URL pointing at a nonexistent path all dead-end for the '
+      + 'agents these files exist for (see issue #349)',
   );
 
-  await rm(publicWikiRoot, { recursive: true, force: true });
+  await rm(publicRoot, { recursive: true, force: true });
 });
 
 test('wiki export verification workflow covers the llms.txt generator', async () => {


### PR DESCRIPTION
# User description
## The problem

The [llms.txt v2 spec](https://llmstxt.org/) says:

> The links in an llms.txt file should therefore point to LLM-friendly content, such as the markdown versions of pages described above.

Ours pointed at SPA hash routes (`https://clawsec.prompt.security/#/wiki/overview`). A `#...` fragment is **never sent to the server**, so an agent following a link from our llms.txt gets the app shell and no content:

```
GET /#/wiki/overview   -> 5189 bytes, contains Overview content? NO
GET /wiki/overview/llms.txt -> 6856 bytes, contains Overview content? YES
```

That's the same dead-end #349 was filed about, one step further along: we fixed the 404s, then pointed the links at a target that serves nothing.

Four more gaps against v2, found while reading the spec:

| Gap | v2 says |
|---|---|
| Two `# H1`s per export (wrapper + inlined body) | "An H1 with the name of the project or site. This is the only required section" |
| No blockquote summary | "A blockquote with a short summary of the project" |
| `## Markdown` inlined an entire page body | H2 sections contain "file lists of URLs"; v2 "shifted... to emphasizing that links should point to LLM-friendly content rather than requiring full page content inline" |
| `/llms.txt` was 404; no `rel` discovery | v2 adds `rel="alternate" type="text/markdown"` and `rel="describedby"` |

(`/wiki/llms.txt` living at a subpath is fine — v2 explicitly allows it: "a file covers the pages under its path, and the most specific file applies".)

## What changed

- **`/wiki/<slug>.md` — new.** A clean markdown alternate per page (122 of them): internal links rewritten to other `.md` alternates, assets to raw source. This is the content surface agents read. Side effect: `/wiki/overview.md`, the URL #349 assumed existed, is now real.
- **`/wiki/llms.txt` — rebuilt as a conformant index.** One H1, blockquote summary, H2 link-list sections pointing at the `.md` alternates. Sections and ordering are derived from `wiki/INDEX.md`, so the curated structure is preserved rather than invented; prose-only sections (Summary, Update Notes, Source References) contribute no links and are dropped.
- **`/llms.txt` — new** site-root index.
- **Discovery** — static `rel="describedby"` in `index.html`, plus a `rel="alternate" type="text/markdown"` in `WikiBrowser.tsx` that tracks the active route (needed because this is an SPA, so a static tag would be wrong on every page but one).
- **`/wiki/<slug>/llms.txt` — unchanged and still published**, so anything already consuming those URLs keeps working. No breaking change.

## Verification

- Export gate extended and passing 6/6, including two new checks: a **v2 structure test** (exactly one H1, blockquote present, every line under an H2 must be a link-list item — this is what catches an inlined page body) and a rule that **fails on any SPA hash route used as a link target**.
- Confirmed in a browser against a live dev server: both discovery links render, `rel="alternate"` updates across route changes (`/#/wiki/overview` → `/wiki/overview.md`, `/#/wiki/es/index` → `/wiki/es/index.md`), and fetching the advertised alternate returns real markdown (200, correct localized content).
- `dist/` contains all 122 `.md` alternates, `/llms.txt`, `/wiki/llms.txt`, and the retained per-page exports. 0 SPA hash routes remain as link targets anywhere in the build.
- `scripts/test-wiki-sync-export.mjs` 4/4 and `scripts/test-deploy-pages-checksums.mjs` pass — GitHub Wiki mirror and advisory pipelines unaffected.
- `npx eslint . --max-warnings 0`, `npx tsc --noEmit`, `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align wiki and site <code>llms.txt</code> exports with the v2 specification by generating markdown page alternates and structured link indexes. Update <code>generate-wiki-llms</code>, <code>WikiBrowser</code>, and static discovery metadata so agents receive real content through route-aware markdown links.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/356?tool=ast&topic=Markdown+Discovery>Markdown Discovery</a>
        </td><td>Advertise the site and active wiki page markdown alternates through <code>rel=&quot;describedby&quot;</code> and route-aware <code>rel=&quot;alternate&quot;</code> metadata, with tests preventing SPA hash routes and broken targets.<details><summary>Modified files (3)</summary><ul><li>index.html</li>
<li>pages/WikiBrowser.tsx</li>
<li>scripts/test-wiki-llms-export.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>feat(wiki): align llms...</td><td>September 01, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(wiki): rewrite int...</td><td>September 01, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/356?tool=ast&topic=LLM+Markdown+Exports>LLM Markdown Exports</a>
        </td><td>Generate per-page <code>.md</code> alternates with rewritten internal links, rebuild wiki and site indexes with one H1, summaries, and curated link-list sections, while retaining existing per-page exports.<details><summary>Modified files (3)</summary><ul><li>.gitignore</li>
<li>scripts/generate-wiki-llms.mjs</li>
<li>scripts/test-wiki-llms-export.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>feat(wiki): align llms...</td><td>September 01, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(wiki): rewrite int...</td><td>September 01, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/clawsec/356?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>