### PR TITLE
ci(workflows): harden with zizmor, refresh pins, retire eol runtimes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,21 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/.github"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/.github/workflows/archive-traffic.yml
+++ b/.github/workflows/archive-traffic.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Prepare archive branch

--- a/.github/workflows/archive-traffic.yml
+++ b/.github/workflows/archive-traffic.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: traffic-archive
@@ -20,12 +20,17 @@ jobs:
   archive:
     name: Capture traffic snapshot
     runs-on: ubuntu-latest
+    permissions:
+      # Pushes the traffic snapshot to the traffic-archive branch.
+      contents: write
     steps:
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   lint-typescript:
@@ -20,7 +21,9 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -38,7 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
       - name: Ruff (lint + format check)
@@ -51,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: ShellCheck
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
@@ -68,8 +75,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Trivy FS Scan
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.34.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -77,7 +86,7 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
       - name: Trivy Config Scan
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.34.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'config'
           scan-ref: '.'
@@ -87,15 +96,14 @@ jobs:
   secret-scan:
     name: Secret Scan
     runs-on: ubuntu-latest
-    # Narrower than the workflow-wide read-all: this job runs third-party
-    # scanners over untrusted PR content and needs nothing but the checkout.
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # TruffleHog needs both sides of the range it is asked to diff.
           fetch-depth: 0
+          # The gitleaks step re-fetches the base ref, which needs no
+          # credentials on a public repository.
+          persist-credentials: false
       # Dead or alive: `unverified` is included deliberately, so a rotated or
       # already-dead credential still fails. It is the same policy as
       # .githooks/pre-push, so the local gate and CI cannot disagree.
@@ -106,7 +114,7 @@ jobs:
       # read as legacy GitHub PATs -- but a range scan sees only the diff, so an
       # ordinary PR reports 0.
       - name: TruffleHog
-        uses: trufflesecurity/trufflehog@20652fbbdefffcdaa493a5bf57ab2ac6b1db715b # v3.97.1
+        uses: trufflesecurity/trufflehog@cc1fe982afc515d2991365ce8d4d0dd07170fcad # v3.97.2
         with:
           extra_args: --results=verified,unknown,unverified
       # Private keys and other deterministic patterns. TruffleHog only emits a
@@ -145,7 +153,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -160,7 +170,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -197,7 +209,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -222,7 +236,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
       - name: Hermes Skill Tests
@@ -238,7 +254,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: ESLint
@@ -157,7 +157,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: npm audit
@@ -174,7 +174,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: GHSA Without CVE Feed Tests
@@ -213,7 +213,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Feed Verification Tests
@@ -240,7 +240,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Hermes Skill Tests
         shell: bash
         run: |
@@ -258,7 +258,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Suppression Config Tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,8 @@ on:
   schedule:
     - cron: "17 3 * * 1"
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analyze:
@@ -26,9 +27,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
@@ -39,4 +42,4 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/community-advisory.yml
+++ b/.github/workflows/community-advisory.yml
@@ -4,7 +4,8 @@ on:
   issues:
     types: [labeled]
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: community-advisory
@@ -27,6 +28,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Parse issue and create advisory
         id: parse
@@ -197,7 +199,7 @@ jobs:
 
       - name: Set up Python for exploitability analysis
         if: steps.parse.outputs.already_exists != 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.10'
 
@@ -252,7 +254,7 @@ jobs:
 
       - name: Sign advisory feed and verify
         if: steps.parse.outputs.already_exists != 'true'
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -313,12 +315,16 @@ jobs:
       - name: Comment on issue
         if: steps.parse.outputs.already_exists != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ADVISORY_ID: ${{ steps.parse.outputs.advisory_id }}
+          PULL_REQUEST_URL: ${{ steps.create-pr.outputs.pull-request-url }}
+          PULL_REQUEST_OPERATION: ${{ steps.create-pr.outputs.pull-request-operation }}
         with:
           github-token: ${{ secrets.POLL_NVD_CVES_PAT }}
           script: |
-            const advisoryId = '${{ steps.parse.outputs.advisory_id }}';
-            const pullRequestUrl = '${{ steps.create-pr.outputs.pull-request-url }}';
-            const operation = '${{ steps.create-pr.outputs.pull-request-operation }}';
+            const advisoryId = process.env.ADVISORY_ID;
+            const pullRequestUrl = process.env.PULL_REQUEST_URL;
+            const operation = process.env.PULL_REQUEST_OPERATION;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -339,10 +345,12 @@ jobs:
       - name: Comment if already exists
         if: steps.parse.outputs.already_exists == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ADVISORY_ID: ${{ steps.parse.outputs.advisory_id }}
         with:
           github-token: ${{ secrets.POLL_NVD_CVES_PAT }}
           script: |
-            const advisoryId = '${{ steps.parse.outputs.advisory_id }}';
+            const advisoryId = process.env.ADVISORY_ID;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/community-advisory.yml
+++ b/.github/workflows/community-advisory.yml
@@ -201,7 +201,7 @@ jobs:
         if: steps.parse.outputs.already_exists != 'true'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Analyze exploitability for community advisory
         if: steps.parse.outputs.already_exists != 'true'

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Verify signing key consistency (repo + docs)
@@ -433,7 +433,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Verify deployed advisory endpoints
         run: |

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,6 +3,9 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  # zizmor: ignore[dangerous-triggers] no PR head is checked out and no artifact
+  # from the triggering run is consumed; every job additionally guards on
+  # workflow_run.event != 'pull_request'.
   workflow_run:
     workflows: ["Skill Release"]
     types: [completed]
@@ -10,8 +13,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -37,9 +38,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -265,7 +268,7 @@ jobs:
           fi
 
       - name: Sign advisory feed and verify
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -275,7 +278,7 @@ jobs:
 
       - name: Sign provisional GHSA feed and verify
         if: hashFiles('public/advisories/ghsa-without-cve.json') != ''
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -286,7 +289,7 @@ jobs:
         run: node scripts/ci/advisory_pages_artifacts.mjs generate --public-dir public --repository "${{ github.repository }}"
 
       - name: Sign checksums and verify
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -315,6 +318,7 @@ jobs:
           ls -la public/checksums.json public/checksums.sig public/signing-public.pem
 
       - name: Get latest clawsec-suite release URL
+        id: suite_url
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -326,10 +330,10 @@ jobs:
               "/repos/${REPO}/releases?per_page=100" \
               | jq -r -s 'add // [] | [.[] | select(.tag_name | startswith("clawsec-suite-v"))] | first | .tag_name // empty'
           )
-          
+
           if [ -n "$LATEST_TAG" ]; then
             echo "Found latest clawsec-suite tag: $LATEST_TAG"
-            echo "VITE_CLAWSEC_SUITE_URL=https://clawsec.prompt.security/releases/download/${LATEST_TAG}/SKILL.md" >> $GITHUB_ENV
+            echo "url=https://clawsec.prompt.security/releases/download/${LATEST_TAG}/SKILL.md" >> "$GITHUB_OUTPUT"
 
             # Create a local "latest" mirror path for clients that use GitHub-style URLs.
             # This enables swapping the host:
@@ -362,7 +366,7 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: production
-          VITE_CLAWSEC_SUITE_URL: ${{ env.VITE_CLAWSEC_SUITE_URL }}
+          VITE_CLAWSEC_SUITE_URL: ${{ steps.suite_url.outputs.url }}
 
       - name: Verify built public artifacts
         run: |
@@ -408,10 +412,13 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1
 
   verify-production:
     name: Verify Production Advisory Endpoints
@@ -420,9 +427,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 

--- a/.github/workflows/i18n-qa.yml
+++ b/.github/workflows/i18n-qa.yml
@@ -10,7 +10,8 @@ on:
       - '.github/workflows/i18n-qa.yml'
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   i18n-qa:
@@ -20,7 +21,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
       - name: Run i18n QA
