### PR TITLE
6/10 ✅ ci(deploy-pages): derive the suite release URL as a step output, not $GITHUB_ENV

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,6 +3,9 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  # zizmor: ignore[dangerous-triggers] no PR head is checked out and no artifact
+  # from the triggering run is consumed; every job additionally guards on
+  # workflow_run.event != 'pull_request'.
   workflow_run:
     workflows: ["Skill Release"]
     types: [completed]
@@ -315,6 +318,7 @@ jobs:
           ls -la public/checksums.json public/checksums.sig public/signing-public.pem
 
       - name: Get latest clawsec-suite release URL
+        id: suite_url
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -326,10 +330,10 @@ jobs:
               "/repos/${REPO}/releases?per_page=100" \
               | jq -r -s 'add // [] | [.[] | select(.tag_name | startswith("clawsec-suite-v"))] | first | .tag_name // empty'
           )
-          
+
           if [ -n "$LATEST_TAG" ]; then
             echo "Found latest clawsec-suite tag: $LATEST_TAG"
-            echo "VITE_CLAWSEC_SUITE_URL=https://clawsec.prompt.security/releases/download/${LATEST_TAG}/SKILL.md" >> $GITHUB_ENV
+            echo "url=https://clawsec.prompt.security/releases/download/${LATEST_TAG}/SKILL.md" >> "$GITHUB_OUTPUT"
 
             # Create a local "latest" mirror path for clients that use GitHub-style URLs.
             # This enables swapping the host:
@@ -362,7 +366,7 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: production
-          VITE_CLAWSEC_SUITE_URL: ${{ env.VITE_CLAWSEC_SUITE_URL }}
+          VITE_CLAWSEC_SUITE_URL: ${{ steps.suite_url.outputs.url }}
 
       - name: Verify built public artifacts
         run: |

