### PR TITLE
1/10 ✅ chore(dependabot): extend the default package cooldown from 3 days to 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,21 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/.github"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/.github/workflows/archive-traffic.yml
+++ b/.github/workflows/archive-traffic.yml
@@ -25,9 +25,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Prepare archive branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: ESLint
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
       - name: Ruff (lint + format check)
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Trivy FS Scan
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.34.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -77,7 +77,7 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
       - name: Trivy Config Scan
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.34.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'config'
           scan-ref: '.'
@@ -106,7 +106,7 @@ jobs:
       # read as legacy GitHub PATs -- but a range scan sees only the diff, so an
       # ordinary PR reports 0.
       - name: TruffleHog
-        uses: trufflesecurity/trufflehog@20652fbbdefffcdaa493a5bf57ab2ac6b1db715b # v3.97.1
+        uses: trufflesecurity/trufflehog@cc1fe982afc515d2991365ce8d4d0dd07170fcad # v3.97.2
         with:
           extra_args: --results=verified,unknown,unverified
       # Private keys and other deterministic patterns. TruffleHog only emits a
@@ -145,9 +145,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: npm audit
@@ -160,9 +160,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: GHSA Without CVE Feed Tests
@@ -197,9 +197,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Feed Verification Tests
@@ -222,9 +222,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Hermes Skill Tests
         shell: bash
         run: |
@@ -238,9 +238,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Suppression Config Tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/community-advisory.yml
+++ b/.github/workflows/community-advisory.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: Set up Python for exploitability analysis
         if: steps.parse.outputs.already_exists != 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.10'
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -39,9 +39,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Verify signing key consistency (repo + docs)
@@ -411,7 +411,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1
 
   verify-production:
     name: Verify Production Advisory Endpoints
@@ -422,9 +422,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Verify deployed advisory endpoints
         run: |

--- a/.github/workflows/i18n-qa.yml
+++ b/.github/workflows/i18n-qa.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
       - name: Run i18n QA

--- a/.github/workflows/pages-verify.yml
+++ b/.github/workflows/pages-verify.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Verify signing key consistency (repo + docs)

--- a/.github/workflows/poll-ghsa-without-cve.yml
+++ b/.github/workflows/poll-ghsa-without-cve.yml
@@ -30,9 +30,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Run GHSA feed tests

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -761,7 +761,7 @@ jobs:
 
       - name: Set up Python for exploitability analysis
         if: steps.transform.outputs.new_count != '0'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.10'
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -50,7 +50,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -84,6 +84,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -43,9 +43,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Verify signing key consistency (repo + docs)
         run: ./scripts/ci/verify_signing_key_consistency.sh
@@ -286,9 +286,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install SkillSpector
         run: |
@@ -1020,9 +1020,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install SkillSpector
         run: |
@@ -1164,6 +1164,11 @@ jobs:
             exit 1
           fi
 
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
       - name: Detect publishability and install defaults
         id: publishable
         run: |
@@ -1193,11 +1198,6 @@ jobs:
           echo "publish_clawhub=${PUBLISH_CLAWHUB}" >> $GITHUB_OUTPUT
           echo "publishable=${PUBLISHABLE}" >> $GITHUB_OUTPUT
           echo "clawhub_slug=${CLAWHUB_SLUG}" >> $GITHUB_OUTPUT
-
-      - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 20
 
       - name: Validate npx skills install docs
         run: node scripts/ci/validate_skill_install_docs.mjs --skills "${{ steps.parse.outputs.skill_path }}"
@@ -1776,6 +1776,11 @@ jobs:
     env:
       CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
     steps:
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
       - name: Check if publishable
         if: needs.release-tag.outputs.publish_clawhub != 'true'
         run: |
@@ -1788,9 +1793,9 @@ jobs:
 
       - name: Setup Node
         if: needs.release-tag.outputs.publish_clawhub == 'true'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Prepare verified ClawHub release package
         id: clawhub-package
@@ -2022,11 +2027,6 @@ jobs:
           CLAWHUB_SLUG=$(node "$RUNNER_TEMP/resolve_clawhub_slug.mjs" "$SKILL_PATH")
           echo "clawhub_slug=${CLAWHUB_SLUG}" >> $GITHUB_OUTPUT
           echo "Skill is publishable to ClawHub"
-
-      - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 20
 
       - name: Prepare verified ClawHub release package
         id: clawhub-package

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -1776,11 +1776,6 @@ jobs:
     env:
       CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
     steps:
