### PR TITLE
8/10 🧪 ci(release): publish releases with gh instead of a third-party action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,21 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/.github"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/.github/workflows/archive-traffic.yml
+++ b/.github/workflows/archive-traffic.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/archive-traffic.yml
+++ b/.github/workflows/archive-traffic.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Prepare archive branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
       - name: Ruff (lint + format check)
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Trivy FS Scan
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.34.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -77,7 +77,7 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
       - name: Trivy Config Scan
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.34.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'config'
           scan-ref: '.'
@@ -106,7 +106,7 @@ jobs:
       # read as legacy GitHub PATs -- but a range scan sees only the diff, so an
       # ordinary PR reports 0.
       - name: TruffleHog
-        uses: trufflesecurity/trufflehog@20652fbbdefffcdaa493a5bf57ab2ac6b1db715b # v3.97.1
+        uses: trufflesecurity/trufflehog@cc1fe982afc515d2991365ce8d4d0dd07170fcad # v3.97.2
         with:
           extra_args: --results=verified,unknown,unverified
       # Private keys and other deterministic patterns. TruffleHog only emits a
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -222,7 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
       - name: Hermes Skill Tests
@@ -238,7 +238,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: ESLint
@@ -147,7 +147,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: npm audit
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: GHSA Without CVE Feed Tests
@@ -199,7 +199,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Feed Verification Tests
@@ -224,7 +224,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Hermes Skill Tests
         shell: bash
         run: |
@@ -240,7 +240,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Suppression Config Tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/community-advisory.yml
+++ b/.github/workflows/community-advisory.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: Set up Python for exploitability analysis
         if: steps.parse.outputs.already_exists != 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.10'
 

--- a/.github/workflows/community-advisory.yml
+++ b/.github/workflows/community-advisory.yml
@@ -199,7 +199,7 @@ jobs:
         if: steps.parse.outputs.already_exists != 'true'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Analyze exploitability for community advisory
         if: steps.parse.outputs.already_exists != 'true'

--- a/.github/workflows/community-advisory.yml
+++ b/.github/workflows/community-advisory.yml
@@ -313,12 +313,16 @@ jobs:
       - name: Comment on issue
         if: steps.parse.outputs.already_exists != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ADVISORY_ID: ${{ steps.parse.outputs.advisory_id }}
+          PULL_REQUEST_URL: ${{ steps.create-pr.outputs.pull-request-url }}
+          PULL_REQUEST_OPERATION: ${{ steps.create-pr.outputs.pull-request-operation }}
         with:
           github-token: ${{ secrets.POLL_NVD_CVES_PAT }}
           script: |
-            const advisoryId = '${{ steps.parse.outputs.advisory_id }}';
-            const pullRequestUrl = '${{ steps.create-pr.outputs.pull-request-url }}';
-            const operation = '${{ steps.create-pr.outputs.pull-request-operation }}';
+            const advisoryId = process.env.ADVISORY_ID;
+            const pullRequestUrl = process.env.PULL_REQUEST_URL;
+            const operation = process.env.PULL_REQUEST_OPERATION;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -339,10 +343,12 @@ jobs:
       - name: Comment if already exists
         if: steps.parse.outputs.already_exists == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ADVISORY_ID: ${{ steps.parse.outputs.advisory_id }}
         with:
           github-token: ${{ secrets.POLL_NVD_CVES_PAT }}
           script: |
-            const advisoryId = '${{ steps.parse.outputs.advisory_id }}';
+            const advisoryId = process.env.ADVISORY_ID;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/community-advisory.yml
+++ b/.github/workflows/community-advisory.yml
@@ -252,7 +252,7 @@ jobs:
 
       - name: Sign advisory feed and verify
         if: steps.parse.outputs.already_exists != 'true'
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -268,7 +268,7 @@ jobs:
           fi
 
       - name: Sign advisory feed and verify
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -278,7 +278,7 @@ jobs:
 
       - name: Sign provisional GHSA feed and verify
         if: hashFiles('public/advisories/ghsa-without-cve.json') != ''
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -289,7 +289,7 @@ jobs:
         run: node scripts/ci/advisory_pages_artifacts.mjs generate --public-dir public --repository "${{ github.repository }}"
 
       - name: Sign checksums and verify
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -411,7 +411,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1
 
   verify-production:
     name: Verify Production Advisory Endpoints
@@ -422,7 +422,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,6 +3,9 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  # zizmor: ignore[dangerous-triggers] no PR head is checked out and no artifact
+  # from the triggering run is consumed; every job additionally guards on
+  # workflow_run.event != 'pull_request'.
   workflow_run:
     workflows: ["Skill Release"]
     types: [completed]
@@ -315,6 +318,7 @@ jobs:
           ls -la public/checksums.json public/checksums.sig public/signing-public.pem
 
       - name: Get latest clawsec-suite release URL
+        id: suite_url
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -326,10 +330,10 @@ jobs:
               "/repos/${REPO}/releases?per_page=100" \
               | jq -r -s 'add // [] | [.[] | select(.tag_name | startswith("clawsec-suite-v"))] | first | .tag_name // empty'
           )
-          
+
           if [ -n "$LATEST_TAG" ]; then
             echo "Found latest clawsec-suite tag: $LATEST_TAG"
-            echo "VITE_CLAWSEC_SUITE_URL=https://clawsec.prompt.security/releases/download/${LATEST_TAG}/SKILL.md" >> $GITHUB_ENV
+            echo "url=https://clawsec.prompt.security/releases/download/${LATEST_TAG}/SKILL.md" >> "$GITHUB_OUTPUT"
 
             # Create a local "latest" mirror path for clients that use GitHub-style URLs.
             # This enables swapping the host:
@@ -362,7 +366,7 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: production
-          VITE_CLAWSEC_SUITE_URL: ${{ env.VITE_CLAWSEC_SUITE_URL }}
+          VITE_CLAWSEC_SUITE_URL: ${{ steps.suite_url.outputs.url }}
 
       - name: Verify built public artifacts
         run: |

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Verify signing key consistency (repo + docs)
@@ -424,7 +424,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Verify deployed advisory endpoints
         run: |

--- a/.github/workflows/i18n-qa.yml
+++ b/.github/workflows/i18n-qa.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
       - name: Run i18n QA

--- a/.github/workflows/i18n-qa.yml
+++ b/.github/workflows/i18n-qa.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Check markdown links (README/wiki)
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            python scripts/i18n/link_check.py --changed-only --base-ref "origin/${{ github.base_ref }}"
+            python scripts/i18n/link_check.py --changed-only --base-ref "origin/${GITHUB_BASE_REF}"
           else
             python scripts/i18n/link_check.py
           fi

--- a/.github/workflows/pages-verify.yml
+++ b/.github/workflows/pages-verify.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/pages-verify.yml
+++ b/.github/workflows/pages-verify.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Verify signing key consistency (repo + docs)

--- a/.github/workflows/pages-verify.yml
+++ b/.github/workflows/pages-verify.yml
@@ -51,7 +51,7 @@ jobs:
           rm -f "$KEY_FILE"
 
       - name: Sign advisory feed and verify
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ steps.test_key.outputs.private_key }}
           input_file: public/advisories/feed.json
@@ -60,7 +60,7 @@ jobs:
 
       - name: Sign provisional GHSA feed and verify
         if: hashFiles('public/advisories/ghsa-without-cve.json') != ''
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ steps.test_key.outputs.private_key }}
           input_file: public/advisories/ghsa-without-cve.json
