### PR TITLE
3/10 ✅ ci(workflows): replace eol node 20 with node 24 lts

### DIFF
--- a/.github/workflows/archive-traffic.yml
+++ b/.github/workflows/archive-traffic.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Prepare archive branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: ESLint
@@ -147,7 +147,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: npm audit
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: GHSA Without CVE Feed Tests
@@ -199,7 +199,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Feed Verification Tests
@@ -224,7 +224,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Hermes Skill Tests
         shell: bash
         run: |
@@ -240,7 +240,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Suppression Config Tests

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Verify signing key consistency (repo + docs)
@@ -424,7 +424,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Verify deployed advisory endpoints
         run: |

--- a/.github/workflows/pages-verify.yml
+++ b/.github/workflows/pages-verify.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Verify signing key consistency (repo + docs)

--- a/.github/workflows/poll-ghsa-without-cve.yml
+++ b/.github/workflows/poll-ghsa-without-cve.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Run GHSA feed tests

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Verify signing key consistency (repo + docs)
         run: ./scripts/ci/verify_signing_key_consistency.sh
@@ -288,7 +288,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install SkillSpector
         run: |
@@ -1022,7 +1022,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install SkillSpector
         run: |
@@ -1197,7 +1197,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Validate npx skills install docs
         run: node scripts/ci/validate_skill_install_docs.mjs --skills "${{ steps.parse.outputs.skill_path }}"
@@ -1790,7 +1790,7 @@ jobs:
         if: needs.release-tag.outputs.publish_clawhub == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Prepare verified ClawHub release package
         id: clawhub-package
@@ -2026,7 +2026,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Prepare verified ClawHub release package
         id: clawhub-package