--- a/scripts/test-deploy-pages-checksums.mjs
+++ b/scripts/test-deploy-pages-checksums.mjs
@@ -96,6 +96,35 @@ assert.match(
 const productionMirrorStep = stepBody(workflow, "Get latest clawsec-suite release URL");
 assert.match(
   productionMirrorStep,
+  /^\s+id: suite_url$/m,
+  "Deploy Pages must identify the suite URL producer as suite_url",
+);
+assert.match(
+  productionMirrorStep,
+  /echo "url=https:\/\/clawsec\.prompt\.security\/releases\/download\/\$\{LATEST_TAG\}\/SKILL\.md" >> "\$GITHUB_OUTPUT"/,
+  "Deploy Pages must publish the suite release URL as the url step output",
+);
+assert.doesNotMatch(
+  productionMirrorStep,
+  /\$\{?GITHUB_ENV\}?/,
+  "the suite URL producer must not write to the shared workflow environment",
+);
+assert.match(
+  productionMirrorStep,
+  /else\n\s+echo "No clawsec-suite release found, using fallback"\n\s+fi\s*$/,
+  "without a suite tag, the producer must leave the URL output unset for the build fallback",
+);
+assert.match(
+  stepBody(workflow, "Build"),
+  /^\s+VITE_CLAWSEC_SUITE_URL: \$\{\{ steps\.suite_url\.outputs\.url \}\}$/m,
+  "Build must consume the suite_url step output",
+);
+assert.ok(
+  stepIndex(workflow, "Get latest clawsec-suite release URL") < stepIndex(workflow, "Build"),
+  "Deploy Pages must derive the suite URL before Build consumes it",
+);
+assert.match(
+  productionMirrorStep,
   /advisory_pages_artifacts\.mjs publish-release-mirror/,
   "Deploy Pages must use the tested release compatibility mirror",
 );


### PR DESCRIPTION
# User description
> ## ✅ Free to merge
> Small and self-contained. **This PR exists because of the split review** — it was riding inside the template-injection change and is a different finding with a different revert.

A step that writes to `$GITHUB_ENV` can set **any** environment variable for every later step in the job, `NODE_OPTIONS` included — so a value derived from an API response reaching `$GITHUB_ENV` is a wider primitive than the job needs. A step output cannot do that: it is readable only where explicitly referenced.

The producer step gains `id: suite_url` and writes `url=` to `$GITHUB_OUTPUT`; the single consumer — the Build step's `VITE_CLAWSEC_SUITE_URL` — reads `steps.suite_url.outputs.url`.

**Equivalent in both branches of the conditional.** The write stays inside the same `if [ -n "$LATEST_TAG" ]`, producer and consumer are in the same job, and there is exactly one consumer in the repository — so when no `clawsec-suite` tag exists the variable resolves empty exactly as before.

Also records **why `deploy-pages` keeps its `workflow_run` trigger**, as a scoped `zizmor` ignore rather than a blanket suppression: no PR head is checked out, no artifact from the triggering run is consumed, and every job additionally guards on `workflow_run.event != 'pull_request'`. Switching to `pull_request` would break the release→deploy chain.

Split out of PR 5 because that one moves expansions out of `run:` bodies, whereas the consumer here was already inside an `env:` mapping.

---

## Where this sits in the series

This is one of **10 stacked PRs** splitting #359 into single-concern changes, so any one of them can be reverted on its own. Merge in numeric order — each targets its predecessor, and GitHub retargets the next automatically as each lands.

| # | PR | Merge guidance |
|---|---|---|
| 1 | dependabot cooldown | ✅ **Free to merge** |
| 2 | refresh action pins | ✅ **Free to merge** |
| 3 | node 20 → 24 | ✅ **Free to merge** |
| 4 | python 3.10 → 3.12 | ✅ **Free to merge** |
| 5 | template-injection hardening | ⚡ **Ship promptly** — closes a live exec path on `main` |
| 5b | `$GITHUB_ENV` → step output | ✅ **Free to merge** |
| 6 | `./` → `$/` action refs | ⚖️ **Decide knowingly** — Scorecard badge will move |
| 7 | `gh release` migration | 🧪 **Tag-test first** — never executed by CI |
| 8 | narrow permissions | ⛔ **Merge last, watched** — carries a blocker fix CI can't exercise |
| 9 | `persist-credentials: false` | ⛔ **Merge last, watched** — carries a blocker fix CI can't exercise |

### Why the last three need care

A fully green PR here proves less than it looks. The workflows these change cannot be triggered by a pull request: `poll-nvd-cves` runs on schedule only, `deploy-pages`' build job only on push-to-main or `workflow_run`, and `release-tag` / `publish-clawhub` / `republish-clawhub` are **skipped** without a tag push. #359 was green on all 22 checks while carrying two workflow-breaking bugs in exactly those blind spots.

### Two bugs found in #359 and fixed here

- **The daily NVD poller would have broken.** `persist-credentials: false` was added to the checkout while `git push --force origin` still relied on those credentials. `git fetch` still succeeds on a public repo, so it fails late, at the push, with `could not read Username`. Fixed in PR 9.
- **Pages deployment would have broken.** `pages`/`id-token` moved to the `deploy` job, but the `build` job runs `actions/configure-pages`, which calls the Pages API unconditionally and throws on failure. A job-level `permissions:` block replaces rather than merges, so `build` was left with no `pages` scope. Fixed in PR 8.

<sub>Full review, evidence and merge-order rationale: https://claude.ai/code/artifact/722db3dc-dfc5-40f6-974c-fba34b5dad9c</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Derive the suite release URL in the Pages deployment workflow as a scoped <code>suite_url</code> step output instead of a shared environment variable, then pass it to the build through <code>VITE_CLAWSEC_SUITE_URL</code>. Document the scoped <code>zizmor</code> exception for the <code>workflow_run</code> trigger and extend deployment checks to verify output production, fallback behavior, and consumption order.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/365?tool=ast&topic=Trigger+safety+rationale>Trigger safety rationale</a>
        </td><td>Document why the <code>workflow_run</code> trigger is safe for this deployment workflow through a narrowly scoped <code>zizmor</code> suppression.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/deploy-pages.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>1/10 ✅ chore(dependa...</td><td>September 07, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>ci(deploy-pages): deri...</td><td>September 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/365?tool=ast&topic=Scoped+suite+URL>Scoped suite URL</a>
        </td><td>Replace the shared <code>$GITHUB_ENV</code> write with a <code>suite_url</code> step output and consume it explicitly during the Pages build, preserving the empty fallback when no release tag exists.<details><summary>Modified files (2)</summary><ul><li>.github/workflows/deploy-pages.yml</li>
<li>scripts/test-deploy-pages-checksums.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>test(ci): cover Pages ...</td><td>September 07, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>1/10 ✅ chore(dependa...</td><td>September 07, 2026</td></tr></table></details></td></tr></table>
<a href="https://baz.co/changes/prompt-security/clawsec/365?tool=ast">Review this PR on Baz</a><br>
<a href="https://baz.co/agents/baz">Customize your next review</a>