-      - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-
       - name: Check if publishable
         if: needs.release-tag.outputs.publish_clawhub != 'true'
         run: |
@@ -2012,6 +2007,11 @@ jobs:
             exit 1
           fi
           echo "Skill validated: $SKILL_PATH"
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
 
       - name: Check if publishable
         id: publishable

--- a/.github/workflows/wiki-export-verify.yml
+++ b/.github/workflows/wiki-export-verify.yml
@@ -31,9 +31,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Test wiki export transform
         run: node scripts/test-wiki-sync-export.mjs

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -27,9 +27,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Test wiki export transform
         run: node scripts/test-wiki-sync-export.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ source .venv/bin/activate
 uv pip install ruff bandit   # linters configured in pyproject.toml
 ```
 
-Required tools: Node 20+, Python 3.10+, openssl, jq, shellcheck, gitleaks,
+Required tools: Node 24+, Python 3.10+, openssl, jq, shellcheck, gitleaks,
 trufflehog (`brew install shellcheck gitleaks trufflehog`). The pre-commit hook
 exits 1 without gitleaks.
 

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -23,6 +23,14 @@ const patchClawhubTrustExtensions = await readFile(patchClawhubTrustExtensionsPa
 const guardClawhubSlugOwner = await readFile(guardClawhubSlugOwnerPath, 'utf8');
 const releaseSkillScript = await readFile(releaseSkillScriptPath, 'utf8');
 
+for (const resolverStep of ['Detect publishability and install defaults', 'Check if publishable']) {
+  assert.match(
+    workflow,
+    new RegExp(`      - name: Setup Node\n        uses: actions/setup-node@[^\n]+\n        with:\n          node-version: 24\n\n      - name: ${resolverStep}\n`),
+    `${resolverStep} must run after Setup Node selects Node 24`,
+  );
+}
+
 const preservedHelperBlock = workflow.match(
   /- name: Prepare current ClawHub workflow helpers\s+run: \|\n(?<body>[\s\S]*?)\n\s+- name: Checkout tag/,
 )?.groups?.body;

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -23,11 +23,17 @@ const patchClawhubTrustExtensions = await readFile(patchClawhubTrustExtensionsPa
 const guardClawhubSlugOwner = await readFile(guardClawhubSlugOwnerPath, 'utf8');
 const releaseSkillScript = await readFile(releaseSkillScriptPath, 'utf8');
 
-for (const resolverStep of ['Detect publishability and install defaults', 'Check if publishable']) {
+for (const [jobName, resolverStep] of [
+  ['release-tag', 'Detect publishability and install defaults'],
+  ['republish-clawhub', 'Check if publishable'],
+]) {
+  const jobStart = workflow.indexOf(`\n  ${jobName}:\n`);
+  assert.ok(jobStart !== -1, `${jobName} must exist`);
+  const job = workflow.slice(jobStart + 1).split(/\n {2}[\w-]+:\n/)[0];
   assert.match(
-    workflow,
+    job,
     new RegExp(`      - name: Setup Node\n        uses: actions/setup-node@[^\n]+\n        with:\n          node-version: 24\n\n      - name: ${resolverStep}\n`),
-    `${resolverStep} must run after Setup Node selects Node 24`,
+    `${jobName}: ${resolverStep} must run after Setup Node selects Node 24`,
   );
 }
 


### PR DESCRIPTION
# User description
> ## ✅ Free to merge
> Lowest-risk change in the series. Nothing in the repo reads `dependabot.yml` — it is consumed only by GitHub's hosted service — so a forward dependency on later PRs is impossible.

Extends the cooldown before Dependabot opens a version-update PR.

**One correction to how #359 described this.** The original message implied this introduces protection that was absent. It does not: since **2026-07-14** Dependabot applies a **three-day cooldown by default**, with no configuration. The real delta is **3 days → 7**, not 0 → 7. Still worth setting — it roughly doubles the window in which upstream can yank or patch — but a reviewer should not read it as closing an open hole.

**No effect on CVE response time.** Cooldown governs version updates only. Per GitHub, *"security updates still open immediately, so critical fixes are never delayed"* — so the `npm audit` and Trivy gates in `ci.yml` still receive their fix PRs without delay. (A 2026 bug where cooldown did leak into security updates was fixed upstream in dependabot-core#14050.)

All three ecosystems here — `github-actions`, `npm`, `pip` — support `default-days`.

---

## Where this sits in the series

This is one of **10 stacked PRs** splitting #359 into single-concern changes, so any one of them can be reverted on its own. Merge in numeric order — each targets its predecessor, and GitHub retargets the next automatically as each lands.

| # | PR | Merge guidance |
|---|---|---|
| 1 | dependabot cooldown | ✅ **Free to merge** |
| 2 | refresh action pins | ✅ **Free to merge** |
| 3 | node 20 → 24 | ✅ **Free to merge** |
| 4 | python 3.10 → 3.12 | ✅ **Free to merge** |
| 5 | template-injection hardening | ⚡ **Ship promptly** — closes a live exec path on `main` |
| 5b | `$GITHUB_ENV` → step output | ✅ **Free to merge** |
| 6 | `./` → `$/` action refs | ⚖️ **Decide knowingly** — Scorecard badge will move |
| 7 | `gh release` migration | 🧪 **Tag-test first** — never executed by CI |
| 8 | narrow permissions | ⛔ **Merge last, watched** — carries a blocker fix CI can't exercise |
| 9 | `persist-credentials: false` | ⛔ **Merge last, watched** — carries a blocker fix CI can't exercise |

### Why the last three need care

A fully green PR here proves less than it looks. The workflows these change cannot be triggered by a pull request: `poll-nvd-cves` runs on schedule only, `deploy-pages`' build job only on push-to-main or `workflow_run`, and `release-tag` / `publish-clawhub` / `republish-clawhub` are **skipped** without a tag push. #359 was green on all 22 checks while carrying two workflow-breaking bugs in exactly those blind spots.

### Two bugs found in #359 and fixed here

- **The daily NVD poller would have broken.** `persist-credentials: false` was added to the checkout while `git push --force origin` still relied on those credentials. `git fetch` still succeeds on a public repo, so it fails late, at the push, with `could not read Username`. Fixed in PR 9.
- **Pages deployment would have broken.** `pages`/`id-token` moved to the `deploy` job, but the `build` job runs `actions/configure-pages`, which calls the Pages API unconditionally and throws on failure. A job-level `permissions:` block replaces rather than merges, so `build` was left with no `pages` scope. Fixed in PR 8.

<sub>Full review, evidence and merge-order rationale: https://claude.ai/code/artifact/722db3dc-dfc5-40f6-974c-fba34b5dad9c</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Extend Dependabot cooldowns to seven days across GitHub Actions, npm, and pip updates. Modernize workflow tooling by upgrading Node.js, Python and security actions, and ensure skill-release setup steps run under Node 24.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/360?tool=ast&topic=CI+toolchain+updates>CI toolchain updates</a>
        </td><td>Upgrade CI and release workflows to Node 24 and newer setup, scanning, CodeQL, and deployment actions, while validating the revised <code>skill-release</code> setup ordering.<details><summary>Modified files (15)</summary><ul><li>.github/workflows/archive-traffic.yml</li>
<li>.github/workflows/ci.yml</li>
<li>.github/workflows/codeql.yml</li>
<li>.github/workflows/community-advisory.yml</li>
<li>.github/workflows/deploy-pages.yml</li>
<li>.github/workflows/i18n-qa.yml</li>
<li>.github/workflows/pages-verify.yml</li>
<li>.github/workflows/poll-ghsa-without-cve.yml</li>
<li>.github/workflows/poll-nvd-cves.yml</li>
<li>.github/workflows/scorecard.yml</li>
<li>.github/workflows/skill-release.yml</li>
<li>.github/workflows/wiki-export-verify.yml</li>
<li>.github/workflows/wiki-sync.yml</li>
<li>CLAUDE.md</li>
<li>scripts/test-skill-release-workflow.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>2/10 ✅ ci(deps): ref...</td><td>September 07, 2026</td></tr>
<tr><td>aldo@osstek.com</td><td>fix(portability): hard...</td><td>February 25, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/360?tool=ast&topic=Dependabot+cooldown>Dependabot cooldown</a>
        </td><td>Extend <code>dependabot.yml</code> cooldowns to seven days for all supported ecosystems, delaying version-update PRs without affecting immediate security updates.<details><summary>Modified files (1)</summary><ul><li>.github/dependabot.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bnaya.harel@sentinelon...</td><td>chore(dependabot): ext...</td><td>September 03, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>Feat/codescan (#27)</td><td>February 16, 2026</td></tr></table></details></td></tr></table>
<a href="https://baz.co/changes/prompt-security/clawsec/360?tool=ast">Review this PR on Baz</a><br>
<a href="https://baz.co/agents/baz">Customize your next review</a>