--- a/.github/workflows/wiki-export-verify.yml
+++ b/.github/workflows/wiki-export-verify.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Test wiki export transform
         run: node scripts/test-wiki-sync-export.mjs

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Test wiki export transform
         run: node scripts/test-wiki-sync-export.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ source .venv/bin/activate
 uv pip install ruff bandit   # linters configured in pyproject.toml
 ```
 
-Required tools: Node 20+, Python 3.10+, openssl, jq, shellcheck, gitleaks,
+Required tools: Node 24+, Python 3.10+, openssl, jq, shellcheck, gitleaks,
 trufflehog (`brew install shellcheck gitleaks trufflehog`). The pre-commit hook
 exits 1 without gitleaks.
 


### PR DESCRIPTION
# User description
> ## ✅ Free to merge
> #359 flagged this as its one unverified change. That gap is now closed with a real build.

Node 20 reached EOL on 2026-04-30; Node 24 is active LTS through 2028-04-30. Swaps all 19 `node-version` literals and the CLAUDE.md prerequisite.

### Verified, not assumed

A **3-cell matrix** — `main`@20, this@20, this@24 — so runtime effects could be separated from branch effects. **39/39 pass in all three cells** on v24.20.0: `npm ci`, `eslint --max-warnings 0`, `tsc --noEmit`, `npm run build`, `npm audit`, and all 36 test files. The `windows-latest` leg is confirmed green on Node 24 by CI on #359.

All **260 `engines.node` ranges across 421 lockfile packages** are satisfied by Node 24; Node 20 fails exactly one. Node 24 emits zero `EBADENGINE`.

**Trust path checked harder than the repo's own suite does.** Ed25519 differential across the OpenSSL 3.0.19 → 3.5.7 jump: 7/7 identical including negative controls (tampered payload, flipped signature byte, wrong key all correctly reject). The **real production artifacts** — `advisories/feed.json` (1.4 MB) and the GHSA feed — both verify `true` on Node 24 with an unchanged key fingerprint. Per CLAUDE.md the test suite uses ephemeral keys, so real-artifact verification under a runtime change was previously uncovered.

### One correction to #359's framing

#359 presents the `react-router@8.3.0` / `engines.node ">=22.22.0"` mismatch as though this PR avoids it. `package-lock.json` is unchanged, so **that condition already exists on `main` today** and `npm ci` still exits 0 there — `EBADENGINE` is a warning. This PR *fixes* a latent condition rather than avoiding one it introduced.

*Note: `node-version` quoting is left inconsistent (13 quoted, 6 bare). That predates this change; normalising it is a separate concern.*

---

## Where this sits in the series

This is one of **10 stacked PRs** splitting #359 into single-concern changes, so any one of them can be reverted on its own. Merge in numeric order — each targets its predecessor, and GitHub retargets the next automatically as each lands.

| # | PR | Merge guidance |
|---|---|---|
| 1 | dependabot cooldown | ✅ **Free to merge** |
| 2 | refresh action pins | ✅ **Free to merge** |
| 3 | node 20 → 24 | ✅ **Free to merge** |
| 4 | python 3.10 → 3.12 | ✅ **Free to merge** |
| 5 | template-injection hardening | ⚡ **Ship promptly** — closes a live exec path on `main` |
| 5b | `$GITHUB_ENV` → step output | ✅ **Free to merge** |
| 6 | `./` → `$/` action refs | ⚖️ **Decide knowingly** — Scorecard badge will move |
| 7 | `gh release` migration | 🧪 **Tag-test first** — never executed by CI |
| 8 | narrow permissions | ⛔ **Merge last, watched** — carries a blocker fix CI can't exercise |
| 9 | `persist-credentials: false` | ⛔ **Merge last, watched** — carries a blocker fix CI can't exercise |

### Why the last three need care

A fully green PR here proves less than it looks. The workflows these change cannot be triggered by a pull request: `poll-nvd-cves` runs on schedule only, `deploy-pages`' build job only on push-to-main or `workflow_run`, and `release-tag` / `publish-clawhub` / `republish-clawhub` are **skipped** without a tag push. #359 was green on all 22 checks while carrying two workflow-breaking bugs in exactly those blind spots.

### Two bugs found in #359 and fixed here

- **The daily NVD poller would have broken.** `persist-credentials: false` was added to the checkout while `git push --force origin` still relied on those credentials. `git fetch` still succeeds on a public repo, so it fails late, at the push, with `could not read Username`. Fixed in PR 9.
- **Pages deployment would have broken.** `pages`/`id-token` moved to the `deploy` job, but the `build` job runs `actions/configure-pages`, which calls the Pages API unconditionally and throws on failure. A job-level `permissions:` block replaces rather than merges, so `build` was left with no `pages` scope. Fixed in PR 8.

<sub>Full review, evidence and merge-order rationale: https://claude.ai/code/artifact/722db3dc-dfc5-40f6-974c-fba34b5dad9c</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Upgrade the repository’s GitHub Actions workflows and contributor prerequisites from Node 20 to Node 24 LTS. Update CI, deployment, release, advisory, and wiki validation flows to run their existing installs, builds, tests, and verification scripts on the supported runtime.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/362?tool=ast&topic=Node+runtime+upgrade>Node runtime upgrade</a>
        </td><td>Upgrade all automated CI, deployment, release, advisory, archive, and wiki workflows to execute on Node 24 instead of the end-of-life Node 20 runtime.<details><summary>Modified files (8)</summary><ul><li>.github/workflows/archive-traffic.yml</li>
<li>.github/workflows/ci.yml</li>
<li>.github/workflows/deploy-pages.yml</li>
<li>.github/workflows/pages-verify.yml</li>
<li>.github/workflows/poll-ghsa-without-cve.yml</li>
<li>.github/workflows/skill-release.yml</li>
<li>.github/workflows/wiki-export-verify.yml</li>
<li>.github/workflows/wiki-sync.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>ci(workflows): replace...</td><td>September 07, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>feat(security): add Tr...</td><td>August 30, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/362?tool=ast&topic=Developer+prerequisite>Developer prerequisite</a>
        </td><td>Update the documented local development prerequisite to require Node 24 or newer.<details><summary>Modified files (1)</summary><ul><li>CLAUDE.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>ci(workflows): replace...</td><td>September 07, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>feat(security): add Tr...</td><td>August 30, 2026</td></tr></table></details></td></tr></table>
<a href="https://baz.co/changes/prompt-security/clawsec/362?tool=ast">Review this PR on Baz</a><br>
<a href="https://baz.co/agents/baz">Customize your next review</a>