@@ -29,7 +31,7 @@ jobs:
       - name: Check markdown links (README/wiki)
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            python scripts/i18n/link_check.py --changed-only --base-ref "origin/${{ github.base_ref }}"
+            python scripts/i18n/link_check.py --changed-only --base-ref "origin/${GITHUB_BASE_REF}"
           else
             python scripts/i18n/link_check.py
           fi

--- a/.github/workflows/pages-verify.yml
+++ b/.github/workflows/pages-verify.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Verify signing key consistency (repo + docs)

--- a/.github/workflows/pages-verify.yml
+++ b/.github/workflows/pages-verify.yml
@@ -18,9 +18,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -51,7 +53,7 @@ jobs:
           rm -f "$KEY_FILE"
 
       - name: Sign advisory feed and verify
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ steps.test_key.outputs.private_key }}
           input_file: public/advisories/feed.json
@@ -60,7 +62,7 @@ jobs:
 
       - name: Sign provisional GHSA feed and verify
         if: hashFiles('public/advisories/ghsa-without-cve.json') != ''
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ steps.test_key.outputs.private_key }}
           input_file: public/advisories/ghsa-without-cve.json
@@ -70,7 +72,7 @@ jobs:
         run: node scripts/ci/advisory_pages_artifacts.mjs generate --public-dir public --repository "${{ github.repository }}"
 
       - name: Sign checksums and verify
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ steps.test_key.outputs.private_key }}
           input_file: public/checksums.json

--- a/.github/workflows/poll-ghsa-without-cve.yml
+++ b/.github/workflows/poll-ghsa-without-cve.yml
@@ -3,7 +3,8 @@ name: Poll GHSA Without CVE
 on:
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: poll-ghsa-without-cve
@@ -28,9 +29,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -85,7 +88,7 @@ jobs:
 
       - name: Sign GHSA feed and verify
         if: steps.changes.outputs.ghsa_changed == 'true'
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -94,7 +97,7 @@ jobs:
 
       - name: Sign consolidated agent feed and verify
         if: steps.changes.outputs.agent_changed == 'true'
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -152,16 +155,21 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Feed changed | ${{ steps.changes.outputs.changed }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Agent feed changed | ${{ steps.changes.outputs.agent_changed }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| GHSA source feed changed | ${{ steps.changes.outputs.ghsa_changed }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Feed changed | ${STEPS_CHANGES_OUTPUTS_CHANGED} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Agent feed changed | ${STEPS_CHANGES_OUTPUTS_AGENT_CHANGED} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| GHSA source feed changed | ${STEPS_CHANGES_OUTPUTS_GHSA_CHANGED} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Feed path | $GHSA_FEED_PATH |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Agent feed path | $FEED_PATH |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Total advisories | $(jq '.advisories | length' "$GHSA_FEED_PATH") |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Active | $(jq '[.advisories[] | select(.status == "active")] | length' "$GHSA_FEED_PATH") |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Matured | $(jq '[.advisories[] | select(.status == "matured")] | length' "$GHSA_FEED_PATH") |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Stale | $(jq '[.advisories[] | select(.status == "stale")] | length' "$GHSA_FEED_PATH") |" >> "$GITHUB_STEP_SUMMARY"
-          if [ -n "${{ steps.create-pr.outputs.pull-request-url }}" ]; then
+          if [ -n "${STEPS_CREATE_PR_OUTPUTS_PULL_REQUEST_URL}" ]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "Upserted PR: ${{ steps.create-pr.outputs.pull-request-url }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "Upserted PR: ${STEPS_CREATE_PR_OUTPUTS_PULL_REQUEST_URL}" >> "$GITHUB_STEP_SUMMARY"
           fi
+        env:
+          STEPS_CHANGES_OUTPUTS_CHANGED: ${{ steps.changes.outputs.changed }}
+          STEPS_CHANGES_OUTPUTS_AGENT_CHANGED: ${{ steps.changes.outputs.agent_changed }}
+          STEPS_CHANGES_OUTPUTS_GHSA_CHANGED: ${{ steps.changes.outputs.ghsa_changed }}
+          STEPS_CREATE_PR_OUTPUTS_PULL_REQUEST_URL: ${{ steps.create-pr.outputs.pull-request-url }}

--- a/.github/workflows/poll-ghsa-without-cve.yml
+++ b/.github/workflows/poll-ghsa-without-cve.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Run GHSA feed tests

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -12,7 +12,8 @@ on:
         default: 'false'
         type: boolean
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: poll-nvd-cves
@@ -40,6 +41,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Get last poll date from feed
         id: last_poll
@@ -63,8 +65,10 @@ jobs:
 
       - name: Set date window
         id: dates
+        env:
+          STEPS_LAST_POLL_OUTPUTS_LAST_DATE: ${{ steps.last_poll.outputs.last_date }}
         run: |
-          START_DATE="${{ steps.last_poll.outputs.last_date }}"
+          START_DATE="${STEPS_LAST_POLL_OUTPUTS_LAST_DATE}"
           END_DATE=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
           
           # Convert to epoch for comparison
@@ -85,6 +89,9 @@ jobs:
 
       - name: Fetch CVEs from NVD
         id: fetch
+        env:
+          STEPS_DATES_OUTPUTS_START_DATE: ${{ steps.dates.outputs.start_date }}
+          STEPS_DATES_OUTPUTS_END_DATE: ${{ steps.dates.outputs.end_date }}
         run: |
           set -euo pipefail
           source scripts/feed-utils.sh
@@ -92,8 +99,8 @@ jobs:
           FORCE_FULL_SCAN="${{ inputs.force_full_scan }}"
           NVD_QUERY_SPECS="$(nvd_query_specs)"
           
-          START_DATE="${{ steps.dates.outputs.start_date }}"
-          END_DATE="${{ steps.dates.outputs.end_date }}"
+          START_DATE="${STEPS_DATES_OUTPUTS_START_DATE}"
+          END_DATE="${STEPS_DATES_OUTPUTS_END_DATE}"
           
           # URL encode the dates
           START_ENC=$(echo "$START_DATE" | sed 's/:/%3A/g')
@@ -540,6 +547,8 @@ jobs:
 
       - name: Transform CVEs to advisories
         id: transform
+        env:
+          STEPS_PROCESS_OUTPUTS_FILTERED_COUNT: ${{ steps.process.outputs.filtered_count }}
         run: |
           # Read existing IDs into jq-friendly files (avoids huge CLI args on full scans).
           jq -R -s 'split("\n") | map(select(length > 0))' < tmp/existing_ids.txt > tmp/existing_ids_from_feed.json
@@ -747,7 +756,7 @@ jobs:
           echo "nvd_new_to_feed_count=$NET_NEW_COUNT" >> $GITHUB_OUTPUT
 
           if [ "${{ inputs.force_full_scan }}" = "true" ]; then
-            FILTERED_COUNT="${{ steps.process.outputs.filtered_count }}"
+            FILTERED_COUNT="${STEPS_PROCESS_OUTPUTS_FILTERED_COUNT}"
             if [ "$NEW_COUNT" -ne "$FILTERED_COUNT" ]; then
               echo "::error::Full scan transform mismatch: filtered CVEs=$FILTERED_COUNT transformed advisories=$NEW_COUNT"
               exit 1
@@ -761,7 +770,7 @@ jobs:
 
       - name: Set up Python for exploitability analysis
         if: steps.transform.outputs.new_count != '0'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.10'
 
@@ -916,6 +925,10 @@ jobs:
 
       - name: Detect advisory feed changes
         id: feed_changes
+        env:
+          STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT: ${{ steps.transform.outputs.nvd_rebuilt_count }}
+          STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT: ${{ steps.transform.outputs.nvd_new_to_feed_count }}
+          STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT: ${{ steps.nvd_counts.outputs.nvd_updated_count }}
         run: |
           set -euo pipefail
 
@@ -935,7 +948,7 @@ jobs:
             ' "$FEED_PATH"
           )"
 
-          if [ "${{ steps.transform.outputs.nvd_rebuilt_count }}" != "0" ] || [ "${{ steps.transform.outputs.nvd_new_to_feed_count }}" != "0" ] || [ "${{ steps.nvd_counts.outputs.nvd_updated_count }}" != "0" ]; then
+          if [ "${STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT}" != "0" ] || [ "${STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT}" != "0" ] || [ "${STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT}" != "0" ]; then
             NVD_CHANGED=true
           fi
 
@@ -979,7 +992,7 @@ jobs:
 
       - name: Sign GHSA feed and verify
         if: steps.feed_changes.outputs.ghsa_changed == 'true'
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -988,7 +1001,7 @@ jobs:
 
       - name: Sign advisory feed and verify
         if: steps.feed_changes.outputs.agent_changed == 'true'
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -1017,14 +1030,25 @@ jobs:
         id: upsert-pr
         env:
           GH_TOKEN: ${{ github.token }}
+          STEPS_DATES_OUTPUTS_START_DATE: ${{ steps.dates.outputs.start_date }}
+          STEPS_DATES_OUTPUTS_END_DATE: ${{ steps.dates.outputs.end_date }}
+          STEPS_PROCESS_OUTPUTS_NVD_FILTERED_COUNT: ${{ steps.process.outputs.nvd_filtered_count }}
+          STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT: ${{ steps.transform.outputs.nvd_rebuilt_count }}
+          STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT: ${{ steps.transform.outputs.nvd_new_to_feed_count }}
+          STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT: ${{ steps.nvd_counts.outputs.nvd_updated_count }}
+          STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT: ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }}
+          STEPS_FEED_CHANGES_OUTPUTS_GHSA_CHANGED: ${{ steps.feed_changes.outputs.ghsa_changed }}
+          STEPS_FEED_CHANGES_OUTPUTS_AGENT_CHANGED: ${{ steps.feed_changes.outputs.agent_changed }}
         run: |
           set -euo pipefail
 
           BRANCH_PREFIX="automated/nvd-cve-update"
           PR_COMMENT="Superseded by newer automated NVD advisory update."
