### PR TITLE
fix(ci): install Python linters from the manifest Dependabot maintains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,14 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
+      # Versions come from the manifest so Dependabot's pip entry governs what
+      # CI actually executes. Inline `pipx --spec` pins are invisible to it.
+      - name: Install linters
+        run: pip install -r .github/requirements-lint-python.txt
       - name: Ruff (lint + format check)
-        run: pipx run --spec "ruff==0.6.9" ruff check utils/ --output-format=github
+        run: ruff check utils/ --output-format=github
       - name: Bandit (security)
-        run: pipx run --spec "bandit==1.7.9" bandit -r utils/ -ll
+        run: bandit -r utils/ -ll
 
   lint-shell:
     name: Lint Shell Scripts


### PR DESCRIPTION
# User description
Follow-up to a [Baz finding on #360](https://github.com/prompt-security/clawsec/pull/360#discussion_r3947762471). Split out because that PR is 1/10 of a single-concern stack touching `dependabot.yml` only, and this fix lives in `ci.yml`.

## The problem

`.github/requirements-lint-python.txt` has exactly one reference anywhere in the repo — a `paths:` trigger filter at `.github/workflows/scorecard.yml:19`. **No job installs it.** `lint-python` pinned its own versions inline instead:

```yaml
run: pipx run --spec "ruff==0.6.9" ruff check utils/ --output-format=github
run: pipx run --spec "bandit==1.7.9" bandit -r utils/ -ll
```

Dependabot's pip entry (`directory: "/.github"`) picks up the manifest. It cannot see an inline `pipx --spec` string.

The file was created holding **exactly** `ruff==0.6.9` / `bandit==1.7.9` — the values still inlined in `ci.yml` today. Dependabot has bumped it eight times since (#30, #32, #55, #103, #121, #169, #210, #237) to `ruff==0.15.13` / `bandit==1.9.4`. `ci.yml` never moved.

So CI has been linting on a **nine-month-stale Ruff** while Dependabot faithfully maintained a manifest nothing read. A decoy.

## The fix

Install from the manifest, so the versions Dependabot governs are the versions CI executes. Six lines added, two changed.

## Why not the other option

Deleting the decoy manifest and keeping the pins inline was the alternative, and it is worse: Dependabot's `github-actions` ecosystem updates `uses:` refs only, not arbitrary strings in `run:` blocks. Inline `pipx --spec` pins would be unmanaged permanently rather than merely stale.

## Verification

I told the reviewer on #360 that this jump would "very likely" mean a red build plus a round of lint fixes. **That was wrong** — I had not measured it. `utils/` is 3 Python files, 675 LOC, and clean at both version pairs.

On a clean Python 3.12 env at the target versions, running the three steps exactly as the workflow does:

| Step | Exit |
|---|---|
| `pip install -r .github/requirements-lint-python.txt` | 0 |
| `ruff check utils/ --output-format=github` (ruff 0.15.13) | 0 |
| `bandit -r utils/ -ll` (bandit 1.9.4) | 0 — no issues, 675 LOC |

Also confirmed: `--output-format=github` is still valid in Ruff 0.15.13; the `[tool.ruff]` config in `pyproject.toml` produces no deprecation warnings at 0.15.13; and nothing in `scripts/`, `skills/`, or `utils/` asserts on the old inline pins.

## Deliberately out of scope

- **`scripts/prepare-to-push.sh`** invokes whatever `ruff`/`bandit` happen to be installed locally and skips if absent, so local and CI can still disagree. Pinning it would change a dev script's install behavior — separate call.
- **`target-version = "py310"`** in `pyproject.toml` while the lint job runs 3.12. PR 4 of the #360 stack covers Python versions.
- **`setup-python`'s pip cache** (`cache: pip` + `cache-dependency-path`) would now have a real dependency file to key on. Left out to keep the diff surgical.
- The **`Ruff (lint + format check)`** step name is a misnomer — `ruff check` runs no format check. Left as-is; unrelated.

Independent of the #360 stack, so it can land whenever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the Python lint workflow to install Ruff and Bandit from the Dependabot-managed requirements manifest, ensuring CI uses maintained versions. Run the installed linters directly against <code>utils/</code> while preserving the existing checks and workflow structure.

<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>1/10 ✅ chore(dependa...</td><td>September 07, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>fix(ci): install Pytho...</td><td>September 07, 2026</td></tr></table></details>
<a href="https://baz.co/changes/prompt-security/clawsec/370?tool=ast">Review this PR on Baz</a><br>
<a href="https://baz.co/agents/baz">Customize your next review</a>