@@ -70,7 +70,7 @@ jobs:
         run: node scripts/ci/advisory_pages_artifacts.mjs generate --public-dir public --repository "${{ github.repository }}"
 
       - name: Sign checksums and verify
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ steps.test_key.outputs.private_key }}
           input_file: public/checksums.json

--- a/.github/workflows/poll-ghsa-without-cve.yml
+++ b/.github/workflows/poll-ghsa-without-cve.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/poll-ghsa-without-cve.yml
+++ b/.github/workflows/poll-ghsa-without-cve.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Sign GHSA feed and verify
         if: steps.changes.outputs.ghsa_changed == 'true'
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Sign consolidated agent feed and verify
         if: steps.changes.outputs.agent_changed == 'true'
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}

--- a/.github/workflows/poll-ghsa-without-cve.yml
+++ b/.github/workflows/poll-ghsa-without-cve.yml
@@ -152,16 +152,21 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Feed changed | ${{ steps.changes.outputs.changed }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Agent feed changed | ${{ steps.changes.outputs.agent_changed }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| GHSA source feed changed | ${{ steps.changes.outputs.ghsa_changed }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Feed changed | ${STEPS_CHANGES_OUTPUTS_CHANGED} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Agent feed changed | ${STEPS_CHANGES_OUTPUTS_AGENT_CHANGED} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| GHSA source feed changed | ${STEPS_CHANGES_OUTPUTS_GHSA_CHANGED} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Feed path | $GHSA_FEED_PATH |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Agent feed path | $FEED_PATH |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Total advisories | $(jq '.advisories | length' "$GHSA_FEED_PATH") |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Active | $(jq '[.advisories[] | select(.status == "active")] | length' "$GHSA_FEED_PATH") |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Matured | $(jq '[.advisories[] | select(.status == "matured")] | length' "$GHSA_FEED_PATH") |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Stale | $(jq '[.advisories[] | select(.status == "stale")] | length' "$GHSA_FEED_PATH") |" >> "$GITHUB_STEP_SUMMARY"
-          if [ -n "${{ steps.create-pr.outputs.pull-request-url }}" ]; then
+          if [ -n "${STEPS_CREATE_PR_OUTPUTS_PULL_REQUEST_URL}" ]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "Upserted PR: ${{ steps.create-pr.outputs.pull-request-url }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "Upserted PR: ${STEPS_CREATE_PR_OUTPUTS_PULL_REQUEST_URL}" >> "$GITHUB_STEP_SUMMARY"
           fi
+        env:
+          STEPS_CHANGES_OUTPUTS_CHANGED: ${{ steps.changes.outputs.changed }}
+          STEPS_CHANGES_OUTPUTS_AGENT_CHANGED: ${{ steps.changes.outputs.agent_changed }}
+          STEPS_CHANGES_OUTPUTS_GHSA_CHANGED: ${{ steps.changes.outputs.ghsa_changed }}
+          STEPS_CREATE_PR_OUTPUTS_PULL_REQUEST_URL: ${{ steps.create-pr.outputs.pull-request-url }}

--- a/.github/workflows/poll-ghsa-without-cve.yml
+++ b/.github/workflows/poll-ghsa-without-cve.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Run GHSA feed tests

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -761,7 +761,7 @@ jobs:
 
       - name: Set up Python for exploitability analysis
         if: steps.transform.outputs.new_count != '0'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.10'
 

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -63,8 +63,10 @@ jobs:
 
       - name: Set date window
         id: dates
+        env:
+          STEPS_LAST_POLL_OUTPUTS_LAST_DATE: ${{ steps.last_poll.outputs.last_date }}
         run: |
-          START_DATE="${{ steps.last_poll.outputs.last_date }}"
+          START_DATE="${STEPS_LAST_POLL_OUTPUTS_LAST_DATE}"
           END_DATE=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
           
           # Convert to epoch for comparison
@@ -85,6 +87,9 @@ jobs:
 
       - name: Fetch CVEs from NVD
         id: fetch
+        env:
+          STEPS_DATES_OUTPUTS_START_DATE: ${{ steps.dates.outputs.start_date }}
+          STEPS_DATES_OUTPUTS_END_DATE: ${{ steps.dates.outputs.end_date }}
         run: |
           set -euo pipefail
           source scripts/feed-utils.sh
@@ -92,8 +97,8 @@ jobs:
           FORCE_FULL_SCAN="${{ inputs.force_full_scan }}"
           NVD_QUERY_SPECS="$(nvd_query_specs)"
           
-          START_DATE="${{ steps.dates.outputs.start_date }}"
-          END_DATE="${{ steps.dates.outputs.end_date }}"
+          START_DATE="${STEPS_DATES_OUTPUTS_START_DATE}"
+          END_DATE="${STEPS_DATES_OUTPUTS_END_DATE}"
           
           # URL encode the dates
           START_ENC=$(echo "$START_DATE" | sed 's/:/%3A/g')
@@ -540,6 +545,8 @@ jobs:
 
       - name: Transform CVEs to advisories
         id: transform
+        env:
+          STEPS_PROCESS_OUTPUTS_FILTERED_COUNT: ${{ steps.process.outputs.filtered_count }}
         run: |
           # Read existing IDs into jq-friendly files (avoids huge CLI args on full scans).
           jq -R -s 'split("\n") | map(select(length > 0))' < tmp/existing_ids.txt > tmp/existing_ids_from_feed.json
@@ -747,7 +754,7 @@ jobs:
           echo "nvd_new_to_feed_count=$NET_NEW_COUNT" >> $GITHUB_OUTPUT
 
           if [ "${{ inputs.force_full_scan }}" = "true" ]; then
-            FILTERED_COUNT="${{ steps.process.outputs.filtered_count }}"
+            FILTERED_COUNT="${STEPS_PROCESS_OUTPUTS_FILTERED_COUNT}"
             if [ "$NEW_COUNT" -ne "$FILTERED_COUNT" ]; then
               echo "::error::Full scan transform mismatch: filtered CVEs=$FILTERED_COUNT transformed advisories=$NEW_COUNT"
               exit 1
@@ -916,6 +923,10 @@ jobs:
 
       - name: Detect advisory feed changes
         id: feed_changes
+        env:
+          STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT: ${{ steps.transform.outputs.nvd_rebuilt_count }}
+          STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT: ${{ steps.transform.outputs.nvd_new_to_feed_count }}
+          STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT: ${{ steps.nvd_counts.outputs.nvd_updated_count }}
         run: |
           set -euo pipefail
 
@@ -935,7 +946,7 @@ jobs:
             ' "$FEED_PATH"
           )"
 
-          if [ "${{ steps.transform.outputs.nvd_rebuilt_count }}" != "0" ] || [ "${{ steps.transform.outputs.nvd_new_to_feed_count }}" != "0" ] || [ "${{ steps.nvd_counts.outputs.nvd_updated_count }}" != "0" ]; then
+          if [ "${STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT}" != "0" ] || [ "${STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT}" != "0" ] || [ "${STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT}" != "0" ]; then
             NVD_CHANGED=true
           fi
 
@@ -1017,14 +1028,25 @@ jobs:
         id: upsert-pr
         env:
           GH_TOKEN: ${{ github.token }}
+          STEPS_DATES_OUTPUTS_START_DATE: ${{ steps.dates.outputs.start_date }}
+          STEPS_DATES_OUTPUTS_END_DATE: ${{ steps.dates.outputs.end_date }}
+          STEPS_PROCESS_OUTPUTS_NVD_FILTERED_COUNT: ${{ steps.process.outputs.nvd_filtered_count }}
+          STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT: ${{ steps.transform.outputs.nvd_rebuilt_count }}
+          STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT: ${{ steps.transform.outputs.nvd_new_to_feed_count }}
+          STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT: ${{ steps.nvd_counts.outputs.nvd_updated_count }}
+          STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT: ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }}
+          STEPS_FEED_CHANGES_OUTPUTS_GHSA_CHANGED: ${{ steps.feed_changes.outputs.ghsa_changed }}
+          STEPS_FEED_CHANGES_OUTPUTS_AGENT_CHANGED: ${{ steps.feed_changes.outputs.agent_changed }}
         run: |
           set -euo pipefail
 
           BRANCH_PREFIX="automated/nvd-cve-update"
           PR_COMMENT="Superseded by newer automated NVD advisory update."