-          TITLE="chore: update NVD/GHSA advisories - ${{ steps.transform.outputs.nvd_new_to_feed_count }} NVD new, ${{ steps.nvd_counts.outputs.nvd_updated_count }} NVD updated, ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }} GHSA active added"
+          TITLE="chore: update NVD/GHSA advisories - ${STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT} NVD new, ${STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT} NVD updated, ${STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT} GHSA active added"
           COMMIT_SUBJECT="$TITLE"
-          COMMIT_BODY=$'Automated update from NVD CVE and GHSA advisory feeds.\nKeywords: ${{ env.KEYWORDS }}\nPoll window: ${{ steps.dates.outputs.start_date }} to ${{ steps.dates.outputs.end_date }}'
+          # printf, not $'...': ANSI-C quoting does not expand parameters.
+          COMMIT_BODY="$(printf 'Automated update from NVD CVE and GHSA advisory feeds.\nKeywords: %s\nPoll window: %s to %s' \
+            "$KEYWORDS" "$STEPS_DATES_OUTPUTS_START_DATE" "$STEPS_DATES_OUTPUTS_END_DATE")"
 
           GHSA_TOTAL="$(jq '.advisories | length' "$GHSA_FEED_PATH")"
           GHSA_ACTIVE="$(jq '[.advisories[] | select(.status == "active")] | length' "$GHSA_FEED_PATH")"
@@ -1043,16 +1067,16 @@ jobs:
           Automated update from NVD CVE and GHSA advisory feeds.
 
           - **Mode:** ${MODE}
-          - **Filtered NVD CVEs:** ${{ steps.process.outputs.nvd_filtered_count }}
-          - **Rebuilt NVD advisories:** ${{ steps.transform.outputs.nvd_rebuilt_count }}
-          - **Net-new NVD advisories:** ${{ steps.transform.outputs.nvd_new_to_feed_count }}
-          - **Updated NVD advisories:** ${{ steps.nvd_counts.outputs.nvd_updated_count }}
-          - **GHSA active advisories added to consolidated feed:** ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }}
-          - **GHSA source feed changed:** ${{ steps.feed_changes.outputs.ghsa_changed }}
-          - **Consolidated agent feed changed:** ${{ steps.feed_changes.outputs.agent_changed }}
+          - **Filtered NVD CVEs:** ${STEPS_PROCESS_OUTPUTS_NVD_FILTERED_COUNT}
+          - **Rebuilt NVD advisories:** ${STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT}
+          - **Net-new NVD advisories:** ${STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT}
+          - **Updated NVD advisories:** ${STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT}
+          - **GHSA active advisories added to consolidated feed:** ${STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT}
+          - **GHSA source feed changed:** ${STEPS_FEED_CHANGES_OUTPUTS_GHSA_CHANGED}
+          - **Consolidated agent feed changed:** ${STEPS_FEED_CHANGES_OUTPUTS_AGENT_CHANGED}
           - **GHSA provisional advisories:** ${GHSA_TOTAL} total (${GHSA_ACTIVE} active, ${GHSA_MATURED} matured, ${GHSA_STALE} stale)
-          - **Poll window:** ${{ steps.dates.outputs.start_date }} → ${{ steps.dates.outputs.end_date }}
-          - **Keywords:** ${{ env.KEYWORDS }}
+          - **Poll window:** ${STEPS_DATES_OUTPUTS_START_DATE} → ${STEPS_DATES_OUTPUTS_END_DATE}
+          - **Keywords:** ${KEYWORDS}
 
           ---
           *This PR was automatically generated by the NVD CVE polling workflow with GHSA consolidation.*
@@ -1130,10 +1154,11 @@ jobs:
         if: steps.upsert-pr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          STEPS_UPSERT_PR_OUTPUTS_PULL_REQUEST_BRANCH: ${{ steps.upsert-pr.outputs.pull-request-branch }}
         run: |
           set -euo pipefail
 
-          BRANCH="${{ steps.upsert-pr.outputs.pull-request-branch }}"
+          BRANCH="${STEPS_UPSERT_PR_OUTPUTS_PULL_REQUEST_BRANCH}"
           if [ -z "$BRANCH" ]; then
             echo "::error::Missing pull-request-branch output from upsert-pr step"
             exit 1
@@ -1179,6 +1204,18 @@ jobs:
           gh run watch "$RUN_ID" --exit-status
 
       - name: Summary
+        env:
+          STEPS_DATES_OUTPUTS_START_DATE: ${{ steps.dates.outputs.start_date }}
+          STEPS_DATES_OUTPUTS_END_DATE: ${{ steps.dates.outputs.end_date }}
+          STEPS_PROCESS_OUTPUTS_NVD_FILTERED_COUNT: ${{ steps.process.outputs.nvd_filtered_count }}
+          STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT: ${{ steps.transform.outputs.nvd_rebuilt_count }}
+          STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT: ${{ steps.transform.outputs.nvd_new_to_feed_count }}
+          STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT: ${{ steps.nvd_counts.outputs.nvd_updated_count }}
+          STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT: ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }}
+          STEPS_FEED_CHANGES_OUTPUTS_GHSA_CHANGED: ${{ steps.feed_changes.outputs.ghsa_changed }}
+          STEPS_FEED_CHANGES_OUTPUTS_AGENT_CHANGED: ${{ steps.feed_changes.outputs.agent_changed }}
+          STEPS_FEED_CHANGES_OUTPUTS_CHANGED: ${{ steps.feed_changes.outputs.changed }}
+          STEPS_UPSERT_PR_OUTPUTS_PULL_REQUEST_URL: ${{ steps.upsert-pr.outputs.pull-request-url }}
         run: |
           if [ "${{ inputs.force_full_scan }}" = "true" ]; then
             MODE="full-rebuild (ignore feed state)"
