### PR TITLE
5/10 ⚡ ci(workflows): move expression expansions out of run and script bodies

### DIFF
--- a/.github/workflows/community-advisory.yml
+++ b/.github/workflows/community-advisory.yml
@@ -313,12 +313,16 @@ jobs:
       - name: Comment on issue
         if: steps.parse.outputs.already_exists != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ADVISORY_ID: ${{ steps.parse.outputs.advisory_id }}
+          PULL_REQUEST_URL: ${{ steps.create-pr.outputs.pull-request-url }}
+          PULL_REQUEST_OPERATION: ${{ steps.create-pr.outputs.pull-request-operation }}
         with:
           github-token: ${{ secrets.POLL_NVD_CVES_PAT }}
           script: |
-            const advisoryId = '${{ steps.parse.outputs.advisory_id }}';
-            const pullRequestUrl = '${{ steps.create-pr.outputs.pull-request-url }}';
-            const operation = '${{ steps.create-pr.outputs.pull-request-operation }}';
+            const advisoryId = process.env.ADVISORY_ID;
+            const pullRequestUrl = process.env.PULL_REQUEST_URL;
+            const operation = process.env.PULL_REQUEST_OPERATION;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -339,10 +343,12 @@ jobs:
       - name: Comment if already exists
         if: steps.parse.outputs.already_exists == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ADVISORY_ID: ${{ steps.parse.outputs.advisory_id }}
         with:
           github-token: ${{ secrets.POLL_NVD_CVES_PAT }}
           script: |
-            const advisoryId = '${{ steps.parse.outputs.advisory_id }}';
+            const advisoryId = process.env.ADVISORY_ID;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/i18n-qa.yml
+++ b/.github/workflows/i18n-qa.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Check markdown links (README/wiki)
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            python scripts/i18n/link_check.py --changed-only --base-ref "origin/${{ github.base_ref }}"
+            python scripts/i18n/link_check.py --changed-only --base-ref "origin/${GITHUB_BASE_REF}"
           else
             python scripts/i18n/link_check.py
           fi

