### PR TITLE
7/10 ⚖️ ci(workflows): reference the in-repo signing action with self-repository syntax

### DIFF
--- a/.github/workflows/community-advisory.yml
+++ b/.github/workflows/community-advisory.yml
@@ -252,7 +252,7 @@ jobs:
 
       - name: Sign advisory feed and verify
         if: steps.parse.outputs.already_exists != 'true'
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -268,7 +268,7 @@ jobs:
           fi
 
       - name: Sign advisory feed and verify
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -278,7 +278,7 @@ jobs:
 
       - name: Sign provisional GHSA feed and verify
         if: hashFiles('public/advisories/ghsa-without-cve.json') != ''
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -289,7 +289,7 @@ jobs:
         run: node scripts/ci/advisory_pages_artifacts.mjs generate --public-dir public --repository "${{ github.repository }}"
 
       - name: Sign checksums and verify
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}

--- a/.github/workflows/pages-verify.yml
+++ b/.github/workflows/pages-verify.yml
@@ -51,7 +51,7 @@ jobs:
           rm -f "$KEY_FILE"
 
       - name: Sign advisory feed and verify
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ steps.test_key.outputs.private_key }}
           input_file: public/advisories/feed.json
@@ -60,7 +60,7 @@ jobs:
 
       - name: Sign provisional GHSA feed and verify
         if: hashFiles('public/advisories/ghsa-without-cve.json') != ''
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ steps.test_key.outputs.private_key }}
           input_file: public/advisories/ghsa-without-cve.json
@@ -70,7 +70,7 @@ jobs:
         run: node scripts/ci/advisory_pages_artifacts.mjs generate --public-dir public --repository "${{ github.repository }}"
 
       - name: Sign checksums and verify
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ steps.test_key.outputs.private_key }}
           input_file: public/checksums.json

--- a/.github/workflows/poll-ghsa-without-cve.yml
+++ b/.github/workflows/poll-ghsa-without-cve.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Sign GHSA feed and verify
         if: steps.changes.outputs.ghsa_changed == 'true'
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Sign consolidated agent feed and verify
         if: steps.changes.outputs.agent_changed == 'true'
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -989,7 +989,7 @@ jobs:
 
       - name: Sign GHSA feed and verify
         if: steps.feed_changes.outputs.ghsa_changed == 'true'
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -998,7 +998,7 @@ jobs:
 
       - name: Sign advisory feed and verify
         if: steps.feed_changes.outputs.agent_changed == 'true'
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -1226,7 +1226,7 @@ jobs:
 
       - name: Sign embedded advisory feed and verify
         if: hashFiles(format('skills/{0}/advisories/feed.json', steps.parse.outputs.skill_name)) != ''
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -1291,7 +1291,7 @@ jobs:
 
       - name: Sign embedded advisory checksums and verify
         if: hashFiles(format('skills/{0}/advisories/feed.json', steps.parse.outputs.skill_name)) != ''
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -1541,7 +1541,7 @@ jobs:
           STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Sign checksums and verify
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}


### PR DESCRIPTION
# User description
> ## ⚖️ Correct, but merge is a judgement call — read the Scorecard note
> Nothing breaks. But your **Scorecard Pinned-Dependencies score is expected to drop** until upstream tooling catches up. Isolated as its own PR precisely so you can hold it back without touching anything else.

Replaces `./.github/actions/sign-and-verify` with `$/.github/actions/sign-and-verify` at all **14** call sites.

`$/` resolves to this repository **at the exact commit the workflow is running**, with no checkout required, where `./` resolves against whatever happens to be in the workspace. For an action that signs the advisory feed, pinning it to the same commit as the calling workflow is the property worth having.

Checked at every site that the two resolve identically today, so this is a **durability change, not a behaviour change**: `deploy-pages` (push / `workflow_run` / dispatch) and `skill-release`'s tag-gated release job both resolve `github.sha` to the same commit their checkout gets, and `pages-verify` is `pull_request`-only, where the merge ref is both the workflow ref and the checkout.

### Two things to know before approving

**1. Your local tooling will call this invalid. It is not.** `$/` is a GitHub feature released **2026-07-30** ([changelog](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/)). `actionlint` 1.7.12 rejects it because its error path only enumerates the pre-release grammar. The syntax is confirmed working: the three `$/` signing steps in `pages-verify.yml` ran to **success** on CI for #359. Two independent reviewers of this series initially flagged it as a fabricated `sed` artifact — worth knowing so it does not get re-flagged.

**2. The consequential one.** `ossf/scorecard` vendors its own actionlint. Until that catches up, Scorecard is expected to reclassify these 14 sites as **unpinned third-party action references** and lower the Pinned-Dependencies score. `scorecard.yml` keeps running; the badge and any alerting on it will move. Merging means accepting that noise knowingly — holding this one PR back until tooling lands is an equally reasonable call.