@@ -1191,34 +1228,34 @@ jobs:
           echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Mode | $MODE |" >> $GITHUB_STEP_SUMMARY
-          echo "| Poll Window | ${{ steps.dates.outputs.start_date }} → ${{ steps.dates.outputs.end_date }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Poll Window | ${STEPS_DATES_OUTPUTS_START_DATE} → ${STEPS_DATES_OUTPUTS_END_DATE} |" >> $GITHUB_STEP_SUMMARY
           echo "| Keywords | $KEYWORDS |" >> $GITHUB_STEP_SUMMARY
-          echo "| NVD CVEs Found (filtered) | ${{ steps.process.outputs.nvd_filtered_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| NVD Advisories Rebuilt | ${{ steps.transform.outputs.nvd_rebuilt_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Net-new NVD Advisories | ${{ steps.transform.outputs.nvd_new_to_feed_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Updated NVD Advisories | ${{ steps.nvd_counts.outputs.nvd_updated_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| GHSA Active Added | ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| GHSA source feed changed | ${{ steps.feed_changes.outputs.ghsa_changed }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Consolidated agent feed changed | ${{ steps.feed_changes.outputs.agent_changed }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| NVD CVEs Found (filtered) | ${STEPS_PROCESS_OUTPUTS_NVD_FILTERED_COUNT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| NVD Advisories Rebuilt | ${STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Net-new NVD Advisories | ${STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Updated NVD Advisories | ${STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| GHSA Active Added | ${STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| GHSA source feed changed | ${STEPS_FEED_CHANGES_OUTPUTS_GHSA_CHANGED} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Consolidated agent feed changed | ${STEPS_FEED_CHANGES_OUTPUTS_AGENT_CHANGED} |" >> $GITHUB_STEP_SUMMARY
           echo "| GHSA provisional advisories | $(jq '.advisories | length' "$GHSA_FEED_PATH") |" >> $GITHUB_STEP_SUMMARY
 
