### PR TITLE
chore(dependabot): watch the pinned ClawHub CLI manifest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,16 @@
 version: 2
 updates:
+  # The clawhub CLI that skill-release.yml installs with `npm ci --prefix
+  # .github/clawhub-cli`. Its own entry rather than `directories:` on the root
+  # npm block, so a mistake here cannot take root npm updates down with it.
+  - package-ecosystem: "npm"
+    directory: "/.github/clawhub-cli"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -14,6 +14,9 @@ on:
       - '.github/workflows/skill-release.yml'
       - 'scripts/ci/**'
       - 'scripts/test-skill-*.mjs'
+      # Dependabot bumps of the pinned ClawHub CLI must exercise
+      # simulate-tag-release-build; nothing else installs the CLI on a PR.
+      - '.github/clawhub-cli/**'
   workflow_dispatch:
     inputs:
       tag:

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -94,6 +94,12 @@ assert.match(
   'Skill release workflow must also run when the release pipeline itself changes',
 );
 
+assert.match(
+  workflow,
+  /pull_request:[\s\S]*paths:[\s\S]*- '\.github\/clawhub-cli\/\*\*'/,
+  'Skill release workflow must run for Dependabot bumps of the pinned ClawHub CLI; simulate-tag-release-build is the only PR-time job that installs it',
+);
+
 assert.ok(
   ciWorkflow.includes(`      - name: Skill Release Tooling Tests
         run: |


### PR DESCRIPTION
# User description
Split out of #360, where it landed as a Baz-prompted addition to a cooldown-only change. One concern, revertable as a unit.

## The gap

`directory: "/"` on the npm Dependabot entry covers the repository root only. The `clawhub@0.7.0` pin in `.github/clawhub-cli/package.json` — the CLI that `skill-release.yml` installs with `npm ci --prefix .github/clawhub-cli`, in a job holding the ClawHub publish credentials — was outside Dependabot **entirely**: no version updates, and no security-update PRs.

## The change

**`dependabot.yml`** — its own `updates` entry for `/.github/clawhub-cli`, so the CLI reads as its own line with its own explanation and its own open-PR budget. **Not** for fault isolation: Dependabot validates the file as a whole, and GitHub runs that validation as the `.github/dependabot.yml` check on every PR touching it (visible on this PR). An earlier revision of this body claimed otherwise; Baz was right to call it. Carries `cooldown: default-days: 7`, matching #360.

The entry sits **first** under `updates:`, deliberately. #360 appends `cooldown:` to the tail of every existing entry, so a new entry appended at EOF conflicts with it on merge (verified — that was this PR's first revision). The top of the list is the one spot that neither #360 nor any of #361–#369 edits.

**`skill-release.yml`** — adds `.github/clawhub-cli/**` to `pull_request.paths`. Not a second concern; the entry is unsafe without it. `simulate-tag-release-build` is the only PR-time job that installs the CLI and runs `verify-client-selection --cli-prefix .github/clawhub-cli`. Without the path, a Dependabot CLI bump runs only `ci.yml` (which never touches the CLI), merges green, and breaks at the next real tag push — the exact blind spot the #360 series describes.

**`scripts/test-skill-release-workflow.mjs`** — asserts the trigger path is present, in the same form as the existing trigger-path assertions. Mutation-checked: deleting the path from the workflow fails the test.

## Verification

- `dependabot.yml` parses standalone (4 entries) and after a simulated merge with #360 (`git merge-tree`): 4 entries, each with `default-days: 7` exactly once.
- `git merge-tree --write-tree` is **clean** against #360's head, every stack branch #361–#369, #370 and #372 — this can land before or after any of them.
- `scripts/test-skill-release-workflow.mjs` passes on this branch and fails when the trigger path is removed.

## Not in this PR

Extending `npm audit` and the Scorecard trigger to the nested lockfile — a scan-coverage change independent of who bumps the manifest: #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add a dedicated Dependabot update entry for the pinned ClawHub CLI and trigger the skill-release workflow when it changes. Extend the workflow test to enforce coverage for <code>simulate-tag-release-build</code>, which installs and validates the CLI.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/371?tool=ast&topic=Workflow+coverage>Workflow coverage</a>
        </td><td>Assert that the skill-release workflow includes the ClawHub CLI path trigger, preventing regressions in PR-time dependency validation.<details><summary>Modified files (1)</summary><ul><li>scripts/test-skill-release-workflow.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>test(skill-release): a...</td><td>September 07, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>ci(workflows): move ex...</td><td>September 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/371?tool=ast&topic=CLI+dependency+safety>CLI dependency safety</a>
        </td><td>Watch the pinned ClawHub CLI with weekly Dependabot updates and a seven-day cooldown, then run the release simulation when CLI files change so dependency bumps are validated before publishing.<details><summary>Modified files (2)</summary><ul><li>.github/dependabot.yml</li>
<li>.github/workflows/skill-release.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>ci(workflows): referen...</td><td>September 07, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>chore(dependabot): wat...</td><td>September 07, 2026</td></tr></table></details></td></tr></table>
<a href="https://baz.co/changes/prompt-security/clawsec/371?tool=ast">Review this PR on Baz</a><br>
<a href="https://baz.co/agents/baz">Customize your next review</a>