Constraints, both satisfied: requires runner ≥ 2.336.0, and github.com only. Every job here runs on a GitHub-hosted runner.

---

## Where this sits in the series

This is one of **10 stacked PRs** splitting #359 into single-concern changes, so any one of them can be reverted on its own. Merge in numeric order — each targets its predecessor, and GitHub retargets the next automatically as each lands.

| # | PR | Merge guidance |
|---|---|---|
| 1 | dependabot cooldown | ✅ **Free to merge** |
| 2 | refresh action pins | ✅ **Free to merge** |
| 3 | node 20 → 24 | ✅ **Free to merge** |
| 4 | python 3.10 → 3.12 | ✅ **Free to merge** |
| 5 | template-injection hardening | ⚡ **Ship promptly** — closes a live exec path on `main` |
| 5b | `$GITHUB_ENV` → step output | ✅ **Free to merge** |
| 6 | `./` → `$/` action refs | ⚖️ **Decide knowingly** — Scorecard badge will move |
| 7 | `gh release` migration | 🧪 **Tag-test first** — never executed by CI |
| 8 | narrow permissions | ⛔ **Merge last, watched** — carries a blocker fix CI can't exercise |
| 9 | `persist-credentials: false` | ⛔ **Merge last, watched** — carries a blocker fix CI can't exercise |

### Why the last three need care

A fully green PR here proves less than it looks. The workflows these change cannot be triggered by a pull request: `poll-nvd-cves` runs on schedule only, `deploy-pages`' build job only on push-to-main or `workflow_run`, and `release-tag` / `publish-clawhub` / `republish-clawhub` are **skipped** without a tag push. #359 was green on all 22 checks while carrying two workflow-breaking bugs in exactly those blind spots.

### Two bugs found in #359 and fixed here

- **The daily NVD poller would have broken.** `persist-credentials: false` was added to the checkout while `git push --force origin` still relied on those credentials. `git fetch` still succeeds on a public repo, so it fails late, at the push, with `could not read Username`. Fixed in PR 9.
- **Pages deployment would have broken.** `pages`/`id-token` moved to the `deploy` job, but the `build` job runs `actions/configure-pages`, which calls the Pages API unconditionally and throws on failure. A job-level `permissions:` block replaces rather than merges, so `build` was left with no `pages` scope. Fixed in PR 8.

<sub>Full review, evidence and merge-order rationale: https://claude.ai/code/artifact/722db3dc-dfc5-40f6-974c-fba34b5dad9c</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Replace local <code>sign-and-verify</code> action references across advisory, pages, polling, and release workflows with GitHub’s same-repository <code>$/.github/actions/sign-and-verify</code> syntax. Pin the signing action to the workflow’s exact repository commit without changing signing behavior, while potentially affecting Scorecard’s pinned-dependency reporting.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/366?tool=ast&topic=Pinned+signing+action>Pinned signing action</a>
        </td><td>Update all advisory signing and verification workflow call sites to resolve the in-repository action at the calling workflow’s commit, preserving existing signing inputs and conditions.<details><summary>Modified files (6)</summary><ul><li>.github/workflows/community-advisory.yml</li>
<li>.github/workflows/deploy-pages.yml</li>
<li>.github/workflows/pages-verify.yml</li>
<li>.github/workflows/poll-ghsa-without-cve.yml</li>
<li>.github/workflows/poll-nvd-cves.yml</li>
<li>.github/workflows/skill-release.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>6/10 ✅ ci(deploy-pag...</td><td>September 07, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>ci(workflows): referen...</td><td>September 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/366?tool=ast&topic=Tooling+compatibility>Tooling compatibility</a>
        </td><td>Adopt the newer <code>$</code> repository syntax, which may be rejected by older local tooling and temporarily lower Scorecard pinned-dependency results despite equivalent runtime behavior.<details><summary>Modified files (6)</summary><ul><li>.github/workflows/community-advisory.yml</li>
<li>.github/workflows/deploy-pages.yml</li>
<li>.github/workflows/pages-verify.yml</li>
<li>.github/workflows/poll-ghsa-without-cve.yml</li>
<li>.github/workflows/poll-nvd-cves.yml</li>
<li>.github/workflows/skill-release.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>6/10 ✅ ci(deploy-pag...</td><td>September 07, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>ci(workflows): referen...</td><td>September 07, 2026</td></tr></table></details></td></tr></table>
<a href="https://baz.co/changes/prompt-security/clawsec/366?tool=ast">Review this PR on Baz</a><br>
<a href="https://baz.co/agents/baz">Customize your next review</a>