-          if [ "${{ steps.transform.outputs.nvd_new_to_feed_count }}" != "0" ]; then
+          if [ "${STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT}" != "0" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Net-new NVD Advisories" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             jq -r '.[] | "- **\(.id)** (\(.severity)): \(.title)"' tmp/net_new_advisories.json >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ "${{ steps.nvd_counts.outputs.nvd_updated_count }}" != "0" ]; then
+          if [ "${STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT}" != "0" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Updated NVD Advisories" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             jq -r '.[] | "- **\(.id)**: \(.changes | join(", "))"' tmp/updated_advisories.json >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ "${{ steps.feed_changes.outputs.changed }}" = "true" ]; then
+          if [ "${STEPS_FEED_CHANGES_OUTPUTS_CHANGED}" = "true" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "🔀 Upserted PR: ${{ steps.upsert-pr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
+            echo "🔀 Upserted PR: ${STEPS_UPSERT_PR_OUTPUTS_PULL_REQUEST_URL}" >> $GITHUB_STEP_SUMMARY
           else
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "✅ No new or updated NVD CVEs or GHSA changes found." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -772,7 +772,7 @@ jobs:
         if: steps.transform.outputs.new_count != '0'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Analyze exploitability for new advisories
         if: steps.transform.outputs.new_count != '0'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,7 +26,8 @@ on:
   workflow_dispatch:
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:
@@ -50,7 +51,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -84,6 +85,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
           # This workflow signs and publishes releases; never restore a cache
           # into that trust path. Explicit because the input defaults to true.
           package-manager-cache: false
@@ -294,7 +294,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
           # This workflow signs and publishes releases; never restore a cache
           # into that trust path. Explicit because the input defaults to true.
           package-manager-cache: false
@@ -1032,7 +1032,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
           # This workflow signs and publishes releases; never restore a cache
           # into that trust path. Explicit because the input defaults to true.
           package-manager-cache: false
@@ -1222,7 +1222,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
           # This workflow signs and publishes releases; never restore a cache
           # into that trust path. Explicit because the input defaults to true.
           package-manager-cache: false
@@ -1863,7 +1863,7 @@ jobs:
         if: needs.release-tag.outputs.publish_clawhub == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
           # This workflow signs and publishes releases; never restore a cache
           # into that trust path. Explicit because the input defaults to true.
           package-manager-cache: false
@@ -2128,7 +2128,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
           # This workflow signs and publishes releases; never restore a cache
           # into that trust path. Explicit because the input defaults to true.
           package-manager-cache: false

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -21,7 +21,8 @@ on:
         required: true
         type: string
 
-permissions: read-all
+permissions:
+  contents: read
 
 # The ClawHub CLI version is pinned (with integrity hashes) in
 # .github/clawhub-cli/package-lock.json — bump it there.
@@ -41,11 +42,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
+          # This workflow signs and publishes releases; never restore a cache
+          # into that trust path. Explicit because the input defaults to true.
+          package-manager-cache: false
 
       - name: Verify signing key consistency (repo + docs)
         run: ./scripts/ci/verify_signing_key_consistency.sh
@@ -284,11 +289,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
+          # This workflow signs and publishes releases; never restore a cache
+          # into that trust path. Explicit because the input defaults to true.
+          package-manager-cache: false
 
       - name: Install SkillSpector
         run: |
@@ -1018,11 +1027,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
+          # This workflow signs and publishes releases; never restore a cache
+          # into that trust path. Explicit because the input defaults to true.
+          package-manager-cache: false
 
       - name: Install SkillSpector
         run: |
@@ -1093,7 +1106,7 @@ jobs:
       - name: Parse tag
         id: parse
         run: |
-          TAG="${{ github.ref_name }}"
+          TAG="${GITHUB_REF_NAME}"
           # Extract skill name (everything before -v)
           SKILL_NAME="${TAG%-v*}"
           # Extract version (everything after -v)
@@ -1107,13 +1120,15 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Verify signing key consistency (repo + docs)
         run: ./scripts/ci/verify_signing_key_consistency.sh
 
       - name: Validate skill exists
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
           if [ ! -d "$SKILL_PATH" ]; then
             echo "Error: Skill directory not found: $SKILL_PATH"
             exit 1
@@ -1123,11 +1138,13 @@ jobs:
             exit 1
           fi
           echo "Skill validated: $SKILL_PATH"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Validate version match
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
-          TAG_VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+          TAG_VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
 
           # Extract version from skill.json
           JSON_VERSION=$(jq -r '.version' "$SKILL_PATH/skill.json")
@@ -1139,11 +1156,14 @@ jobs:
           fi
 
           echo "Version validated: $TAG_VERSION"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Validate SKILL.md frontmatter version
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
-          TAG_VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+          TAG_VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
 
           # Check if SKILL.md exists
           if [ -f "$SKILL_PATH/SKILL.md" ]; then
@@ -1163,11 +1183,14 @@ jobs:
             echo "::error::Missing required SKILL.md: $SKILL_PATH/SKILL.md"
             exit 1
           fi
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Detect publishability and install defaults
         id: publishable
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
           INTERNAL=$(jq -r 'if (.openclaw | type) == "object" then (.openclaw.internal // false) else false end' "$SKILL_PATH/skill.json")
 
           OPENCLAW_SKILL=false
@@ -1193,14 +1216,21 @@ jobs:
           echo "publish_clawhub=${PUBLISH_CLAWHUB}" >> $GITHUB_OUTPUT
           echo "publishable=${PUBLISHABLE}" >> $GITHUB_OUTPUT
           echo "clawhub_slug=${CLAWHUB_SLUG}" >> $GITHUB_OUTPUT
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
+          # This workflow signs and publishes releases; never restore a cache
+          # into that trust path. Explicit because the input defaults to true.
+          package-manager-cache: false
 
       - name: Validate npx skills install docs
-        run: node scripts/ci/validate_skill_install_docs.mjs --skills "${{ steps.parse.outputs.skill_path }}"
+        run: node scripts/ci/validate_skill_install_docs.mjs --skills "${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Install SkillSpector
         run: |
@@ -1214,7 +1244,7 @@ jobs:
 
       - name: Sign embedded advisory feed and verify
         if: hashFiles(format('skills/{0}/advisories/feed.json', steps.parse.outputs.skill_name)) != ''
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -1226,7 +1256,7 @@ jobs:
         if: hashFiles(format('skills/{0}/advisories/feed.json', steps.parse.outputs.skill_name)) != ''
         run: |
           set -euo pipefail
-          ADVISORY_DIR="${{ steps.parse.outputs.skill_path }}/advisories"
+          ADVISORY_DIR="${STEPS_PARSE_OUTPUTS_SKILL_PATH}/advisories"
           FEED_SHA=$(sha256sum "$ADVISORY_DIR/feed.json" | awk '{print $1}')
           FEED_SIZE=$(stat -c%s "$ADVISORY_DIR/feed.json" 2>/dev/null || stat -f%z "$ADVISORY_DIR/feed.json")
           FEED_SIG_SHA=$(sha256sum "$ADVISORY_DIR/feed.json.sig" | awk '{print $1}')
@@ -1237,7 +1267,7 @@ jobs:
           jq -n \
             --arg schema_version "1" \
             --arg algorithm "sha256" \
-            --arg version "${{ steps.parse.outputs.version }}" \
+            --arg version "${STEPS_PARSE_OUTPUTS_VERSION}" \
             --arg generated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg repo "${{ github.repository }}" \
             --arg feed_sha "$FEED_SHA" \
@@ -1273,10 +1303,13 @@ jobs:
 
           echo "Generated $ADVISORY_DIR/checksums.json"
           jq . "$ADVISORY_DIR/checksums.json"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Sign embedded advisory checksums and verify
         if: hashFiles(format('skills/{0}/advisories/feed.json', steps.parse.outputs.skill_name)) != ''
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -1286,17 +1319,19 @@ jobs:
       - name: Show embedded advisory signing outputs
         if: hashFiles(format('skills/{0}/advisories/feed.json', steps.parse.outputs.skill_name)) != ''
         run: |
-          ADVISORY_DIR="${{ steps.parse.outputs.skill_path }}/advisories"
+          ADVISORY_DIR="${STEPS_PARSE_OUTPUTS_SKILL_PATH}/advisories"
           echo "Successfully signed embedded advisory artifacts:"
           ls -la "$ADVISORY_DIR"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Package release assets
         run: |
           set -euo pipefail
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
-          VERSION="${{ steps.parse.outputs.version }}"
-          TAG="${{ github.ref_name }}"
+          SKILL_NAME="${STEPS_PARSE_OUTPUTS_SKILL_NAME}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
+          TAG="${GITHUB_REF_NAME}"
 
           mkdir -p release-assets
 
@@ -1518,9 +1553,13 @@ jobs:
           echo ""
           echo "=== Release assets ==="
           ls -la release-assets/
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Sign checksums and verify
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -1549,8 +1588,8 @@ jobs:
         id: changelog
         run: |
           set -euo pipefail
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
-          VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
 
           if [ ! -f "$SKILL_PATH/CHANGELOG.md" ]; then
             echo "::error::Missing required changelog file: $SKILL_PATH/CHANGELOG.md"
@@ -1580,16 +1619,19 @@ jobs:
             echo "$CHANGELOG_ENTRY"
             echo "EOF"
           } >> $GITHUB_OUTPUT
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Build quick install instructions
         id: install
         run: |
           set -euo pipefail
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          CLAWHUB_SLUG="${{ steps.publishable.outputs.clawhub_slug }}"
-          VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_NAME="${STEPS_PARSE_OUTPUTS_SKILL_NAME}"
+          CLAWHUB_SLUG="${STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
           REPO="${{ github.repository }}"
-          TAG="${{ github.ref_name }}"
+          TAG="${GITHUB_REF_NAME}"
 
           {
             echo "quick_install<<INSTALL_EOF"
@@ -1614,7 +1656,7 @@ jobs:
 
           EOF
 
-            if [ "${{ steps.publishable.outputs.publish_clawhub }}" = "true" ] && [ "${{ steps.publishable.outputs.openclaw_skill }}" = "true" ]; then
+            if [ "${STEPS_PUBLISHABLE_OUTPUTS_PUBLISH_CLAWHUB}" = "true" ] && [ "${STEPS_PUBLISHABLE_OUTPUTS_OPENCLAW_SKILL}" = "true" ]; then
               cat <<EOF
           ### Quick Install
 
@@ -1666,6 +1708,12 @@ jobs:
 
             echo "INSTALL_EOF"
           } >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG: ${{ steps.publishable.outputs.clawhub_slug }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
+          STEPS_PUBLISHABLE_OUTPUTS_PUBLISH_CLAWHUB: ${{ steps.publishable.outputs.publish_clawhub }}
+          STEPS_PUBLISHABLE_OUTPUTS_OPENCLAW_SKILL: ${{ steps.publishable.outputs.openclaw_skill }}
 
       - name: Prepare GitHub release body
         env:
@@ -1716,21 +1764,42 @@ jobs:
           '
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          name: "${{ steps.parse.outputs.skill_name }} ${{ steps.parse.outputs.version }}"
-          tag_name: ${{ github.ref_name }}
-          files: release-assets/*
-          body_path: ${{ runner.temp }}/skill-release-body.md
-          draft: false
-          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          RELEASE_TITLE: ${{ steps.parse.outputs.skill_name }} ${{ steps.parse.outputs.version }}
+          PRERELEASE: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+        run: |
+          set -euo pipefail
+
+          BODY_FILE="${RUNNER_TEMP}/skill-release-body.md"
+          shopt -s nullglob
+          ASSETS=(release-assets/*)
+          if [ "${#ASSETS[@]}" -eq 0 ]; then
+            echo "::error::No release assets found in release-assets/"
+            exit 1
+          fi
+
+          # Re-pushing a tag re-runs this job, so upsert rather than create.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --title "$RELEASE_TITLE" \
+              --notes-file "$BODY_FILE" \
+              --draft=false \
+              --prerelease="$PRERELEASE"
+            gh release upload "$TAG" "${ASSETS[@]}" --clobber
+          else
+            gh release create "$TAG" \
+              --title "$RELEASE_TITLE" \
+              --notes-file "$BODY_FILE" \
+              --prerelease="$PRERELEASE" \
+              "${ASSETS[@]}"
+          fi
 
       - name: Delete superseded releases
         run: |
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          CURRENT_VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_NAME="${STEPS_PARSE_OUTPUTS_SKILL_NAME}"
+          CURRENT_VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
 
           # Extract major version from current release
           CURRENT_MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
@@ -1763,6 +1832,8 @@ jobs:
           echo "Superseded release cleanup complete"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STEPS_PARSE_OUTPUTS_SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
   publish-clawhub:
     # Separate blocking job for ClawHub publishing - runs after GitHub release.
@@ -1785,23 +1856,30 @@ jobs:
       - name: Checkout
         if: needs.release-tag.outputs.publish_clawhub == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         if: needs.release-tag.outputs.publish_clawhub == 'true'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
+          # This workflow signs and publishes releases; never restore a cache
+          # into that trust path. Explicit because the input defaults to true.
+          package-manager-cache: false
 
       - name: Prepare verified ClawHub release package
         id: clawhub-package
         if: needs.release-tag.outputs.publish_clawhub == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME: ${{ needs.release-tag.outputs.skill_name }}
+          NEEDS_RELEASE_TAG_OUTPUTS_VERSION: ${{ needs.release-tag.outputs.version }}
         run: |
           set -euo pipefail
-          SKILL_NAME="${{ needs.release-tag.outputs.skill_name }}"
-          VERSION="${{ needs.release-tag.outputs.version }}"
-          TAG="${{ github.ref_name }}"
+          SKILL_NAME="${NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME}"
+          VERSION="${NEEDS_RELEASE_TAG_OUTPUTS_VERSION}"
+          TAG="${GITHUB_REF_NAME}"
           RELEASE_DIR="$RUNNER_TEMP/clawhub-release"
           OUTPUT_DIR="$RUNNER_TEMP/clawhub-package"
 
@@ -1866,7 +1944,9 @@ jobs:
           export CLAWHUB_SITE="$SITE"
           export CLAWHUB_REGISTRY="$REGISTRY"
           bash scripts/ci/guard_clawhub_slug_owner.sh \
-            "${{ needs.release-tag.outputs.clawhub_slug }}"
+            "${NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG}"
+        env:
+          NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG: ${{ needs.release-tag.outputs.clawhub_slug }}
 
       - name: Check existing ClawHub version
         id: clawhub-version
@@ -1875,9 +1955,9 @@ jobs:
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          SKILL_NAME="${{ needs.release-tag.outputs.skill_name }}"
-          CLAWHUB_SLUG="${{ needs.release-tag.outputs.clawhub_slug }}"
-          VERSION="${{ needs.release-tag.outputs.version }}"
+          SKILL_NAME="${NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME}"
+          CLAWHUB_SLUG="${NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${NEEDS_RELEASE_TAG_OUTPUTS_VERSION}"
           export CLAWHUB_CONFIG_PATH="$HOME/.clawhub-ci/config.json"
 
           set +e
@@ -1901,6 +1981,10 @@ jobs:
             cat /tmp/clawhub-existing-version.err
             exit 1
           fi
+        env:
+          NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME: ${{ needs.release-tag.outputs.skill_name }}
+          NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG: ${{ needs.release-tag.outputs.clawhub_slug }}
+          NEEDS_RELEASE_TAG_OUTPUTS_VERSION: ${{ needs.release-tag.outputs.version }}
 
       - name: Publish to ClawHub
         if: needs.release-tag.outputs.publish_clawhub == 'true' && steps.clawhub-version.outputs.already_exists != 'true'
@@ -1908,10 +1992,10 @@ jobs:
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
-          SKILL_NAME="${{ needs.release-tag.outputs.skill_name }}"
-          CLAWHUB_SLUG="${{ needs.release-tag.outputs.clawhub_slug }}"
-          VERSION="${{ needs.release-tag.outputs.version }}"
+          SKILL_PATH="${STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH}"
+          SKILL_NAME="${NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME}"
+          CLAWHUB_SLUG="${NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${NEEDS_RELEASE_TAG_OUTPUTS_VERSION}"
           NAME=$(jq -r '.name' "$SKILL_PATH/skill.json")
           CHANGELOG="Release ${VERSION} via CI"
 
@@ -1934,6 +2018,11 @@ jobs:
           fi
 
           echo "ClawHub publish request completed for $SKILL_NAME@$VERSION as $CLAWHUB_SLUG"
+        env:
+          STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH: ${{ steps.clawhub-package.outputs.skill_path }}
+          NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME: ${{ needs.release-tag.outputs.skill_name }}
+          NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG: ${{ needs.release-tag.outputs.clawhub_slug }}
+          NEEDS_RELEASE_TAG_OUTPUTS_VERSION: ${{ needs.release-tag.outputs.version }}
 
       - name: Verify published ClawHub package
         if: needs.release-tag.outputs.publish_clawhub == 'true'
@@ -1941,9 +2030,9 @@ jobs:
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          CLAWHUB_SLUG="${{ needs.release-tag.outputs.clawhub_slug }}"
-          VERSION="${{ needs.release-tag.outputs.version }}"
-          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
+          CLAWHUB_SLUG="${NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${NEEDS_RELEASE_TAG_OUTPUTS_VERSION}"
+          SKILL_PATH="${STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH}"
           export CLAWHUB_CONFIG_PATH="$HOME/.clawhub-ci/config.json"
           export CLAWHUB_SITE="$SITE"
           export CLAWHUB_REGISTRY="$REGISTRY"
@@ -1953,6 +2042,10 @@ jobs:
             --slug "$CLAWHUB_SLUG" \
             --version "$VERSION"
           echo "✓ Verified published ClawHub package matches the signed release payload"
+        env:
+          NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG: ${{ needs.release-tag.outputs.clawhub_slug }}
+          NEEDS_RELEASE_TAG_OUTPUTS_VERSION: ${{ needs.release-tag.outputs.version }}
+          STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH: ${{ steps.clawhub-package.outputs.skill_path }}
 
   republish-clawhub:
     # Manual workflow to republish a specific tag to ClawHub
@@ -1967,7 +2060,7 @@ jobs:
       - name: Parse tag
         id: parse
         run: |
-          TAG="${{ github.event.inputs.tag }}"
+          TAG="${GITHUB_EVENT_INPUTS_TAG}"
           # Extract skill name (everything before -v)
           SKILL_NAME="${TAG%-v*}"
           # Extract version (everything after -v)
@@ -1978,9 +2071,13 @@ jobs:
           echo "skill_path=skills/${SKILL_NAME}" >> $GITHUB_OUTPUT
 
           echo "Parsed tag: skill=${SKILL_NAME}, version=${VERSION}"
+        env:
+          GITHUB_EVENT_INPUTS_TAG: ${{ github.event.inputs.tag }}
 
       - name: Checkout workflow helpers
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Prepare current ClawHub workflow helpers
         run: |
@@ -1994,10 +2091,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.inputs.tag }}
+          persist-credentials: false
 
       - name: Validate skill exists
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
           if [ ! -d "$SKILL_PATH" ]; then
             echo "Error: Skill directory not found: $SKILL_PATH"
             exit 1
@@ -2007,11 +2105,13 @@ jobs:
             exit 1
           fi
           echo "Skill validated: $SKILL_PATH"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Check if publishable
         id: publishable
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
           INTERNAL=$(jq -r 'if (.openclaw | type) == "object" then (.openclaw.internal // false) else false end' "$SKILL_PATH/skill.json")
 
           if [ "$INTERNAL" = "true" ]; then
@@ -2022,21 +2122,29 @@ jobs:
           CLAWHUB_SLUG=$(node "$RUNNER_TEMP/resolve_clawhub_slug.mjs" "$SKILL_PATH")
           echo "clawhub_slug=${CLAWHUB_SLUG}" >> $GITHUB_OUTPUT
           echo "Skill is publishable to ClawHub"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
+          # This workflow signs and publishes releases; never restore a cache
+          # into that trust path. Explicit because the input defaults to true.
+          package-manager-cache: false
 
       - name: Prepare verified ClawHub release package
         id: clawhub-package
         env:
           GH_TOKEN: ${{ github.token }}
+          STEPS_PARSE_OUTPUTS_SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
+          GITHUB_EVENT_INPUTS_TAG: ${{ github.event.inputs.tag }}
         run: |
           set -euo pipefail
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          VERSION="${{ steps.parse.outputs.version }}"
-          TAG="${{ github.event.inputs.tag }}"
+          SKILL_NAME="${STEPS_PARSE_OUTPUTS_SKILL_NAME}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
+          TAG="${GITHUB_EVENT_INPUTS_TAG}"
           RELEASE_DIR="$RUNNER_TEMP/clawhub-release"
           OUTPUT_DIR="$RUNNER_TEMP/clawhub-package"
 
@@ -2073,7 +2181,9 @@ jobs:
           echo "skill_path=$OUTPUT_DIR/$SKILL_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Validate npx skills install docs
-        run: node scripts/ci/validate_skill_install_docs.mjs --skills "${{ steps.parse.outputs.skill_path }}"
+        run: node scripts/ci/validate_skill_install_docs.mjs --skills "${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Install clawhub CLI
         run: bash scripts/ci/install_clawhub_cli.sh
@@ -2110,17 +2220,19 @@ jobs:
           export CLAWHUB_SITE="$SITE"
           export CLAWHUB_REGISTRY="$REGISTRY"
           bash scripts/ci/guard_clawhub_slug_owner.sh \
-            "${{ steps.publishable.outputs.clawhub_slug }}"
+            "${STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG}"
+        env:
+          STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG: ${{ steps.publishable.outputs.clawhub_slug }}
 
       - name: Publish to ClawHub
         run: |
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          CLAWHUB_SLUG="${{ steps.publishable.outputs.clawhub_slug }}"
-          VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_PATH="${STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH}"
+          SKILL_NAME="${STEPS_PARSE_OUTPUTS_SKILL_NAME}"
+          CLAWHUB_SLUG="${STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
           NAME=$(jq -r '.name' "$SKILL_PATH/skill.json")
           CHANGELOG="Manual republish of ${VERSION} via workflow_dispatch"
 
@@ -2152,15 +2264,20 @@ jobs:
           fi
 
           echo "✓ Successfully published $SKILL_NAME@$VERSION to ClawHub"
+        env:
+          STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH: ${{ steps.clawhub-package.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG: ${{ steps.publishable.outputs.clawhub_slug }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Verify published ClawHub package
         run: |
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          CLAWHUB_SLUG="${{ steps.publishable.outputs.clawhub_slug }}"
-          VERSION="${{ steps.parse.outputs.version }}"
-          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
+          CLAWHUB_SLUG="${STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
+          SKILL_PATH="${STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH}"
           export CLAWHUB_CONFIG_PATH="$HOME/.clawhub-ci/config.json"
           export CLAWHUB_SITE="$SITE"
           export CLAWHUB_REGISTRY="$REGISTRY"
@@ -2170,3 +2287,7 @@ jobs:
             --slug "$CLAWHUB_SLUG" \
             --version "$VERSION"
           echo "✓ Verified published ClawHub package matches the signed release payload"
+        env:
+          STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG: ${{ steps.publishable.outputs.clawhub_slug }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
+          STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH: ${{ steps.clawhub-package.outputs.skill_path }}

--- a/.github/workflows/wiki-export-verify.yml
+++ b/.github/workflows/wiki-export-verify.yml
@@ -29,9 +29,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 

--- a/.github/workflows/wiki-export-verify.yml
+++ b/.github/workflows/wiki-export-verify.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Test wiki export transform
         run: node scripts/test-wiki-sync-export.mjs

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: wiki-sync
@@ -22,12 +22,17 @@ concurrency:
 jobs:
   sync-wiki:
     runs-on: ubuntu-latest
+    permissions:
+      # Pushes the generated export to the repository wiki.
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Test wiki export transform
         run: node scripts/test-wiki-sync-export.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ source .venv/bin/activate
 uv pip install ruff bandit   # linters configured in pyproject.toml
 ```
 
-Required tools: Node 20+, Python 3.10+, openssl, jq, shellcheck, gitleaks,
+Required tools: Node 24+, Python 3.10+, openssl, jq, shellcheck, gitleaks,
 trufflehog (`brew install shellcheck gitleaks trufflehog`). The pre-commit hook
 exits 1 without gitleaks.
 

--- a/scripts/test-nvd-ghsa-consolidation-workflow.mjs
+++ b/scripts/test-nvd-ghsa-consolidation-workflow.mjs
@@ -96,12 +96,12 @@ assert.match(
 );
 assert.match(
   workflow,
-  /TITLE="chore: update NVD\/GHSA advisories - \$\{\{ steps\.transform\.outputs\.nvd_new_to_feed_count \}\} NVD new, \$\{\{ steps\.nvd_counts\.outputs\.nvd_updated_count \}\} NVD updated, \$\{\{ steps\.feed_changes\.outputs\.ghsa_added_to_consolidated_count \}\} GHSA active added"/,
+  /TITLE="chore: update NVD\/GHSA advisories - \$\{STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT\} NVD new, \$\{STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT\} NVD updated, \$\{STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT\} GHSA active added"/,
   'Generated PR titles must include net-new NVD, updated NVD, and GHSA-only addition counts',
 );
 assert.match(
   workflow,
-  /\*\*GHSA active advisories added to consolidated feed:\*\* \$\{\{ steps\.feed_changes\.outputs\.ghsa_added_to_consolidated_count \}\}/,
+  /\*\*GHSA active advisories added to consolidated feed:\*\* \$\{STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT\}/,
   'Generated PR bodies must include GHSA-only additions',
 );
 assert.doesNotMatch(

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -231,8 +231,8 @@ assert.match(
 
 assert.match(
   workflow,
-  /body_path: \$\{\{ runner\.temp \}\}\/skill-release-body\.md/,
-  'GitHub release creation must use body_path for the generated release body file',
+  /BODY_FILE="\$\{RUNNER_TEMP\}\/skill-release-body\.md"[\s\S]*--notes-file "\$BODY_FILE"/,
+  'GitHub release creation must take its body from the generated release body file',
 );
 
 assert.doesNotMatch(
@@ -550,7 +550,7 @@ assert.doesNotMatch(
 );
 
 assert.equal(
-  workflow.match(/SKILL_PATH="\$\{\{ steps\.clawhub-package\.outputs\.skill_path \}\}"/g)?.length,
+  workflow.match(/SKILL_PATH="\$\{STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH\}"/g)?.length,
   4,
   'ClawHub publish, republish, and their verification steps must use the verified release package path',
 );


### PR DESCRIPTION
# User description
## Opener Type

- [x] Agent (automated)

---

## Summary

A maintenance pass over all 13 workflows plus the composite action. `zizmor` went
from **31 findings** (10 high, 2 medium) to **zero**, every action pin was
verified against its real tag, and two end-of-life runtimes were retired.

Findings are fixed on the merits rather than suppressed. There is exactly one
`zizmor: ignore`, and it carries its justification inline.

## Changes Made

**Permissions** — `permissions: read-all` replaced with `contents: read` in the
eight workflows that used it. Write scopes pushed down to the single job that
needs them: `pages`/`id-token` to deploy-pages' `deploy` job, `contents: write`
to the archive-traffic and wiki-sync jobs.

**Template injection (33 sites)** — every `${{ }}` expansion moved out of `run:`
and `github-script` bodies into step `env:` / `process.env`. One subtlety: the
NVD PR body used `$'...'`, which does **not** expand parameters, so a naive
`${VAR}` swap would have silently broken it. Rewritten with `printf` and
byte-compared against the original.

**`$GITHUB_ENV` → step output** — deploy-pages derived the suite release URL into
`$GITHUB_ENV`, which can set `NODE_OPTIONS`. A step output cannot.

**Third-party action dropped** — `softprops/action-gh-release` replaced with
`gh release`, which is preinstalled and pre-authenticated. Re-pushing a tag
re-runs the job, so the action's upsert behaviour is preserved explicitly
(`view` → `edit` + `upload --clobber`, else `create`).

**Cache kept out of the release trust path** — `setup-node`'s
`package-manager-cache` input defaults to `true`, so the six release-job steps
now set it to `false`. Not a false positive.

**Pins** — all 72 refs SHA-pinned and each SHA verified to resolve to its claimed
tag. Updated: `deploy-pages` v5.0.0→v5.0.1, `trufflehog` v3.97.1→v3.97.2,
`setup-python` v6.2.0→v7.0.0 (one stale straggler).

`codeql-action` repinned from `codeql-bundle-v2.26.4` to **v4.37.9**. The bundle
tag is unparseable by Dependabot (`Version.correct?` rejects it), and no `v4.x.y`
tag points at that SHA, so Dependabot could not compute updates for it at all.
v4.37.9 is 5 commits ahead of the bundle commit.

**Pin comments normalised** to Dependabot's own `@<sha> # <tag>` form. Verified
by replicating Dependabot's `VersionCommenter` logic against live tag data: all
72 pins are recognised, so bump PRs rewrite both the SHA and the comment.

**Also** — `persist-credentials: false` on checkouts that do not push;
`$/...` self-repository syntax for in-repo action refs (15 sites).

### Retired end-of-life runtimes

**Node 20 → 24.** Node 20 hit EOL on 2026-04-30; 24 is active LTS through
2028-04-30. This was worse than staleness: `node-version: '20'` resolves to
v20.20.2, while `react-router@8.3.0` declares `engines.node: ">=22.22.0"` —
unsatisfiable by *any* Node 20. The deployed site was built on a runtime its own
router declares unsupported. It never failed because there is no `.npmrc`, so
`engine-strict` is off and npm downgrades `EBADENGINE` to a warning. Every
`engines.node` range in `package-lock.json` admits Node 24.

**Python 3.10 → 3.12** in the two advisory jobs. CI lints `utils/` on 3.12, but
the jobs that execute that code against live NVD data and commit a *signed* feed
ran it on 3.10 — the one version no gate exercised. `pyproject`'s
`requires-python = ">=3.10"` is deliberately left alone: `utils/` is documented
for users to run on their own Python across the READMEs, wiki and four
`SKILL.md` files. Run on 3.12, stay source-compatible with 3.10.

### The one suppression

deploy-pages' `workflow_run` trigger. Safe here: it checks out no PR head,
consumes no artifact from the triggering run, and every job guards on
`workflow_run.event != 'pull_request'`. Switching to `pull_request` would break
the release→deploy chain, so the trigger stays with a documented ignore.

## Related Issues

None.

---

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

---

## Testing

- `zizmor .` → clean (1 documented ignore). `--persona=pedantic` → 0 errors/warnings.
- All 14 workflow/action YAML files parse; `bash -n` passes on all 154 `run:` blocks.
- All `scripts/test-*.mjs` pass. Two files needed assertion updates because they
  match on workflow text; both are in the hardening commit so tests are green at
  every commit (verified per-commit for bisectability).
- Python paths exercised on 3.12: analyzer self-tests 10/10, `validate_skill.py`
  against a real skill, and the enrichment path end-to-end.
- `gitleaks` and `trufflehog` run manually over `main..HEAD` (hooks are disabled
  in this checkout): no findings.

**Not verified:** `npm ci && npm run build` on Node 24. The authoring environment
has no route to `registry.npmjs.org` and no Node version manager, so the Node
bump rests on the declared `engines` ranges rather than a green build. First CI
run here is the real check — please don't merge before it passes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

---

## Follow-ups found but deliberately not fixed here

1. **CI's linters are stale and Dependabot cannot reach them.** `ci.yml` hardcodes
   `ruff==0.6.9` / `bandit==1.7.9` via `pipx run --spec`, while
   `.github/requirements-lint-python.txt` declares `ruff==0.15.13` /
   `bandit==1.9.4`. Nothing installs that file — its only reference in the repo is
   a `paths:` filter in `scorecard.yml`. So the `pip` entry in `dependabot.yml`
   produces PRs that change nothing.
2. **13 of 16 Python files are never linted.** CI checks `utils/` only. Unlinted:
   `scripts/i18n/*.py` (which `i18n-qa.yml` executes), `scripts/ci/verify_skill_release_import_closure.py`,
   and `skills/soul-guardian/scripts/*.py`.
3. **No single source of truth for runtime versions.** Node appears as a literal in
   19 places, which is why 20 rotted past EOL unnoticed. An `engines` field plus
   `.nvmrc` and `node-version-file:` would collapse it to one number.
4. **Nothing executes `analyze_exploitability.py --test-cases` in CI,** despite its
   output being written into the signed advisory feed.
5. **`clawsec-scanner/SKILL.md` self-contradicts** — line 109 says Python 3.10+,
   line 334 says 3.8+.
6. **GitHub secret-scanning push protection is still disabled** on this repo
   (noted in CLAUDE.md as the control worth more than all the local gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Harden GitHub Actions workflows and the composite signing action by eliminating unsafe interpolations, narrowing permissions, pinning verified action SHAs, and removing unnecessary credential persistence. Retire Node 20 and Python 3.10 in CI and update release, advisory, deployment, and publishing flows to use safer runtime and artifact handling.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/359?tool=ast&topic=Workflow+hardening>Workflow hardening</a>
        </td><td>Harden workflow execution by moving expressions into <code>env</code>, restricting permissions, disabling credential persistence and release caching, replacing the third-party release action with <code>gh release</code>, and documenting the sole <code>zizmor</code> exception.<details><summary>Modified files (15)</summary><ul><li>.github/workflows/archive-traffic.yml</li>
<li>.github/workflows/ci.yml</li>
<li>.github/workflows/codeql.yml</li>
<li>.github/workflows/community-advisory.yml</li>
<li>.github/workflows/deploy-pages.yml</li>
<li>.github/workflows/i18n-qa.yml</li>
<li>.github/workflows/pages-verify.yml</li>
<li>.github/workflows/poll-ghsa-without-cve.yml</li>
<li>.github/workflows/poll-nvd-cves.yml</li>
<li>.github/workflows/scorecard.yml</li>
<li>.github/workflows/skill-release.yml</li>
<li>.github/workflows/wiki-export-verify.yml</li>
<li>.github/workflows/wiki-sync.yml</li>
<li>scripts/test-nvd-ghsa-consolidation-workflow.mjs</li>
<li>scripts/test-skill-release-workflow.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bnaya.harel@sentinelon...</td><td>ci(workflows): replace...</td><td>September 03, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>feat(security): add Tr...</td><td>August 30, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/359?tool=ast&topic=Runtime+and+pin+refresh>Runtime and pin refresh</a>
        </td><td>Refresh pinned action references and upgrade CI runtimes to Node 24 and Python 3.12 across build, advisory, release, deployment, and publishing paths, while adding Dependabot cooldowns and updating developer requirements.<details><summary>Modified files (14)</summary><ul><li>.github/dependabot.yml</li>
<li>.github/workflows/archive-traffic.yml</li>
<li>.github/workflows/ci.yml</li>
<li>.github/workflows/codeql.yml</li>
<li>.github/workflows/community-advisory.yml</li>
<li>.github/workflows/deploy-pages.yml</li>
<li>.github/workflows/i18n-qa.yml</li>
<li>.github/workflows/pages-verify.yml</li>
<li>.github/workflows/poll-nvd-cves.yml</li>
<li>.github/workflows/scorecard.yml</li>
<li>.github/workflows/skill-release.yml</li>
<li>.github/workflows/wiki-export-verify.yml</li>
<li>.github/workflows/wiki-sync.yml</li>
<li>CLAUDE.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bnaya.harel@sentinelon...</td><td>ci(workflows): replace...</td><td>September 03, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>feat(security): add Tr...</td><td>August 30, 2026</td></tr></table></details></td></tr></table>
<a href="https://baz.co/changes/prompt-security/clawsec/359?tool=ast">Review this PR on Baz</a><br>
<a href="https://baz.co/agents/baz">Customize your next review</a>