--- a/.github/workflows/poll-ghsa-without-cve.yml
+++ b/.github/workflows/poll-ghsa-without-cve.yml
@@ -152,16 +152,21 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Feed changed | ${{ steps.changes.outputs.changed }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Agent feed changed | ${{ steps.changes.outputs.agent_changed }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| GHSA source feed changed | ${{ steps.changes.outputs.ghsa_changed }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Feed changed | ${STEPS_CHANGES_OUTPUTS_CHANGED} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Agent feed changed | ${STEPS_CHANGES_OUTPUTS_AGENT_CHANGED} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| GHSA source feed changed | ${STEPS_CHANGES_OUTPUTS_GHSA_CHANGED} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Feed path | $GHSA_FEED_PATH |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Agent feed path | $FEED_PATH |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Total advisories | $(jq '.advisories | length' "$GHSA_FEED_PATH") |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Active | $(jq '[.advisories[] | select(.status == "active")] | length' "$GHSA_FEED_PATH") |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Matured | $(jq '[.advisories[] | select(.status == "matured")] | length' "$GHSA_FEED_PATH") |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Stale | $(jq '[.advisories[] | select(.status == "stale")] | length' "$GHSA_FEED_PATH") |" >> "$GITHUB_STEP_SUMMARY"
-          if [ -n "${{ steps.create-pr.outputs.pull-request-url }}" ]; then
+          if [ -n "${STEPS_CREATE_PR_OUTPUTS_PULL_REQUEST_URL}" ]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "Upserted PR: ${{ steps.create-pr.outputs.pull-request-url }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "Upserted PR: ${STEPS_CREATE_PR_OUTPUTS_PULL_REQUEST_URL}" >> "$GITHUB_STEP_SUMMARY"
           fi
+        env:
+          STEPS_CHANGES_OUTPUTS_CHANGED: ${{ steps.changes.outputs.changed }}
+          STEPS_CHANGES_OUTPUTS_AGENT_CHANGED: ${{ steps.changes.outputs.agent_changed }}
+          STEPS_CHANGES_OUTPUTS_GHSA_CHANGED: ${{ steps.changes.outputs.ghsa_changed }}
+          STEPS_CREATE_PR_OUTPUTS_PULL_REQUEST_URL: ${{ steps.create-pr.outputs.pull-request-url }}

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -68,8 +68,10 @@ jobs:
 
       - name: Set date window
         id: dates
+        env:
+          STEPS_LAST_POLL_OUTPUTS_LAST_DATE: ${{ steps.last_poll.outputs.last_date }}
         run: |
-          START_DATE="${{ steps.last_poll.outputs.last_date }}"
+          START_DATE="${STEPS_LAST_POLL_OUTPUTS_LAST_DATE}"
           END_DATE=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
           
           # Convert to epoch for comparison
@@ -90,6 +92,9 @@ jobs:
 
       - name: Fetch CVEs from NVD
         id: fetch
+        env:
+          STEPS_DATES_OUTPUTS_START_DATE: ${{ steps.dates.outputs.start_date }}
+          STEPS_DATES_OUTPUTS_END_DATE: ${{ steps.dates.outputs.end_date }}
         run: |
           set -euo pipefail
           source scripts/feed-utils.sh
@@ -97,8 +102,8 @@ jobs:
           FORCE_FULL_SCAN="${{ inputs.force_full_scan }}"
           NVD_QUERY_SPECS="$(nvd_query_specs)"
           
-          START_DATE="${{ steps.dates.outputs.start_date }}"
-          END_DATE="${{ steps.dates.outputs.end_date }}"
+          START_DATE="${STEPS_DATES_OUTPUTS_START_DATE}"
+          END_DATE="${STEPS_DATES_OUTPUTS_END_DATE}"
           
           # URL encode the dates
           START_ENC=$(echo "$START_DATE" | sed 's/:/%3A/g')
@@ -545,6 +550,8 @@ jobs:
 
       - name: Transform CVEs to advisories
         id: transform
+        env:
+          STEPS_PROCESS_OUTPUTS_FILTERED_COUNT: ${{ steps.process.outputs.filtered_count }}
         run: |
           # Read existing IDs into jq-friendly files (avoids huge CLI args on full scans).
           jq -R -s 'split("\n") | map(select(length > 0))' < tmp/existing_ids.txt > tmp/existing_ids_from_feed.json
@@ -752,7 +759,7 @@ jobs:
           echo "nvd_new_to_feed_count=$NET_NEW_COUNT" >> $GITHUB_OUTPUT
 
           if [ "${{ inputs.force_full_scan }}" = "true" ]; then
-            FILTERED_COUNT="${{ steps.process.outputs.filtered_count }}"
+            FILTERED_COUNT="${STEPS_PROCESS_OUTPUTS_FILTERED_COUNT}"
             if [ "$NEW_COUNT" -ne "$FILTERED_COUNT" ]; then
               echo "::error::Full scan transform mismatch: filtered CVEs=$FILTERED_COUNT transformed advisories=$NEW_COUNT"
               exit 1
@@ -915,6 +922,10 @@ jobs:
 
       - name: Detect advisory feed changes
         id: feed_changes
+        env:
+          STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT: ${{ steps.transform.outputs.nvd_rebuilt_count }}
+          STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT: ${{ steps.transform.outputs.nvd_new_to_feed_count }}
+          STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT: ${{ steps.nvd_counts.outputs.nvd_updated_count }}
         run: |
           set -euo pipefail
 
@@ -934,7 +945,7 @@ jobs:
             ' "$FEED_PATH"
           )"
 
-          if [ "${{ steps.transform.outputs.nvd_rebuilt_count }}" != "0" ] || [ "${{ steps.transform.outputs.nvd_new_to_feed_count }}" != "0" ] || [ "${{ steps.nvd_counts.outputs.nvd_updated_count }}" != "0" ]; then
+          if [ "${STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT}" != "0" ] || [ "${STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT}" != "0" ] || [ "${STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT}" != "0" ]; then
             NVD_CHANGED=true
           fi
 
@@ -1016,14 +1027,25 @@ jobs:
         id: upsert-pr
         env:
           GH_TOKEN: ${{ github.token }}
+          STEPS_DATES_OUTPUTS_START_DATE: ${{ steps.dates.outputs.start_date }}
+          STEPS_DATES_OUTPUTS_END_DATE: ${{ steps.dates.outputs.end_date }}
+          STEPS_PROCESS_OUTPUTS_NVD_FILTERED_COUNT: ${{ steps.process.outputs.nvd_filtered_count }}
+          STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT: ${{ steps.transform.outputs.nvd_rebuilt_count }}
+          STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT: ${{ steps.transform.outputs.nvd_new_to_feed_count }}
+          STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT: ${{ steps.nvd_counts.outputs.nvd_updated_count }}
+          STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT: ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }}
+          STEPS_FEED_CHANGES_OUTPUTS_GHSA_CHANGED: ${{ steps.feed_changes.outputs.ghsa_changed }}
+          STEPS_FEED_CHANGES_OUTPUTS_AGENT_CHANGED: ${{ steps.feed_changes.outputs.agent_changed }}
         run: |
           set -euo pipefail
 
           BRANCH_PREFIX="automated/nvd-cve-update"
           PR_COMMENT="Superseded by newer automated NVD advisory update."
-          TITLE="chore: update NVD/GHSA advisories - ${{ steps.transform.outputs.nvd_new_to_feed_count }} NVD new, ${{ steps.nvd_counts.outputs.nvd_updated_count }} NVD updated, ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }} GHSA active added"
+          TITLE="chore: update NVD/GHSA advisories - ${STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT} NVD new, ${STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT} NVD updated, ${STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT} GHSA active added"
           COMMIT_SUBJECT="$TITLE"
-          COMMIT_BODY=$'Automated update from NVD CVE and GHSA advisory feeds.\nKeywords: ${{ env.KEYWORDS }}\nPoll window: ${{ steps.dates.outputs.start_date }} to ${{ steps.dates.outputs.end_date }}'
+          # printf, not $'...': ANSI-C quoting does not expand parameters.
+          COMMIT_BODY="$(printf 'Automated update from NVD CVE and GHSA advisory feeds.\nKeywords: %s\nPoll window: %s to %s' \
+            "$KEYWORDS" "$STEPS_DATES_OUTPUTS_START_DATE" "$STEPS_DATES_OUTPUTS_END_DATE")"
 
           GHSA_TOTAL="$(jq '.advisories | length' "$GHSA_FEED_PATH")"
           GHSA_ACTIVE="$(jq '[.advisories[] | select(.status == "active")] | length' "$GHSA_FEED_PATH")"
@@ -1042,16 +1064,16 @@ jobs:
           Automated update from NVD CVE and GHSA advisory feeds.
 
           - **Mode:** ${MODE}