-          TITLE="chore: update NVD/GHSA advisories - ${{ steps.transform.outputs.nvd_new_to_feed_count }} NVD new, ${{ steps.nvd_counts.outputs.nvd_updated_count }} NVD updated, ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }} GHSA active added"
+          TITLE="chore: update NVD/GHSA advisories - ${STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT} NVD new, ${STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT} NVD updated, ${STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT} GHSA active added"
           COMMIT_SUBJECT="$TITLE"
-          COMMIT_BODY=$'Automated update from NVD CVE and GHSA advisory feeds.\nKeywords: ${{ env.KEYWORDS }}\nPoll window: ${{ steps.dates.outputs.start_date }} to ${{ steps.dates.outputs.end_date }}'
+          # printf, not $'...': ANSI-C quoting does not expand parameters.
+          COMMIT_BODY="$(printf 'Automated update from NVD CVE and GHSA advisory feeds.\nKeywords: %s\nPoll window: %s to %s' \
+            "$KEYWORDS" "$STEPS_DATES_OUTPUTS_START_DATE" "$STEPS_DATES_OUTPUTS_END_DATE")"
 
           GHSA_TOTAL="$(jq '.advisories | length' "$GHSA_FEED_PATH")"
           GHSA_ACTIVE="$(jq '[.advisories[] | select(.status == "active")] | length' "$GHSA_FEED_PATH")"
@@ -1043,16 +1065,16 @@ jobs:
           Automated update from NVD CVE and GHSA advisory feeds.
 
           - **Mode:** ${MODE}
-          - **Filtered NVD CVEs:** ${{ steps.process.outputs.nvd_filtered_count }}
-          - **Rebuilt NVD advisories:** ${{ steps.transform.outputs.nvd_rebuilt_count }}
-          - **Net-new NVD advisories:** ${{ steps.transform.outputs.nvd_new_to_feed_count }}
-          - **Updated NVD advisories:** ${{ steps.nvd_counts.outputs.nvd_updated_count }}
-          - **GHSA active advisories added to consolidated feed:** ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }}
-          - **GHSA source feed changed:** ${{ steps.feed_changes.outputs.ghsa_changed }}
-          - **Consolidated agent feed changed:** ${{ steps.feed_changes.outputs.agent_changed }}
+          - **Filtered NVD CVEs:** ${STEPS_PROCESS_OUTPUTS_NVD_FILTERED_COUNT}
+          - **Rebuilt NVD advisories:** ${STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT}
+          - **Net-new NVD advisories:** ${STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT}
+          - **Updated NVD advisories:** ${STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT}
+          - **GHSA active advisories added to consolidated feed:** ${STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT}
+          - **GHSA source feed changed:** ${STEPS_FEED_CHANGES_OUTPUTS_GHSA_CHANGED}
+          - **Consolidated agent feed changed:** ${STEPS_FEED_CHANGES_OUTPUTS_AGENT_CHANGED}
           - **GHSA provisional advisories:** ${GHSA_TOTAL} total (${GHSA_ACTIVE} active, ${GHSA_MATURED} matured, ${GHSA_STALE} stale)
-          - **Poll window:** ${{ steps.dates.outputs.start_date }} → ${{ steps.dates.outputs.end_date }}
-          - **Keywords:** ${{ env.KEYWORDS }}
+          - **Poll window:** ${STEPS_DATES_OUTPUTS_START_DATE} → ${STEPS_DATES_OUTPUTS_END_DATE}
+          - **Keywords:** ${KEYWORDS}
 
           ---
           *This PR was automatically generated by the NVD CVE polling workflow with GHSA consolidation.*
@@ -1130,10 +1152,11 @@ jobs:
         if: steps.upsert-pr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          STEPS_UPSERT_PR_OUTPUTS_PULL_REQUEST_BRANCH: ${{ steps.upsert-pr.outputs.pull-request-branch }}
         run: |
           set -euo pipefail
 
-          BRANCH="${{ steps.upsert-pr.outputs.pull-request-branch }}"
+          BRANCH="${STEPS_UPSERT_PR_OUTPUTS_PULL_REQUEST_BRANCH}"
           if [ -z "$BRANCH" ]; then
             echo "::error::Missing pull-request-branch output from upsert-pr step"
             exit 1
@@ -1179,6 +1202,18 @@ jobs:
           gh run watch "$RUN_ID" --exit-status
 
       - name: Summary
+        env:
+          STEPS_DATES_OUTPUTS_START_DATE: ${{ steps.dates.outputs.start_date }}
+          STEPS_DATES_OUTPUTS_END_DATE: ${{ steps.dates.outputs.end_date }}
+          STEPS_PROCESS_OUTPUTS_NVD_FILTERED_COUNT: ${{ steps.process.outputs.nvd_filtered_count }}
+          STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT: ${{ steps.transform.outputs.nvd_rebuilt_count }}
+          STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT: ${{ steps.transform.outputs.nvd_new_to_feed_count }}
+          STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT: ${{ steps.nvd_counts.outputs.nvd_updated_count }}
+          STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT: ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }}
+          STEPS_FEED_CHANGES_OUTPUTS_GHSA_CHANGED: ${{ steps.feed_changes.outputs.ghsa_changed }}
+          STEPS_FEED_CHANGES_OUTPUTS_AGENT_CHANGED: ${{ steps.feed_changes.outputs.agent_changed }}
+          STEPS_FEED_CHANGES_OUTPUTS_CHANGED: ${{ steps.feed_changes.outputs.changed }}
+          STEPS_UPSERT_PR_OUTPUTS_PULL_REQUEST_URL: ${{ steps.upsert-pr.outputs.pull-request-url }}
         run: |
           if [ "${{ inputs.force_full_scan }}" = "true" ]; then
             MODE="full-rebuild (ignore feed state)"
@@ -1191,34 +1226,34 @@ jobs:
           echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Mode | $MODE |" >> $GITHUB_STEP_SUMMARY
-          echo "| Poll Window | ${{ steps.dates.outputs.start_date }} → ${{ steps.dates.outputs.end_date }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Poll Window | ${STEPS_DATES_OUTPUTS_START_DATE} → ${STEPS_DATES_OUTPUTS_END_DATE} |" >> $GITHUB_STEP_SUMMARY
           echo "| Keywords | $KEYWORDS |" >> $GITHUB_STEP_SUMMARY
