### PR TITLE
9/10 ⛔ ci(workflows): replace read-all with least-privilege permission blocks

### DIFF
--- a/.github/workflows/archive-traffic.yml
+++ b/.github/workflows/archive-traffic.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: traffic-archive
@@ -20,6 +20,9 @@ jobs:
   archive:
     name: Capture traffic snapshot
     runs-on: ubuntu-latest
+    permissions:
+      # Pushes the traffic snapshot to the traffic-archive branch.
+      contents: write
     steps:
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   lint-typescript:
@@ -87,8 +88,9 @@ jobs:
   secret-scan:
     name: Secret Scan
     runs-on: ubuntu-latest
-    # Narrower than the workflow-wide read-all: this job runs third-party
-    # scanners over untrusted PR content and needs nothing but the checkout.
+    # Stated explicitly, not inherited: this job runs third-party scanners over
+    # untrusted PR content and needs nothing but the checkout. Keeping the block
+    # here means a future widening of the workflow default cannot widen this job.
     permissions:
       contents: read
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,8 @@ on:
   schedule:
     - cron: "17 3 * * 1"
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analyze:

--- a/.github/workflows/community-advisory.yml
+++ b/.github/workflows/community-advisory.yml
@@ -4,7 +4,8 @@ on:
   issues:
     types: [labeled]
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: community-advisory

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -13,8 +13,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -23,6 +21,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # actions/configure-pages reads the Pages site config.
+      pages: read
     # Production build only: manual dispatch, push to main, or trusted release workflows.
     # PR validation runs in .github/workflows/pages-verify.yml.
     if: |
@@ -412,6 +414,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/i18n-qa.yml
+++ b/.github/workflows/i18n-qa.yml
@@ -10,7 +10,8 @@ on:
       - '.github/workflows/i18n-qa.yml'
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   i18n-qa:

--- a/.github/workflows/poll-ghsa-without-cve.yml
+++ b/.github/workflows/poll-ghsa-without-cve.yml
@@ -3,7 +3,8 @@ name: Poll GHSA Without CVE
 on:
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: poll-ghsa-without-cve

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -12,7 +12,8 @@ on:
         default: 'false'
         type: boolean
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: poll-nvd-cves

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,7 +26,8 @@ on:
   workflow_dispatch:
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -21,7 +21,8 @@ on:
         required: true
         type: string
 
-permissions: read-all
+permissions:
+  contents: read
 
 # The ClawHub CLI version is pinned (with integrity hashes) in
 # .github/clawhub-cli/package-lock.json — bump it there.

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: wiki-sync
@@ -22,6 +22,9 @@ concurrency:
 jobs:
   sync-wiki:
     runs-on: ubuntu-latest
+    permissions:
+      # Pushes the generated export to the repository wiki.
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
# User description
> ## ⛔ Merge last, and watch the next push to `main`
> **Carries a fix for a bug in #359 that would have stopped Pages deployment.** CI structurally cannot validate this PR: the `build` job runs only on push-to-`main` and `workflow_run`, never on a pull request. A green check here is not evidence.

`permissions: read-all` grants read on every scope, including ones these workflows never touch. Replaced with `contents: read` in the eight workflows that used it, with write scopes pushed down to the single job that needs them:

| Workflow | Scope | Moved to |
|---|---|---|
| `archive-traffic` | `contents: write` | the job that pushes the traffic branch |
| `wiki-sync` | `contents: write` | the job that pushes the wiki |
| `deploy-pages` | `pages` / `id-token` | the `deploy` job |

### 🐞 The bug this fixes

#359 moved `pages`/`id-token` down to `deploy` but left the **`build` job with no permissions block at all**. A job-level block **replaces** the workflow default rather than merging with it, so `build` would have inherited `contents: read` and nothing else — while running `actions/configure-pages`, which calls `GET /repos/{owner}/{repo}/pages` **unconditionally**. With `enablement` at its default `false`, its failure path is `throw` → `setFailed` → `exit 1`: a **hard step failure, not silent degradation**. And `deploy` declares `needs: build`, so the entire Pages deployment stops.

Fixed here by giving `build` an explicit block including `pages: read`.

> Worth knowing for a future cleanup: `configure-pages`' outputs are **unused** — `vite.config.ts` hardcodes `base: '/'` and nothing reads `base_url`/`base_path`. Deleting the step would be an equally valid fix; the permission grant is the smaller diff.

For the same reason, the `deploy` job keeps `contents: read`, which it previously inherited and which GitHub's documented deploy-pages permission set includes.

### One deliberate non-narrowing

The `ci.yml` `secret-scan` job **keeps** its explicit block, which #359 removed. Its effective permissions are identical to the workflow default today, so it reads as redundant — but it is a deliberate marker on the one job that runs third-party scanners over untrusted PR content. With the block present, a future widening of the workflow default cannot silently widen this job. (Its comment is updated, since it referred to `read-all`.)