-          - **Filtered NVD CVEs:** ${{ steps.process.outputs.nvd_filtered_count }}
-          - **Rebuilt NVD advisories:** ${{ steps.transform.outputs.nvd_rebuilt_count }}
-          - **Net-new NVD advisories:** ${{ steps.transform.outputs.nvd_new_to_feed_count }}
-          - **Updated NVD advisories:** ${{ steps.nvd_counts.outputs.nvd_updated_count }}
-          - **GHSA active advisories added to consolidated feed:** ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }}
-          - **GHSA source feed changed:** ${{ steps.feed_changes.outputs.ghsa_changed }}
-          - **Consolidated agent feed changed:** ${{ steps.feed_changes.outputs.agent_changed }}
+          - **Filtered NVD CVEs:** ${STEPS_PROCESS_OUTPUTS_NVD_FILTERED_COUNT}
+          - **Rebuilt NVD advisories:** ${STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT}
+          - **Net-new NVD advisories:** ${STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT}
+          - **Updated NVD advisories:** ${STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT}
+          - **GHSA active advisories added to consolidated feed:** ${STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT}
+          - **GHSA source feed changed:** ${STEPS_FEED_CHANGES_OUTPUTS_GHSA_CHANGED}
+          - **Consolidated agent feed changed:** ${STEPS_FEED_CHANGES_OUTPUTS_AGENT_CHANGED}
           - **GHSA provisional advisories:** ${GHSA_TOTAL} total (${GHSA_ACTIVE} active, ${GHSA_MATURED} matured, ${GHSA_STALE} stale)
-          - **Poll window:** ${{ steps.dates.outputs.start_date }} → ${{ steps.dates.outputs.end_date }}
-          - **Keywords:** ${{ env.KEYWORDS }}
+          - **Poll window:** ${STEPS_DATES_OUTPUTS_START_DATE} → ${STEPS_DATES_OUTPUTS_END_DATE}
+          - **Keywords:** ${KEYWORDS}
 
           ---
           *This PR was automatically generated by the NVD CVE polling workflow with GHSA consolidation.*
@@ -1129,10 +1151,11 @@ jobs:
         if: steps.upsert-pr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          STEPS_UPSERT_PR_OUTPUTS_PULL_REQUEST_BRANCH: ${{ steps.upsert-pr.outputs.pull-request-branch }}
         run: |
           set -euo pipefail
 
-          BRANCH="${{ steps.upsert-pr.outputs.pull-request-branch }}"
+          BRANCH="${STEPS_UPSERT_PR_OUTPUTS_PULL_REQUEST_BRANCH}"
           if [ -z "$BRANCH" ]; then
             echo "::error::Missing pull-request-branch output from upsert-pr step"
             exit 1
@@ -1178,6 +1201,18 @@ jobs:
           gh run watch "$RUN_ID" --exit-status
 
       - name: Summary
+        env:
+          STEPS_DATES_OUTPUTS_START_DATE: ${{ steps.dates.outputs.start_date }}
+          STEPS_DATES_OUTPUTS_END_DATE: ${{ steps.dates.outputs.end_date }}
+          STEPS_PROCESS_OUTPUTS_NVD_FILTERED_COUNT: ${{ steps.process.outputs.nvd_filtered_count }}
+          STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT: ${{ steps.transform.outputs.nvd_rebuilt_count }}
+          STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT: ${{ steps.transform.outputs.nvd_new_to_feed_count }}
+          STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT: ${{ steps.nvd_counts.outputs.nvd_updated_count }}
+          STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT: ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }}
+          STEPS_FEED_CHANGES_OUTPUTS_GHSA_CHANGED: ${{ steps.feed_changes.outputs.ghsa_changed }}
+          STEPS_FEED_CHANGES_OUTPUTS_AGENT_CHANGED: ${{ steps.feed_changes.outputs.agent_changed }}
+          STEPS_FEED_CHANGES_OUTPUTS_CHANGED: ${{ steps.feed_changes.outputs.changed }}
+          STEPS_UPSERT_PR_OUTPUTS_PULL_REQUEST_URL: ${{ steps.upsert-pr.outputs.pull-request-url }}
         run: |
           if [ "${{ inputs.force_full_scan }}" = "true" ]; then
             MODE="full-rebuild (ignore feed state)"
@@ -1190,34 +1225,34 @@ jobs:
           echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Mode | $MODE |" >> $GITHUB_STEP_SUMMARY
-          echo "| Poll Window | ${{ steps.dates.outputs.start_date }} → ${{ steps.dates.outputs.end_date }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Poll Window | ${STEPS_DATES_OUTPUTS_START_DATE} → ${STEPS_DATES_OUTPUTS_END_DATE} |" >> $GITHUB_STEP_SUMMARY
           echo "| Keywords | $KEYWORDS |" >> $GITHUB_STEP_SUMMARY
-          echo "| NVD CVEs Found (filtered) | ${{ steps.process.outputs.nvd_filtered_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| NVD Advisories Rebuilt | ${{ steps.transform.outputs.nvd_rebuilt_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Net-new NVD Advisories | ${{ steps.transform.outputs.nvd_new_to_feed_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Updated NVD Advisories | ${{ steps.nvd_counts.outputs.nvd_updated_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| GHSA Active Added | ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| GHSA source feed changed | ${{ steps.feed_changes.outputs.ghsa_changed }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Consolidated agent feed changed | ${{ steps.feed_changes.outputs.agent_changed }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| NVD CVEs Found (filtered) | ${STEPS_PROCESS_OUTPUTS_NVD_FILTERED_COUNT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| NVD Advisories Rebuilt | ${STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Net-new NVD Advisories | ${STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Updated NVD Advisories | ${STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| GHSA Active Added | ${STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| GHSA source feed changed | ${STEPS_FEED_CHANGES_OUTPUTS_GHSA_CHANGED} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Consolidated agent feed changed | ${STEPS_FEED_CHANGES_OUTPUTS_AGENT_CHANGED} |" >> $GITHUB_STEP_SUMMARY
           echo "| GHSA provisional advisories | $(jq '.advisories | length' "$GHSA_FEED_PATH") |" >> $GITHUB_STEP_SUMMARY
 