-          echo "| NVD CVEs Found (filtered) | ${{ steps.process.outputs.nvd_filtered_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| NVD Advisories Rebuilt | ${{ steps.transform.outputs.nvd_rebuilt_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Net-new NVD Advisories | ${{ steps.transform.outputs.nvd_new_to_feed_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Updated NVD Advisories | ${{ steps.nvd_counts.outputs.nvd_updated_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| GHSA Active Added | ${{ steps.feed_changes.outputs.ghsa_added_to_consolidated_count }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| GHSA source feed changed | ${{ steps.feed_changes.outputs.ghsa_changed }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Consolidated agent feed changed | ${{ steps.feed_changes.outputs.agent_changed }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| NVD CVEs Found (filtered) | ${STEPS_PROCESS_OUTPUTS_NVD_FILTERED_COUNT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| NVD Advisories Rebuilt | ${STEPS_TRANSFORM_OUTPUTS_NVD_REBUILT_COUNT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Net-new NVD Advisories | ${STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Updated NVD Advisories | ${STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| GHSA Active Added | ${STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| GHSA source feed changed | ${STEPS_FEED_CHANGES_OUTPUTS_GHSA_CHANGED} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Consolidated agent feed changed | ${STEPS_FEED_CHANGES_OUTPUTS_AGENT_CHANGED} |" >> $GITHUB_STEP_SUMMARY
           echo "| GHSA provisional advisories | $(jq '.advisories | length' "$GHSA_FEED_PATH") |" >> $GITHUB_STEP_SUMMARY
 
-          if [ "${{ steps.transform.outputs.nvd_new_to_feed_count }}" != "0" ]; then
+          if [ "${STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT}" != "0" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Net-new NVD Advisories" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             jq -r '.[] | "- **\(.id)** (\(.severity)): \(.title)"' tmp/net_new_advisories.json >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ "${{ steps.nvd_counts.outputs.nvd_updated_count }}" != "0" ]; then
+          if [ "${STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT}" != "0" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Updated NVD Advisories" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             jq -r '.[] | "- **\(.id)**: \(.changes | join(", "))"' tmp/updated_advisories.json >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ "${{ steps.feed_changes.outputs.changed }}" = "true" ]; then
+          if [ "${STEPS_FEED_CHANGES_OUTPUTS_CHANGED}" = "true" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "🔀 Upserted PR: ${{ steps.upsert-pr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
+            echo "🔀 Upserted PR: ${STEPS_UPSERT_PR_OUTPUTS_PULL_REQUEST_URL}" >> $GITHUB_STEP_SUMMARY
           else
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "✅ No new or updated NVD CVEs or GHSA changes found." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -990,7 +990,7 @@ jobs:
 
       - name: Sign GHSA feed and verify
         if: steps.feed_changes.outputs.ghsa_changed == 'true'
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -999,7 +999,7 @@ jobs:
 
       - name: Sign advisory feed and verify
         if: steps.feed_changes.outputs.agent_changed == 'true'
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -763,7 +763,7 @@ jobs:
         if: steps.transform.outputs.new_count != '0'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Analyze exploitability for new advisories
         if: steps.transform.outputs.new_count != '0'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -50,7 +50,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -84,6 +84,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
 
@@ -286,7 +286,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
 
@@ -1020,7 +1020,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
 
@@ -1195,7 +1195,7 @@ jobs:
           echo "clawhub_slug=${CLAWHUB_SLUG}" >> $GITHUB_OUTPUT
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
 
@@ -1788,7 +1788,7 @@ jobs:
 
       - name: Setup Node
         if: needs.release-tag.outputs.publish_clawhub == 'true'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
 
@@ -2024,7 +2024,7 @@ jobs:
           echo "Skill is publishable to ClawHub"
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
 

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Verify signing key consistency (repo + docs)
         run: ./scripts/ci/verify_signing_key_consistency.sh
@@ -288,7 +288,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install SkillSpector
         run: |
@@ -1022,7 +1022,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install SkillSpector
         run: |
@@ -1197,7 +1197,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Validate npx skills install docs
         run: node scripts/ci/validate_skill_install_docs.mjs --skills "${{ steps.parse.outputs.skill_path }}"
@@ -1790,7 +1790,7 @@ jobs:
         if: needs.release-tag.outputs.publish_clawhub == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Prepare verified ClawHub release package
         id: clawhub-package
@@ -2026,7 +2026,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Prepare verified ClawHub release package
         id: clawhub-package

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -1226,7 +1226,7 @@ jobs:
 
       - name: Sign embedded advisory feed and verify
         if: hashFiles(format('skills/{0}/advisories/feed.json', steps.parse.outputs.skill_name)) != ''
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -1291,7 +1291,7 @@ jobs:
 
       - name: Sign embedded advisory checksums and verify
         if: hashFiles(format('skills/{0}/advisories/feed.json', steps.parse.outputs.skill_name)) != ''
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}
@@ -1541,7 +1541,7 @@ jobs:
           STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Sign checksums and verify
-        uses: ./.github/actions/sign-and-verify
+        uses: $/.github/actions/sign-and-verify
         with:
           private_key: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY }}
           private_key_passphrase: ${{ secrets.CLAWSEC_SIGNING_PRIVATE_KEY_PASSPHRASE }}

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -46,6 +46,9 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          # This workflow signs and publishes releases; never restore a cache
+          # into that trust path. Explicit because the input defaults to true.
+          package-manager-cache: false
 
       - name: Verify signing key consistency (repo + docs)
         run: ./scripts/ci/verify_signing_key_consistency.sh
@@ -289,6 +292,9 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          # This workflow signs and publishes releases; never restore a cache
+          # into that trust path. Explicit because the input defaults to true.
+          package-manager-cache: false
 
       - name: Install SkillSpector
         run: |
@@ -1023,6 +1029,9 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          # This workflow signs and publishes releases; never restore a cache
+          # into that trust path. Explicit because the input defaults to true.
+          package-manager-cache: false
 
       - name: Install SkillSpector
         run: |
@@ -1208,6 +1217,9 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          # This workflow signs and publishes releases; never restore a cache
+          # into that trust path. Explicit because the input defaults to true.
+          package-manager-cache: false
 
       - name: Validate npx skills install docs
         run: node scripts/ci/validate_skill_install_docs.mjs --skills "${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