### Audited, not assumed

Every `gh` call, action and `github-script` invocation across all 13 workflows was walked against the resulting scope set. `deploy-pages`' `build` was the **only** job that lost something it uses. Job-level blocks in `codeql.yml`, `scorecard.yml`, `poll-nvd-cves.yml`, `poll-ghsa-without-cve.yml` and `skill-release.yml` are unchanged and verified already correct.

---

## Where this sits in the series

This is one of **10 stacked PRs** splitting #359 into single-concern changes, so any one of them can be reverted on its own. Merge in numeric order — each targets its predecessor, and GitHub retargets the next automatically as each lands.

| # | PR | Merge guidance |
|---|---|---|
| 1 | dependabot cooldown | ✅ **Free to merge** |
| 2 | refresh action pins | ✅ **Free to merge** |
| 3 | node 20 → 24 | ✅ **Free to merge** |
| 4 | python 3.10 → 3.12 | ✅ **Free to merge** |
| 5 | template-injection hardening | ⚡ **Ship promptly** — closes a live exec path on `main` |
| 5b | `$GITHUB_ENV` → step output | ✅ **Free to merge** |
| 6 | `./` → `$/` action refs | ⚖️ **Decide knowingly** — Scorecard badge will move |
| 7 | `gh release` migration | 🧪 **Tag-test first** — never executed by CI |
| 8 | narrow permissions | ⛔ **Merge last, watched** — carries a blocker fix CI can't exercise |
| 9 | `persist-credentials: false` | ⛔ **Merge last, watched** — carries a blocker fix CI can't exercise |

### Why the last three need care

A fully green PR here proves less than it looks. The workflows these change cannot be triggered by a pull request: `poll-nvd-cves` runs on schedule only, `deploy-pages`' build job only on push-to-main or `workflow_run`, and `release-tag` / `publish-clawhub` / `republish-clawhub` are **skipped** without a tag push. #359 was green on all 22 checks while carrying two workflow-breaking bugs in exactly those blind spots.

### Two bugs found in #359 and fixed here

- **The daily NVD poller would have broken.** `persist-credentials: false` was added to the checkout while `git push --force origin` still relied on those credentials. `git fetch` still succeeds on a public repo, so it fails late, at the push, with `could not read Username`. Fixed in PR 9.
- **Pages deployment would have broken.** `pages`/`id-token` moved to the `deploy` job, but the `build` job runs `actions/configure-pages`, which calls the Pages API unconditionally and throws on failure. A job-level `permissions:` block replaces rather than merges, so `build` was left with no `pages` scope. Fixed in PR 8.

<sub>Full review, evidence and merge-order rationale: https://claude.ai/code/artifact/722db3dc-dfc5-40f6-974c-fba34b5dad9c</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Narrow GitHub Actions permissions from <code>read-all</code> to <code>contents: read</code>, moving write and deployment scopes into the jobs that require them. Restore <code>pages: read</code> for the <code>build</code> job while keeping <code>pages: write</code> and <code>id-token: write</code> on <code>deploy</code> so Pages deployments continue to function.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/368?tool=ast&topic=Pages+Deployment>Pages Deployment</a>
        </td><td>Restore <code>pages: read</code> for <code>build</code> and scope deployment credentials to <code>deploy</code>, preventing <code>actions/configure-pages</code> from blocking the Pages release flow.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/deploy-pages.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>ci(workflows): replace...</td><td>September 07, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(pages): back off p...</td><td>August 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/368?tool=ast&topic=Least-Privilege+CI>Least-Privilege CI</a>
        </td><td>Narrow workflow permissions and preserve required write access for traffic archiving, wiki synchronization, and other CI workflows.<details><summary>Modified files (10)</summary><ul><li>.github/workflows/archive-traffic.yml</li>
<li>.github/workflows/ci.yml</li>
<li>.github/workflows/codeql.yml</li>
<li>.github/workflows/community-advisory.yml</li>
<li>.github/workflows/i18n-qa.yml</li>
<li>.github/workflows/poll-ghsa-without-cve.yml</li>
<li>.github/workflows/poll-nvd-cves.yml</li>
<li>.github/workflows/scorecard.yml</li>
<li>.github/workflows/skill-release.yml</li>
<li>.github/workflows/wiki-sync.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>ci(workflows): replace...</td><td>September 07, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>feat(security): add Tr...</td><td>August 30, 2026</td></tr></table></details></td></tr></table>
<a href="https://baz.co/changes/prompt-security/clawsec/368?tool=ast">Review this PR on Baz</a><br>
<a href="https://baz.co/agents/baz">Customize your next review</a>