-          if [ "${{ steps.transform.outputs.nvd_new_to_feed_count }}" != "0" ]; then
+          if [ "${STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT}" != "0" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Net-new NVD Advisories" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             jq -r '.[] | "- **\(.id)** (\(.severity)): \(.title)"' tmp/net_new_advisories.json >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ "${{ steps.nvd_counts.outputs.nvd_updated_count }}" != "0" ]; then
+          if [ "${STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT}" != "0" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Updated NVD Advisories" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             jq -r '.[] | "- **\(.id)**: \(.changes | join(", "))"' tmp/updated_advisories.json >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ "${{ steps.feed_changes.outputs.changed }}" = "true" ]; then
+          if [ "${STEPS_FEED_CHANGES_OUTPUTS_CHANGED}" = "true" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "🔀 Upserted PR: ${{ steps.upsert-pr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
+            echo "🔀 Upserted PR: ${STEPS_UPSERT_PR_OUTPUTS_PULL_REQUEST_URL}" >> $GITHUB_STEP_SUMMARY
           else
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "✅ No new or updated NVD CVEs or GHSA changes found." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -1093,7 +1093,7 @@ jobs:
       - name: Parse tag
         id: parse
         run: |
-          TAG="${{ github.ref_name }}"
+          TAG="${GITHUB_REF_NAME}"
           # Extract skill name (everything before -v)
           SKILL_NAME="${TAG%-v*}"
           # Extract version (everything after -v)
@@ -1113,7 +1113,7 @@ jobs:
 
       - name: Validate skill exists
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
           if [ ! -d "$SKILL_PATH" ]; then
             echo "Error: Skill directory not found: $SKILL_PATH"
             exit 1
@@ -1123,11 +1123,13 @@ jobs:
             exit 1
           fi
           echo "Skill validated: $SKILL_PATH"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Validate version match
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
-          TAG_VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+          TAG_VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
 
           # Extract version from skill.json
           JSON_VERSION=$(jq -r '.version' "$SKILL_PATH/skill.json")
@@ -1139,11 +1141,14 @@ jobs:
           fi
 
           echo "Version validated: $TAG_VERSION"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Validate SKILL.md frontmatter version
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
-          TAG_VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+          TAG_VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
 
           # Check if SKILL.md exists
           if [ -f "$SKILL_PATH/SKILL.md" ]; then
@@ -1163,6 +1168,9 @@ jobs:
             echo "::error::Missing required SKILL.md: $SKILL_PATH/SKILL.md"
             exit 1
           fi
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -1172,7 +1180,7 @@ jobs:
       - name: Detect publishability and install defaults
         id: publishable
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
           INTERNAL=$(jq -r 'if (.openclaw | type) == "object" then (.openclaw.internal // false) else false end' "$SKILL_PATH/skill.json")
 
           OPENCLAW_SKILL=false
@@ -1198,9 +1206,13 @@ jobs:
           echo "publish_clawhub=${PUBLISH_CLAWHUB}" >> $GITHUB_OUTPUT
           echo "publishable=${PUBLISHABLE}" >> $GITHUB_OUTPUT
           echo "clawhub_slug=${CLAWHUB_SLUG}" >> $GITHUB_OUTPUT
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Validate npx skills install docs
-        run: node scripts/ci/validate_skill_install_docs.mjs --skills "${{ steps.parse.outputs.skill_path }}"
+        run: node scripts/ci/validate_skill_install_docs.mjs --skills "${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Install SkillSpector
         run: |
@@ -1226,7 +1238,7 @@ jobs:
         if: hashFiles(format('skills/{0}/advisories/feed.json', steps.parse.outputs.skill_name)) != ''
         run: |
           set -euo pipefail
-          ADVISORY_DIR="${{ steps.parse.outputs.skill_path }}/advisories"
+          ADVISORY_DIR="${STEPS_PARSE_OUTPUTS_SKILL_PATH}/advisories"
           FEED_SHA=$(sha256sum "$ADVISORY_DIR/feed.json" | awk '{print $1}')
           FEED_SIZE=$(stat -c%s "$ADVISORY_DIR/feed.json" 2>/dev/null || stat -f%z "$ADVISORY_DIR/feed.json")
           FEED_SIG_SHA=$(sha256sum "$ADVISORY_DIR/feed.json.sig" | awk '{print $1}')
@@ -1237,7 +1249,7 @@ jobs:
           jq -n \
             --arg schema_version "1" \
             --arg algorithm "sha256" \
-            --arg version "${{ steps.parse.outputs.version }}" \
+            --arg version "${STEPS_PARSE_OUTPUTS_VERSION}" \
             --arg generated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg repo "${{ github.repository }}" \
             --arg feed_sha "$FEED_SHA" \
@@ -1273,6 +1285,9 @@ jobs:
 
           echo "Generated $ADVISORY_DIR/checksums.json"
           jq . "$ADVISORY_DIR/checksums.json"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Sign embedded advisory checksums and verify
         if: hashFiles(format('skills/{0}/advisories/feed.json', steps.parse.outputs.skill_name)) != ''
@@ -1286,17 +1301,19 @@ jobs:
       - name: Show embedded advisory signing outputs
         if: hashFiles(format('skills/{0}/advisories/feed.json', steps.parse.outputs.skill_name)) != ''
         run: |
-          ADVISORY_DIR="${{ steps.parse.outputs.skill_path }}/advisories"
+          ADVISORY_DIR="${STEPS_PARSE_OUTPUTS_SKILL_PATH}/advisories"
           echo "Successfully signed embedded advisory artifacts:"
           ls -la "$ADVISORY_DIR"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Package release assets
         run: |
           set -euo pipefail
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
-          VERSION="${{ steps.parse.outputs.version }}"
-          TAG="${{ github.ref_name }}"
+          SKILL_NAME="${STEPS_PARSE_OUTPUTS_SKILL_NAME}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
+          TAG="${GITHUB_REF_NAME}"
 
           mkdir -p release-assets
 
@@ -1518,6 +1535,10 @@ jobs:
           echo ""
           echo "=== Release assets ==="
           ls -la release-assets/
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Sign checksums and verify
         uses: ./.github/actions/sign-and-verify
@@ -1549,8 +1570,8 @@ jobs:
         id: changelog
         run: |
           set -euo pipefail
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
-          VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
 
           if [ ! -f "$SKILL_PATH/CHANGELOG.md" ]; then
             echo "::error::Missing required changelog file: $SKILL_PATH/CHANGELOG.md"
@@ -1580,16 +1601,19 @@ jobs:
             echo "$CHANGELOG_ENTRY"
             echo "EOF"
           } >> $GITHUB_OUTPUT
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Build quick install instructions
         id: install
         run: |
           set -euo pipefail
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          CLAWHUB_SLUG="${{ steps.publishable.outputs.clawhub_slug }}"
-          VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_NAME="${STEPS_PARSE_OUTPUTS_SKILL_NAME}"
+          CLAWHUB_SLUG="${STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
           REPO="${{ github.repository }}"
-          TAG="${{ github.ref_name }}"
+          TAG="${GITHUB_REF_NAME}"
 
           {
             echo "quick_install<<INSTALL_EOF"
@@ -1614,7 +1638,7 @@ jobs:
 
           EOF
 
-            if [ "${{ steps.publishable.outputs.publish_clawhub }}" = "true" ] && [ "${{ steps.publishable.outputs.openclaw_skill }}" = "true" ]; then
+            if [ "${STEPS_PUBLISHABLE_OUTPUTS_PUBLISH_CLAWHUB}" = "true" ] && [ "${STEPS_PUBLISHABLE_OUTPUTS_OPENCLAW_SKILL}" = "true" ]; then
               cat <<EOF
           ### Quick Install
 
@@ -1666,6 +1690,12 @@ jobs:
 
             echo "INSTALL_EOF"
           } >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG: ${{ steps.publishable.outputs.clawhub_slug }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
+          STEPS_PUBLISHABLE_OUTPUTS_PUBLISH_CLAWHUB: ${{ steps.publishable.outputs.publish_clawhub }}
+          STEPS_PUBLISHABLE_OUTPUTS_OPENCLAW_SKILL: ${{ steps.publishable.outputs.openclaw_skill }}
 
       - name: Prepare GitHub release body
         env:
@@ -1729,8 +1759,8 @@ jobs:
 
       - name: Delete superseded releases
         run: |
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          CURRENT_VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_NAME="${STEPS_PARSE_OUTPUTS_SKILL_NAME}"
+          CURRENT_VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
 
           # Extract major version from current release
           CURRENT_MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
@@ -1763,6 +1793,8 @@ jobs:
           echo "Superseded release cleanup complete"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STEPS_PARSE_OUTPUTS_SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
   publish-clawhub:
     # Separate blocking job for ClawHub publishing - runs after GitHub release.
@@ -1797,11 +1829,13 @@ jobs:
         if: needs.release-tag.outputs.publish_clawhub == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME: ${{ needs.release-tag.outputs.skill_name }}
+          NEEDS_RELEASE_TAG_OUTPUTS_VERSION: ${{ needs.release-tag.outputs.version }}
         run: |
           set -euo pipefail
-          SKILL_NAME="${{ needs.release-tag.outputs.skill_name }}"
-          VERSION="${{ needs.release-tag.outputs.version }}"
-          TAG="${{ github.ref_name }}"
+          SKILL_NAME="${NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME}"
+          VERSION="${NEEDS_RELEASE_TAG_OUTPUTS_VERSION}"
+          TAG="${GITHUB_REF_NAME}"
           RELEASE_DIR="$RUNNER_TEMP/clawhub-release"
           OUTPUT_DIR="$RUNNER_TEMP/clawhub-package"
 
@@ -1866,7 +1900,9 @@ jobs:
           export CLAWHUB_SITE="$SITE"
           export CLAWHUB_REGISTRY="$REGISTRY"
           bash scripts/ci/guard_clawhub_slug_owner.sh \
-            "${{ needs.release-tag.outputs.clawhub_slug }}"
+            "${NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG}"
+        env:
+          NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG: ${{ needs.release-tag.outputs.clawhub_slug }}
 
       - name: Check existing ClawHub version
         id: clawhub-version
@@ -1875,9 +1911,9 @@ jobs:
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          SKILL_NAME="${{ needs.release-tag.outputs.skill_name }}"
-          CLAWHUB_SLUG="${{ needs.release-tag.outputs.clawhub_slug }}"
-          VERSION="${{ needs.release-tag.outputs.version }}"
+          SKILL_NAME="${NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME}"
+          CLAWHUB_SLUG="${NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${NEEDS_RELEASE_TAG_OUTPUTS_VERSION}"
           export CLAWHUB_CONFIG_PATH="$HOME/.clawhub-ci/config.json"
 
           set +e
@@ -1901,6 +1937,10 @@ jobs:
             cat /tmp/clawhub-existing-version.err
             exit 1
           fi
+        env:
+          NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME: ${{ needs.release-tag.outputs.skill_name }}
+          NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG: ${{ needs.release-tag.outputs.clawhub_slug }}
+          NEEDS_RELEASE_TAG_OUTPUTS_VERSION: ${{ needs.release-tag.outputs.version }}
 
       - name: Publish to ClawHub
         if: needs.release-tag.outputs.publish_clawhub == 'true' && steps.clawhub-version.outputs.already_exists != 'true'
@@ -1908,10 +1948,10 @@ jobs:
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
-          SKILL_NAME="${{ needs.release-tag.outputs.skill_name }}"
-          CLAWHUB_SLUG="${{ needs.release-tag.outputs.clawhub_slug }}"
-          VERSION="${{ needs.release-tag.outputs.version }}"
+          SKILL_PATH="${STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH}"
+          SKILL_NAME="${NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME}"
+          CLAWHUB_SLUG="${NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${NEEDS_RELEASE_TAG_OUTPUTS_VERSION}"
           NAME=$(jq -r '.name' "$SKILL_PATH/skill.json")
           CHANGELOG="Release ${VERSION} via CI"
 
@@ -1934,6 +1974,11 @@ jobs:
           fi
 
           echo "ClawHub publish request completed for $SKILL_NAME@$VERSION as $CLAWHUB_SLUG"
+        env:
+          STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH: ${{ steps.clawhub-package.outputs.skill_path }}
+          NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME: ${{ needs.release-tag.outputs.skill_name }}
+          NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG: ${{ needs.release-tag.outputs.clawhub_slug }}
+          NEEDS_RELEASE_TAG_OUTPUTS_VERSION: ${{ needs.release-tag.outputs.version }}
 
       - name: Verify published ClawHub package
         if: needs.release-tag.outputs.publish_clawhub == 'true'
@@ -1941,9 +1986,9 @@ jobs:
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          CLAWHUB_SLUG="${{ needs.release-tag.outputs.clawhub_slug }}"
-          VERSION="${{ needs.release-tag.outputs.version }}"
-          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
+          CLAWHUB_SLUG="${NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${NEEDS_RELEASE_TAG_OUTPUTS_VERSION}"
+          SKILL_PATH="${STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH}"
           export CLAWHUB_CONFIG_PATH="$HOME/.clawhub-ci/config.json"
           export CLAWHUB_SITE="$SITE"
           export CLAWHUB_REGISTRY="$REGISTRY"
@@ -1953,6 +1998,10 @@ jobs:
             --slug "$CLAWHUB_SLUG" \
             --version "$VERSION"
           echo "✓ Verified published ClawHub package matches the signed release payload"
+        env:
+          NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG: ${{ needs.release-tag.outputs.clawhub_slug }}
+          NEEDS_RELEASE_TAG_OUTPUTS_VERSION: ${{ needs.release-tag.outputs.version }}
+          STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH: ${{ steps.clawhub-package.outputs.skill_path }}
 
   republish-clawhub:
     # Manual workflow to republish a specific tag to ClawHub
@@ -1967,7 +2016,7 @@ jobs:
       - name: Parse tag
         id: parse
         run: |
-          TAG="${{ github.event.inputs.tag }}"
+          TAG="${GITHUB_EVENT_INPUTS_TAG}"
           # Extract skill name (everything before -v)
           SKILL_NAME="${TAG%-v*}"
           # Extract version (everything after -v)
@@ -1978,6 +2027,8 @@ jobs:
           echo "skill_path=skills/${SKILL_NAME}" >> $GITHUB_OUTPUT
 
           echo "Parsed tag: skill=${SKILL_NAME}, version=${VERSION}"
+        env:
+          GITHUB_EVENT_INPUTS_TAG: ${{ github.event.inputs.tag }}
 
       - name: Checkout workflow helpers
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1997,7 +2048,7 @@ jobs:
 
       - name: Validate skill exists
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
           if [ ! -d "$SKILL_PATH" ]; then
             echo "Error: Skill directory not found: $SKILL_PATH"
             exit 1
@@ -2007,6 +2058,8 @@ jobs:
             exit 1
           fi
           echo "Skill validated: $SKILL_PATH"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -2016,7 +2069,7 @@ jobs:
       - name: Check if publishable
         id: publishable
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
           INTERNAL=$(jq -r 'if (.openclaw | type) == "object" then (.openclaw.internal // false) else false end' "$SKILL_PATH/skill.json")
 
           if [ "$INTERNAL" = "true" ]; then
@@ -2027,16 +2080,21 @@ jobs:
           CLAWHUB_SLUG=$(node "$RUNNER_TEMP/resolve_clawhub_slug.mjs" "$SKILL_PATH")
           echo "clawhub_slug=${CLAWHUB_SLUG}" >> $GITHUB_OUTPUT
           echo "Skill is publishable to ClawHub"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Prepare verified ClawHub release package
         id: clawhub-package
         env:
           GH_TOKEN: ${{ github.token }}
+          STEPS_PARSE_OUTPUTS_SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
+          GITHUB_EVENT_INPUTS_TAG: ${{ github.event.inputs.tag }}
         run: |
           set -euo pipefail
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          VERSION="${{ steps.parse.outputs.version }}"
-          TAG="${{ github.event.inputs.tag }}"
+          SKILL_NAME="${STEPS_PARSE_OUTPUTS_SKILL_NAME}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
+          TAG="${GITHUB_EVENT_INPUTS_TAG}"
           RELEASE_DIR="$RUNNER_TEMP/clawhub-release"
           OUTPUT_DIR="$RUNNER_TEMP/clawhub-package"
 
@@ -2073,7 +2131,9 @@ jobs:
           echo "skill_path=$OUTPUT_DIR/$SKILL_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Validate npx skills install docs
-        run: node scripts/ci/validate_skill_install_docs.mjs --skills "${{ steps.parse.outputs.skill_path }}"
+        run: node scripts/ci/validate_skill_install_docs.mjs --skills "${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Install clawhub CLI
         run: bash scripts/ci/install_clawhub_cli.sh
@@ -2110,17 +2170,19 @@ jobs:
           export CLAWHUB_SITE="$SITE"
           export CLAWHUB_REGISTRY="$REGISTRY"
           bash scripts/ci/guard_clawhub_slug_owner.sh \
-            "${{ steps.publishable.outputs.clawhub_slug }}"
+            "${STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG}"
+        env:
+          STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG: ${{ steps.publishable.outputs.clawhub_slug }}
 
       - name: Publish to ClawHub
         run: |
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          CLAWHUB_SLUG="${{ steps.publishable.outputs.clawhub_slug }}"
-          VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_PATH="${STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH}"
+          SKILL_NAME="${STEPS_PARSE_OUTPUTS_SKILL_NAME}"
+          CLAWHUB_SLUG="${STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
           NAME=$(jq -r '.name' "$SKILL_PATH/skill.json")
           CHANGELOG="Manual republish of ${VERSION} via workflow_dispatch"
 
@@ -2152,15 +2214,20 @@ jobs:
           fi
 
           echo "✓ Successfully published $SKILL_NAME@$VERSION to ClawHub"
+        env:
+          STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH: ${{ steps.clawhub-package.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG: ${{ steps.publishable.outputs.clawhub_slug }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Verify published ClawHub package
         run: |
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          CLAWHUB_SLUG="${{ steps.publishable.outputs.clawhub_slug }}"
-          VERSION="${{ steps.parse.outputs.version }}"
-          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
+          CLAWHUB_SLUG="${STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
+          SKILL_PATH="${STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH}"
           export CLAWHUB_CONFIG_PATH="$HOME/.clawhub-ci/config.json"
           export CLAWHUB_SITE="$SITE"
           export CLAWHUB_REGISTRY="$REGISTRY"
@@ -2170,3 +2237,7 @@ jobs:
             --slug "$CLAWHUB_SLUG" \
             --version "$VERSION"
           echo "✓ Verified published ClawHub package matches the signed release payload"
+        env:
+          STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG: ${{ steps.publishable.outputs.clawhub_slug }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
+          STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH: ${{ steps.clawhub-package.outputs.skill_path }}

--- a/scripts/test-nvd-ghsa-consolidation-workflow.mjs
+++ b/scripts/test-nvd-ghsa-consolidation-workflow.mjs
@@ -112,12 +112,12 @@ assert.match(
 );
 assert.match(
   workflow,
-  /TITLE="chore: update NVD\/GHSA advisories - \$\{\{ steps\.transform\.outputs\.nvd_new_to_feed_count \}\} NVD new, \$\{\{ steps\.nvd_counts\.outputs\.nvd_updated_count \}\} NVD updated, \$\{\{ steps\.feed_changes\.outputs\.ghsa_added_to_consolidated_count \}\} GHSA active added"/,
+  /TITLE="chore: update NVD\/GHSA advisories - \$\{STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT\} NVD new, \$\{STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT\} NVD updated, \$\{STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT\} GHSA active added"/,
   'Generated PR titles must include net-new NVD, updated NVD, and GHSA-only addition counts',
 );
 assert.match(
   workflow,
-  /\*\*GHSA active advisories added to consolidated feed:\*\* \$\{\{ steps\.feed_changes\.outputs\.ghsa_added_to_consolidated_count \}\}/,
+  /\*\*GHSA active advisories added to consolidated feed:\*\* \$\{STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT\}/,
   'Generated PR bodies must include GHSA-only additions',
 );
 assert.doesNotMatch(

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -564,7 +564,7 @@ assert.doesNotMatch(
 );
 
 assert.equal(
-  workflow.match(/SKILL_PATH="\$\{\{ steps\.clawhub-package\.outputs\.skill_path \}\}"/g)?.length,
+  workflow.match(/SKILL_PATH="\$\{STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH\}"/g)?.length,
   4,
   'ClawHub publish, republish, and their verification steps must use the verified release package path',
 );


### PR DESCRIPTION
# User description
> ## ⚡ Ship promptly — do not queue this behind the riskier PRs
> This closes an **arbitrary-execution path that exists on `main` today**. It is the largest diff in the series but the best-evidenced, and every later PR in the stack is riskier than this one.

Every `${{ }}` expansion inside a `run:` or `github-script` body is substituted by the runner **as text** before bash or node ever sees it, so a value containing a quote can escape its literal and execute. This moves 33 such expansions into step `env:` blocks, read as `${VAR}` / `process.env.X`, where the value arrives as data.

### This is not theoretical

The NVD PR body on `main` builds `COMMIT_BODY` inside `$'...'` with the expansion pasted in raw. A single quote in an advisory-derived value breaks out and runs arbitrary commands. Demonstrated against the pre-change script, and inert after.

### Correction to #359's stated rationale

#359 says `$'...'` "does not expand parameters, so a naive `${VAR}` swap would have silently broken it" — which reads as though the old code was already broken. It was not. GitHub expands `${{ }}` **before** bash sees the script, so the value was substituted and `\n` became a real newline. The byte-comparison claim holds (167 bytes, identical). The change's real value is **injection hardening**, and it deserves to be described as a security fix rather than a quoting cleanup.

### Verified equivalent, not eyeballed

Every rewritten site was **reverse-substituted** back to its `${{ }}` form and byte-compared against the base script across **~140 `run:` blocks**. Exactly 2 divergences, both intentional: the injection fix above, and a literal `\n` in a value now staying literal — correct behaviour for data.

The **`set -u` regression class** was specifically checked, since a skipped step's `${{ }}` output yields an empty string whereas an undeclared `${VAR}` under `set -u` is fatal. Every rewritten site declares its variable in that step's `env:`, so values are set-but-empty and never unbound. Base→branch delta of undeclared references: **zero**.

`shellcheck`: **no new findings, 4 fixed** — two `SC2050` "expression is constant" warnings disappear because those conditions were literally constant at shell level before and are now real variables.

### Deliberately not swept

`${{ github.repository }}`, `${{ inputs.force_full_scan }}`, `${{ github.event_name }}` and `${{ github.event.pull_request.head.sha }}` still expand inline in some `run:` bodies. None is attacker-controlled, and sweeping them would widen this diff without reducing risk — but a template-injection scanner will still flag those files, so #359's "every `${{ }}` expansion moved out" was overstated.

---

## Where this sits in the series

This is one of **10 stacked PRs** splitting #359 into single-concern changes, so any one of them can be reverted on its own. Merge in numeric order — each targets its predecessor, and GitHub retargets the next automatically as each lands.

| # | PR | Merge guidance |
|---|---|---|
| 1 | dependabot cooldown | ✅ **Free to merge** |
| 2 | refresh action pins | ✅ **Free to merge** |
| 3 | node 20 → 24 | ✅ **Free to merge** |
| 4 | python 3.10 → 3.12 | ✅ **Free to merge** |
| 5 | template-injection hardening | ⚡ **Ship promptly** — closes a live exec path on `main` |
| 5b | `$GITHUB_ENV` → step output | ✅ **Free to merge** |
| 6 | `./` → `$/` action refs | ⚖️ **Decide knowingly** — Scorecard badge will move |
| 7 | `gh release` migration | 🧪 **Tag-test first** — never executed by CI |
| 8 | narrow permissions | ⛔ **Merge last, watched** — carries a blocker fix CI can't exercise |
| 9 | `persist-credentials: false` | ⛔ **Merge last, watched** — carries a blocker fix CI can't exercise |

### Why the last three need care

A fully green PR here proves less than it looks. The workflows these change cannot be triggered by a pull request: `poll-nvd-cves` runs on schedule only, `deploy-pages`' build job only on push-to-main or `workflow_run`, and `release-tag` / `publish-clawhub` / `republish-clawhub` are **skipped** without a tag push. #359 was green on all 22 checks while carrying two workflow-breaking bugs in exactly those blind spots.

### Two bugs found in #359 and fixed here

- **The daily NVD poller would have broken.** `persist-credentials: false` was added to the checkout while `git push --force origin` still relied on those credentials. `git fetch` still succeeds on a public repo, so it fails late, at the push, with `could not read Username`. Fixed in PR 9.
- **Pages deployment would have broken.** `pages`/`id-token` moved to the `deploy` job, but the `build` job runs `actions/configure-pages`, which calls the Pages API unconditionally and throws on failure. A job-level `permissions:` block replaces rather than merges, so `build` was left with no `pages` scope. Fixed in PR 8.

<sub>Full review, evidence and merge-order rationale: https://claude.ai/code/artifact/722db3dc-dfc5-40f6-974c-fba34b5dad9c</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Harden GitHub Actions workflows against expression-injection by moving dynamic values from <code>run</code> and <code>github-script</code> bodies into step <code>env</code> variables. Update advisory polling, skill release, publishing, and validation flows to consume those values safely while preserving workflow behavior and adjusting regression tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/364?tool=ast&topic=CI+injection+hardening>CI injection hardening</a>
        </td><td>Move workflow and script expressions into step-scoped environment variables, including the NVD commit-body construction, to prevent attacker-controlled values from becoming executable shell or JavaScript text.<details><summary>Modified files (4)</summary><ul><li>.github/workflows/community-advisory.yml</li>
<li>.github/workflows/i18n-qa.yml</li>
<li>.github/workflows/poll-ghsa-without-cve.yml</li>
<li>.github/workflows/poll-nvd-cves.yml</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/364?tool=ast&topic=Skill+release+safety>Skill release safety</a>
        </td><td>Update tag-based skill release, ClawHub publishing, republishing, and verification flows to read safely passed values from environment variables, with tests covering the rewritten expressions.<details><summary>Modified files (3)</summary><ul><li>.github/workflows/skill-release.yml</li>
<li>scripts/test-nvd-ghsa-consolidation-workflow.mjs</li>
<li>scripts/test-skill-release-workflow.mjs</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
<a href="https://baz.co/changes/prompt-security/clawsec/364?tool=ast">Review this PR on Baz</a><br>
<a href="https://baz.co/agents/baz">Customize your next review</a>