@@ -1746,16 +1758,37 @@ jobs:
           '
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          name: "${{ steps.parse.outputs.skill_name }} ${{ steps.parse.outputs.version }}"
-          tag_name: ${{ github.ref_name }}
-          files: release-assets/*
-          body_path: ${{ runner.temp }}/skill-release-body.md
-          draft: false
-          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          RELEASE_TITLE: ${{ steps.parse.outputs.skill_name }} ${{ steps.parse.outputs.version }}
+          PRERELEASE: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+        run: |
+          set -euo pipefail
+
+          BODY_FILE="${RUNNER_TEMP}/skill-release-body.md"
+          shopt -s nullglob
+          ASSETS=(release-assets/*)
+          if [ "${#ASSETS[@]}" -eq 0 ]; then
+            echo "::error::No release assets found in release-assets/"
+            exit 1
+          fi
+
+          # Re-pushing a tag re-runs this job, so upsert rather than create.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --title "$RELEASE_TITLE" \
+              --notes-file "$BODY_FILE" \
+              --draft=false \
+              --prerelease="$PRERELEASE"
+            gh release upload "$TAG" "${ASSETS[@]}" --clobber
+          else
+            gh release create "$TAG" \
+              --title "$RELEASE_TITLE" \
+              --notes-file "$BODY_FILE" \
+              --prerelease="$PRERELEASE" \
+              "${ASSETS[@]}"
+          fi
 
       - name: Delete superseded releases
         run: |
@@ -1823,6 +1856,9 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          # This workflow signs and publishes releases; never restore a cache
+          # into that trust path. Explicit because the input defaults to true.
+          package-manager-cache: false
 
       - name: Prepare verified ClawHub release package
         id: clawhub-package
@@ -2082,6 +2118,9 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          # This workflow signs and publishes releases; never restore a cache
+          # into that trust path. Explicit because the input defaults to true.
+          package-manager-cache: false
 
       - name: Prepare verified ClawHub release package
         id: clawhub-package

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -1093,7 +1093,7 @@ jobs:
       - name: Parse tag
         id: parse
         run: |
-          TAG="${{ github.ref_name }}"
+          TAG="${GITHUB_REF_NAME}"
           # Extract skill name (everything before -v)
           SKILL_NAME="${TAG%-v*}"
           # Extract version (everything after -v)
@@ -1113,7 +1113,7 @@ jobs:
 
       - name: Validate skill exists
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
           if [ ! -d "$SKILL_PATH" ]; then
             echo "Error: Skill directory not found: $SKILL_PATH"
             exit 1
@@ -1123,11 +1123,13 @@ jobs:
             exit 1
           fi
           echo "Skill validated: $SKILL_PATH"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Validate version match
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
-          TAG_VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+          TAG_VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
 
           # Extract version from skill.json
           JSON_VERSION=$(jq -r '.version' "$SKILL_PATH/skill.json")
@@ -1139,11 +1141,14 @@ jobs:
           fi
 
           echo "Version validated: $TAG_VERSION"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Validate SKILL.md frontmatter version
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
-          TAG_VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+          TAG_VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
 
           # Check if SKILL.md exists
           if [ -f "$SKILL_PATH/SKILL.md" ]; then
@@ -1163,11 +1168,14 @@ jobs:
             echo "::error::Missing required SKILL.md: $SKILL_PATH/SKILL.md"
             exit 1
           fi
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Detect publishability and install defaults
         id: publishable
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
           INTERNAL=$(jq -r 'if (.openclaw | type) == "object" then (.openclaw.internal // false) else false end' "$SKILL_PATH/skill.json")
 
           OPENCLAW_SKILL=false
@@ -1193,6 +1201,8 @@ jobs:
           echo "publish_clawhub=${PUBLISH_CLAWHUB}" >> $GITHUB_OUTPUT
           echo "publishable=${PUBLISHABLE}" >> $GITHUB_OUTPUT
           echo "clawhub_slug=${CLAWHUB_SLUG}" >> $GITHUB_OUTPUT
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -1200,7 +1210,9 @@ jobs:
           node-version: 24
 
       - name: Validate npx skills install docs
-        run: node scripts/ci/validate_skill_install_docs.mjs --skills "${{ steps.parse.outputs.skill_path }}"
+        run: node scripts/ci/validate_skill_install_docs.mjs --skills "${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Install SkillSpector
         run: |
@@ -1226,7 +1238,7 @@ jobs:
         if: hashFiles(format('skills/{0}/advisories/feed.json', steps.parse.outputs.skill_name)) != ''
         run: |
           set -euo pipefail
-          ADVISORY_DIR="${{ steps.parse.outputs.skill_path }}/advisories"
+          ADVISORY_DIR="${STEPS_PARSE_OUTPUTS_SKILL_PATH}/advisories"
           FEED_SHA=$(sha256sum "$ADVISORY_DIR/feed.json" | awk '{print $1}')
           FEED_SIZE=$(stat -c%s "$ADVISORY_DIR/feed.json" 2>/dev/null || stat -f%z "$ADVISORY_DIR/feed.json")
           FEED_SIG_SHA=$(sha256sum "$ADVISORY_DIR/feed.json.sig" | awk '{print $1}')
@@ -1237,7 +1249,7 @@ jobs:
           jq -n \
             --arg schema_version "1" \
             --arg algorithm "sha256" \
-            --arg version "${{ steps.parse.outputs.version }}" \
+            --arg version "${STEPS_PARSE_OUTPUTS_VERSION}" \
             --arg generated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg repo "${{ github.repository }}" \
             --arg feed_sha "$FEED_SHA" \
@@ -1273,6 +1285,9 @@ jobs:
 
           echo "Generated $ADVISORY_DIR/checksums.json"
           jq . "$ADVISORY_DIR/checksums.json"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Sign embedded advisory checksums and verify
         if: hashFiles(format('skills/{0}/advisories/feed.json', steps.parse.outputs.skill_name)) != ''
@@ -1286,17 +1301,19 @@ jobs:
       - name: Show embedded advisory signing outputs
         if: hashFiles(format('skills/{0}/advisories/feed.json', steps.parse.outputs.skill_name)) != ''
         run: |
-          ADVISORY_DIR="${{ steps.parse.outputs.skill_path }}/advisories"
+          ADVISORY_DIR="${STEPS_PARSE_OUTPUTS_SKILL_PATH}/advisories"
           echo "Successfully signed embedded advisory artifacts:"
           ls -la "$ADVISORY_DIR"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Package release assets
         run: |
           set -euo pipefail
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
-          VERSION="${{ steps.parse.outputs.version }}"
-          TAG="${{ github.ref_name }}"
+          SKILL_NAME="${STEPS_PARSE_OUTPUTS_SKILL_NAME}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
+          TAG="${GITHUB_REF_NAME}"
 
           mkdir -p release-assets
 
@@ -1518,6 +1535,10 @@ jobs:
           echo ""
           echo "=== Release assets ==="
           ls -la release-assets/
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Sign checksums and verify
         uses: ./.github/actions/sign-and-verify
@@ -1549,8 +1570,8 @@ jobs:
         id: changelog
         run: |
           set -euo pipefail
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
-          VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
 
           if [ ! -f "$SKILL_PATH/CHANGELOG.md" ]; then
             echo "::error::Missing required changelog file: $SKILL_PATH/CHANGELOG.md"
@@ -1580,16 +1601,19 @@ jobs:
             echo "$CHANGELOG_ENTRY"
             echo "EOF"
           } >> $GITHUB_OUTPUT
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Build quick install instructions
         id: install
         run: |
           set -euo pipefail
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          CLAWHUB_SLUG="${{ steps.publishable.outputs.clawhub_slug }}"
-          VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_NAME="${STEPS_PARSE_OUTPUTS_SKILL_NAME}"
+          CLAWHUB_SLUG="${STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
           REPO="${{ github.repository }}"
-          TAG="${{ github.ref_name }}"
+          TAG="${GITHUB_REF_NAME}"
 
           {
             echo "quick_install<<INSTALL_EOF"
@@ -1614,7 +1638,7 @@ jobs:
 
           EOF
 
-            if [ "${{ steps.publishable.outputs.publish_clawhub }}" = "true" ] && [ "${{ steps.publishable.outputs.openclaw_skill }}" = "true" ]; then
+            if [ "${STEPS_PUBLISHABLE_OUTPUTS_PUBLISH_CLAWHUB}" = "true" ] && [ "${STEPS_PUBLISHABLE_OUTPUTS_OPENCLAW_SKILL}" = "true" ]; then
               cat <<EOF
           ### Quick Install
 
@@ -1666,6 +1690,12 @@ jobs:
 
             echo "INSTALL_EOF"
           } >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG: ${{ steps.publishable.outputs.clawhub_slug }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
+          STEPS_PUBLISHABLE_OUTPUTS_PUBLISH_CLAWHUB: ${{ steps.publishable.outputs.publish_clawhub }}
+          STEPS_PUBLISHABLE_OUTPUTS_OPENCLAW_SKILL: ${{ steps.publishable.outputs.openclaw_skill }}
 
       - name: Prepare GitHub release body
         env:
@@ -1729,8 +1759,8 @@ jobs:
 
       - name: Delete superseded releases
         run: |
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          CURRENT_VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_NAME="${STEPS_PARSE_OUTPUTS_SKILL_NAME}"
+          CURRENT_VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
 
           # Extract major version from current release
           CURRENT_MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
@@ -1763,6 +1793,8 @@ jobs:
           echo "Superseded release cleanup complete"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STEPS_PARSE_OUTPUTS_SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
   publish-clawhub:
     # Separate blocking job for ClawHub publishing - runs after GitHub release.
@@ -1797,11 +1829,13 @@ jobs:
         if: needs.release-tag.outputs.publish_clawhub == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME: ${{ needs.release-tag.outputs.skill_name }}
+          NEEDS_RELEASE_TAG_OUTPUTS_VERSION: ${{ needs.release-tag.outputs.version }}
         run: |
           set -euo pipefail
-          SKILL_NAME="${{ needs.release-tag.outputs.skill_name }}"
-          VERSION="${{ needs.release-tag.outputs.version }}"
-          TAG="${{ github.ref_name }}"
+          SKILL_NAME="${NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME}"
+          VERSION="${NEEDS_RELEASE_TAG_OUTPUTS_VERSION}"
+          TAG="${GITHUB_REF_NAME}"
           RELEASE_DIR="$RUNNER_TEMP/clawhub-release"
           OUTPUT_DIR="$RUNNER_TEMP/clawhub-package"
 
@@ -1866,7 +1900,9 @@ jobs:
           export CLAWHUB_SITE="$SITE"
           export CLAWHUB_REGISTRY="$REGISTRY"
           bash scripts/ci/guard_clawhub_slug_owner.sh \
-            "${{ needs.release-tag.outputs.clawhub_slug }}"
+            "${NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG}"
+        env:
+          NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG: ${{ needs.release-tag.outputs.clawhub_slug }}
 
       - name: Check existing ClawHub version
         id: clawhub-version
@@ -1875,9 +1911,9 @@ jobs:
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          SKILL_NAME="${{ needs.release-tag.outputs.skill_name }}"
-          CLAWHUB_SLUG="${{ needs.release-tag.outputs.clawhub_slug }}"
-          VERSION="${{ needs.release-tag.outputs.version }}"
+          SKILL_NAME="${NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME}"
+          CLAWHUB_SLUG="${NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${NEEDS_RELEASE_TAG_OUTPUTS_VERSION}"
           export CLAWHUB_CONFIG_PATH="$HOME/.clawhub-ci/config.json"
 
           set +e
@@ -1901,6 +1937,10 @@ jobs:
             cat /tmp/clawhub-existing-version.err
             exit 1
           fi
+        env:
+          NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME: ${{ needs.release-tag.outputs.skill_name }}
+          NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG: ${{ needs.release-tag.outputs.clawhub_slug }}
+          NEEDS_RELEASE_TAG_OUTPUTS_VERSION: ${{ needs.release-tag.outputs.version }}
 
       - name: Publish to ClawHub
         if: needs.release-tag.outputs.publish_clawhub == 'true' && steps.clawhub-version.outputs.already_exists != 'true'
@@ -1908,10 +1948,10 @@ jobs:
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
-          SKILL_NAME="${{ needs.release-tag.outputs.skill_name }}"
-          CLAWHUB_SLUG="${{ needs.release-tag.outputs.clawhub_slug }}"
-          VERSION="${{ needs.release-tag.outputs.version }}"
+          SKILL_PATH="${STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH}"
+          SKILL_NAME="${NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME}"
+          CLAWHUB_SLUG="${NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${NEEDS_RELEASE_TAG_OUTPUTS_VERSION}"
           NAME=$(jq -r '.name' "$SKILL_PATH/skill.json")
           CHANGELOG="Release ${VERSION} via CI"
 
@@ -1934,6 +1974,11 @@ jobs:
           fi
 
           echo "ClawHub publish request completed for $SKILL_NAME@$VERSION as $CLAWHUB_SLUG"
+        env:
+          STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH: ${{ steps.clawhub-package.outputs.skill_path }}
+          NEEDS_RELEASE_TAG_OUTPUTS_SKILL_NAME: ${{ needs.release-tag.outputs.skill_name }}
+          NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG: ${{ needs.release-tag.outputs.clawhub_slug }}
+          NEEDS_RELEASE_TAG_OUTPUTS_VERSION: ${{ needs.release-tag.outputs.version }}
 
       - name: Verify published ClawHub package
         if: needs.release-tag.outputs.publish_clawhub == 'true'
@@ -1941,9 +1986,9 @@ jobs:
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          CLAWHUB_SLUG="${{ needs.release-tag.outputs.clawhub_slug }}"
-          VERSION="${{ needs.release-tag.outputs.version }}"
-          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
+          CLAWHUB_SLUG="${NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${NEEDS_RELEASE_TAG_OUTPUTS_VERSION}"
+          SKILL_PATH="${STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH}"
           export CLAWHUB_CONFIG_PATH="$HOME/.clawhub-ci/config.json"
           export CLAWHUB_SITE="$SITE"
           export CLAWHUB_REGISTRY="$REGISTRY"
@@ -1953,6 +1998,10 @@ jobs:
             --slug "$CLAWHUB_SLUG" \
             --version "$VERSION"
           echo "✓ Verified published ClawHub package matches the signed release payload"
+        env:
+          NEEDS_RELEASE_TAG_OUTPUTS_CLAWHUB_SLUG: ${{ needs.release-tag.outputs.clawhub_slug }}
+          NEEDS_RELEASE_TAG_OUTPUTS_VERSION: ${{ needs.release-tag.outputs.version }}
+          STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH: ${{ steps.clawhub-package.outputs.skill_path }}
 
   republish-clawhub:
     # Manual workflow to republish a specific tag to ClawHub
@@ -1967,7 +2016,7 @@ jobs:
       - name: Parse tag
         id: parse
         run: |
-          TAG="${{ github.event.inputs.tag }}"
+          TAG="${GITHUB_EVENT_INPUTS_TAG}"
           # Extract skill name (everything before -v)
           SKILL_NAME="${TAG%-v*}"
           # Extract version (everything after -v)
@@ -1978,6 +2027,8 @@ jobs:
           echo "skill_path=skills/${SKILL_NAME}" >> $GITHUB_OUTPUT
 
           echo "Parsed tag: skill=${SKILL_NAME}, version=${VERSION}"
+        env:
+          GITHUB_EVENT_INPUTS_TAG: ${{ github.event.inputs.tag }}
 
       - name: Checkout workflow helpers
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1997,7 +2048,7 @@ jobs:
 
       - name: Validate skill exists
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
           if [ ! -d "$SKILL_PATH" ]; then
             echo "Error: Skill directory not found: $SKILL_PATH"
             exit 1
@@ -2007,11 +2058,13 @@ jobs:
             exit 1
           fi
           echo "Skill validated: $SKILL_PATH"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Check if publishable
         id: publishable
         run: |
-          SKILL_PATH="${{ steps.parse.outputs.skill_path }}"
+          SKILL_PATH="${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
           INTERNAL=$(jq -r 'if (.openclaw | type) == "object" then (.openclaw.internal // false) else false end' "$SKILL_PATH/skill.json")
 
           if [ "$INTERNAL" = "true" ]; then
@@ -2022,6 +2075,8 @@ jobs:
           CLAWHUB_SLUG=$(node "$RUNNER_TEMP/resolve_clawhub_slug.mjs" "$SKILL_PATH")
           echo "clawhub_slug=${CLAWHUB_SLUG}" >> $GITHUB_OUTPUT
           echo "Skill is publishable to ClawHub"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -2032,11 +2087,14 @@ jobs:
         id: clawhub-package
         env:
           GH_TOKEN: ${{ github.token }}
+          STEPS_PARSE_OUTPUTS_SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
+          GITHUB_EVENT_INPUTS_TAG: ${{ github.event.inputs.tag }}
         run: |
           set -euo pipefail
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          VERSION="${{ steps.parse.outputs.version }}"
-          TAG="${{ github.event.inputs.tag }}"
+          SKILL_NAME="${STEPS_PARSE_OUTPUTS_SKILL_NAME}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
+          TAG="${GITHUB_EVENT_INPUTS_TAG}"
           RELEASE_DIR="$RUNNER_TEMP/clawhub-release"
           OUTPUT_DIR="$RUNNER_TEMP/clawhub-package"
 
@@ -2073,7 +2131,9 @@ jobs:
           echo "skill_path=$OUTPUT_DIR/$SKILL_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Validate npx skills install docs
-        run: node scripts/ci/validate_skill_install_docs.mjs --skills "${{ steps.parse.outputs.skill_path }}"
+        run: node scripts/ci/validate_skill_install_docs.mjs --skills "${STEPS_PARSE_OUTPUTS_SKILL_PATH}"
+        env:
+          STEPS_PARSE_OUTPUTS_SKILL_PATH: ${{ steps.parse.outputs.skill_path }}
 
       - name: Install clawhub CLI
         run: bash scripts/ci/install_clawhub_cli.sh
@@ -2110,17 +2170,19 @@ jobs:
           export CLAWHUB_SITE="$SITE"
           export CLAWHUB_REGISTRY="$REGISTRY"
           bash scripts/ci/guard_clawhub_slug_owner.sh \
-            "${{ steps.publishable.outputs.clawhub_slug }}"
+            "${STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG}"
+        env:
+          STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG: ${{ steps.publishable.outputs.clawhub_slug }}
 
       - name: Publish to ClawHub
         run: |
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
-          SKILL_NAME="${{ steps.parse.outputs.skill_name }}"
-          CLAWHUB_SLUG="${{ steps.publishable.outputs.clawhub_slug }}"
-          VERSION="${{ steps.parse.outputs.version }}"
+          SKILL_PATH="${STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH}"
+          SKILL_NAME="${STEPS_PARSE_OUTPUTS_SKILL_NAME}"
+          CLAWHUB_SLUG="${STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
           NAME=$(jq -r '.name' "$SKILL_PATH/skill.json")
           CHANGELOG="Manual republish of ${VERSION} via workflow_dispatch"
 
@@ -2152,15 +2214,20 @@ jobs:
           fi
 
           echo "✓ Successfully published $SKILL_NAME@$VERSION to ClawHub"
+        env:
+          STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH: ${{ steps.clawhub-package.outputs.skill_path }}
+          STEPS_PARSE_OUTPUTS_SKILL_NAME: ${{ steps.parse.outputs.skill_name }}
+          STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG: ${{ steps.publishable.outputs.clawhub_slug }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
 
       - name: Verify published ClawHub package
         run: |
           set -euo pipefail
           SITE=${CLAWHUB_SITE:-https://clawhub.ai}
           REGISTRY=${CLAWHUB_REGISTRY:-$SITE}
-          CLAWHUB_SLUG="${{ steps.publishable.outputs.clawhub_slug }}"
-          VERSION="${{ steps.parse.outputs.version }}"
-          SKILL_PATH="${{ steps.clawhub-package.outputs.skill_path }}"
+          CLAWHUB_SLUG="${STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG}"
+          VERSION="${STEPS_PARSE_OUTPUTS_VERSION}"
+          SKILL_PATH="${STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH}"
           export CLAWHUB_CONFIG_PATH="$HOME/.clawhub-ci/config.json"
           export CLAWHUB_SITE="$SITE"
           export CLAWHUB_REGISTRY="$REGISTRY"
@@ -2170,3 +2237,7 @@ jobs:
             --slug "$CLAWHUB_SLUG" \
             --version "$VERSION"
           echo "✓ Verified published ClawHub package matches the signed release payload"
+        env:
+          STEPS_PUBLISHABLE_OUTPUTS_CLAWHUB_SLUG: ${{ steps.publishable.outputs.clawhub_slug }}
+          STEPS_PARSE_OUTPUTS_VERSION: ${{ steps.parse.outputs.version }}
+          STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH: ${{ steps.clawhub-package.outputs.skill_path }}

--- a/.github/workflows/wiki-export-verify.yml
+++ b/.github/workflows/wiki-export-verify.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 

--- a/.github/workflows/wiki-export-verify.yml
+++ b/.github/workflows/wiki-export-verify.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Test wiki export transform
         run: node scripts/test-wiki-sync-export.mjs

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Test wiki export transform
         run: node scripts/test-wiki-sync-export.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ source .venv/bin/activate
 uv pip install ruff bandit   # linters configured in pyproject.toml
 ```
 
-Required tools: Node 20+, Python 3.10+, openssl, jq, shellcheck, gitleaks,
+Required tools: Node 24+, Python 3.10+, openssl, jq, shellcheck, gitleaks,
 trufflehog (`brew install shellcheck gitleaks trufflehog`). The pre-commit hook
 exits 1 without gitleaks.
 

--- a/scripts/test-nvd-ghsa-consolidation-workflow.mjs
+++ b/scripts/test-nvd-ghsa-consolidation-workflow.mjs
@@ -96,12 +96,12 @@ assert.match(
 );
 assert.match(
   workflow,
-  /TITLE="chore: update NVD\/GHSA advisories - \$\{\{ steps\.transform\.outputs\.nvd_new_to_feed_count \}\} NVD new, \$\{\{ steps\.nvd_counts\.outputs\.nvd_updated_count \}\} NVD updated, \$\{\{ steps\.feed_changes\.outputs\.ghsa_added_to_consolidated_count \}\} GHSA active added"/,
+  /TITLE="chore: update NVD\/GHSA advisories - \$\{STEPS_TRANSFORM_OUTPUTS_NVD_NEW_TO_FEED_COUNT\} NVD new, \$\{STEPS_NVD_COUNTS_OUTPUTS_NVD_UPDATED_COUNT\} NVD updated, \$\{STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT\} GHSA active added"/,
   'Generated PR titles must include net-new NVD, updated NVD, and GHSA-only addition counts',
 );
 assert.match(
   workflow,
-  /\*\*GHSA active advisories added to consolidated feed:\*\* \$\{\{ steps\.feed_changes\.outputs\.ghsa_added_to_consolidated_count \}\}/,
+  /\*\*GHSA active advisories added to consolidated feed:\*\* \$\{STEPS_FEED_CHANGES_OUTPUTS_GHSA_ADDED_TO_CONSOLIDATED_COUNT\}/,
   'Generated PR bodies must include GHSA-only additions',
 );
 assert.doesNotMatch(

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -550,7 +550,7 @@ assert.doesNotMatch(
 );
 
 assert.equal(
-  workflow.match(/SKILL_PATH="\$\{\{ steps\.clawhub-package\.outputs\.skill_path \}\}"/g)?.length,
+  workflow.match(/SKILL_PATH="\$\{STEPS_CLAWHUB_PACKAGE_OUTPUTS_SKILL_PATH\}"/g)?.length,
   4,
   'ClawHub publish, republish, and their verification steps must use the verified release package path',
 );

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -231,8 +231,17 @@ assert.match(
 
 assert.match(
   workflow,
-  /body_path: \$\{\{ runner\.temp \}\}\/skill-release-body\.md/,
-  'GitHub release creation must use body_path for the generated release body file',
+  /BODY_FILE="\$\{RUNNER_TEMP\}\/skill-release-body\.md"/,
+  'GitHub release creation must derive the release body path from RUNNER_TEMP',
+);
+
+// Both the edit and create branches must use it. A single [\s\S]* match would
+// be satisfied by either one alone, leaving the create branch -- the path taken
+// for every brand-new release -- uncovered.
+assert.equal(
+  workflow.match(/--notes-file "\$BODY_FILE"/g)?.length,
+  2,
+  'both the release edit and create branches must take their body from the generated file',
 );
 
 assert.doesNotMatch(


### PR DESCRIPTION
# User description
> ## 🧪 Test with a throwaway tag before merging
> **This code path has never executed.** `release-tag`, `publish-clawhub` and `republish-clawhub` are all *skipped* without a tag push, so no CI run on any PR — including #359's green one — has exercised a single line of it.

Replaces `softprops/action-gh-release` with the `gh` CLI, which is preinstalled and pre-authenticated on GitHub-hosted runners. For a repository whose thesis is supply-chain integrity, removing a third-party action from the release-publishing path is worth the slightly longer step.

Re-pushing a tag re-runs this job, so the action's implicit upsert is made explicit: `gh release view`, then `edit` + `upload --clobber` if it exists, else `create`. Every configured input is preserved — title, tag, notes file, `draft:false`, and the prerelease expression.

**Worth confirming during the tag test:** `gh release edit` leaves `make_latest` unchanged where `softprops` sent it on every run, so re-running an *older* tag could differ. Arguably the new behaviour is safer, but it is a real difference.

### The cache claim, stated precisely

Also sets `package-manager-cache: false` on the six `setup-node` steps here, keeping a restored npm cache out of the jobs that hold the signing key. #359 called this "not a false positive" — the honest version is narrower: the input only gates `setup-node`'s **implicit** cache path, which requires a `packageManager` field `package.json` does not have. So today it is **defence in depth, not a live fix**.

The larger exposure is untouched and deliberately left for a separate change: `deploy-pages.yml` and `poll-ghsa-without-cve.yml` both restore an explicit `cache: 'npm'` and then sign with the real private key.

### Test strengthened, not just updated

The rewrite turns one code path into two, and the natural translation of the old assertion (`[\s\S]*` between `BODY_FILE` and `--notes-file`) is satisfied by **either branch alone**. Mutation-tested: breaking only the `create` branch — the path every brand-new release takes — **passed** under the loose form and **fails** under the count assertion now in place.

---

## Where this sits in the series

This is one of **10 stacked PRs** splitting #359 into single-concern changes, so any one of them can be reverted on its own. Merge in numeric order — each targets its predecessor, and GitHub retargets the next automatically as each lands.

| # | PR | Merge guidance |
|---|---|---|
| 1 | dependabot cooldown | ✅ **Free to merge** |
| 2 | refresh action pins | ✅ **Free to merge** |
| 3 | node 20 → 24 | ✅ **Free to merge** |
| 4 | python 3.10 → 3.12 | ✅ **Free to merge** |
| 5 | template-injection hardening | ⚡ **Ship promptly** — closes a live exec path on `main` |
| 5b | `$GITHUB_ENV` → step output | ✅ **Free to merge** |
| 6 | `./` → `$/` action refs | ⚖️ **Decide knowingly** — Scorecard badge will move |
| 7 | `gh release` migration | 🧪 **Tag-test first** — never executed by CI |
| 8 | narrow permissions | ⛔ **Merge last, watched** — carries a blocker fix CI can't exercise |
| 9 | `persist-credentials: false` | ⛔ **Merge last, watched** — carries a blocker fix CI can't exercise |

### Why the last three need care

A fully green PR here proves less than it looks. The workflows these change cannot be triggered by a pull request: `poll-nvd-cves` runs on schedule only, `deploy-pages`' build job only on push-to-main or `workflow_run`, and `release-tag` / `publish-clawhub` / `republish-clawhub` are **skipped** without a tag push. #359 was green on all 22 checks while carrying two workflow-breaking bugs in exactly those blind spots.

### Two bugs found in #359 and fixed here

- **The daily NVD poller would have broken.** `persist-credentials: false` was added to the checkout while `git push --force origin` still relied on those credentials. `git fetch` still succeeds on a public repo, so it fails late, at the push, with `could not read Username`. Fixed in PR 9.
- **Pages deployment would have broken.** `pages`/`id-token` moved to the `deploy` job, but the `build` job runs `actions/configure-pages`, which calls the Pages API unconditionally and throws on failure. A job-level `permissions:` block replaces rather than merges, so `build` was left with no `pages` scope. Fixed in PR 8.

<sub>Full review, evidence and merge-order rationale: https://claude.ai/code/artifact/722db3dc-dfc5-40f6-974c-fba34b5dad9c</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Modernize GitHub Actions workflows by upgrading runtime/action versions, hardening expression handling, and routing local actions through <code>$/.github/actions</code>. Replace the third-party release publisher with authenticated <code>gh release</code> upsert logic while disabling implicit npm caching in signing jobs and strengthening workflow tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/367?tool=ast&topic=CI+workflow+hardening>CI workflow hardening</a>
        </td><td>Upgrade Node, Python, and security actions while hardening workflow data passing, local action references, generated summaries, Pages builds, NVD polling, and advisory release automation.<details><summary>Modified files (15)</summary><ul><li>.github/dependabot.yml</li>
<li>.github/workflows/archive-traffic.yml</li>
<li>.github/workflows/ci.yml</li>
<li>.github/workflows/codeql.yml</li>
<li>.github/workflows/community-advisory.yml</li>
<li>.github/workflows/deploy-pages.yml</li>
<li>.github/workflows/i18n-qa.yml</li>
<li>.github/workflows/pages-verify.yml</li>
<li>.github/workflows/poll-ghsa-without-cve.yml</li>
<li>.github/workflows/poll-nvd-cves.yml</li>
<li>.github/workflows/scorecard.yml</li>
<li>.github/workflows/wiki-export-verify.yml</li>
<li>.github/workflows/wiki-sync.yml</li>
<li>CLAUDE.md</li>
<li>scripts/test-nvd-ghsa-consolidation-workflow.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>ci(workflows): replace...</td><td>September 07, 2026</td></tr>
<tr><td>bnaya.harel@sentinelon...</td><td>chore(dependabot): ext...</td><td>September 03, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/367?tool=ast&topic=Release+publishing>Release publishing</a>
        </td><td>Replace <code>softprops/action-gh-release</code> with <code>gh release</code> create/edit/upload logic that preserves release metadata, supports reruns, and avoids restoring npm caches in signing and publishing paths.<details><summary>Modified files (2)</summary><ul><li>.github/workflows/skill-release.yml</li>
<li>scripts/test-skill-release-workflow.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>ci(release): publish r...</td><td>September 07, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(release): publish ...</td><td>July 14, 2026</td></tr></table></details></td></tr></table>
<a href="https://baz.co/changes/prompt-security/clawsec/367?tool=ast">Review this PR on Baz</a><br>
<a href="https://baz.co/agents/baz">Customize your next review</a>