### PR TITLE
ci: extend the dependency scan gates to the ClawHub CLI lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,11 +157,11 @@ jobs:
       - name: npm audit
         run: npm audit --audit-level=high --registry=https://registry.npmjs.org
       # The pinned ClawHub CLI runs in skill-release.yml with publish secrets,
-      # so its lockfile gets the same gate as the root one.
-      - name: npm ci (clawhub-cli)
-        run: npm ci --prefix .github/clawhub-cli
+      # so its lockfile gets the same gate as the root one. No install step:
+      # --package-lock-only audits the lockfile directly, so nothing from that
+      # dependency tree executes in this job.
       - name: npm audit (clawhub-cli)
-        run: npm audit --prefix .github/clawhub-cli --audit-level=high --registry=https://registry.npmjs.org
+        run: npm audit --prefix .github/clawhub-cli --package-lock-only --audit-level=high --registry=https://registry.npmjs.org
       - name: Check for outdated deps
         run: npm outdated || true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,12 @@ jobs:
       - run: npm ci
       - name: npm audit
         run: npm audit --audit-level=high --registry=https://registry.npmjs.org
+      # The pinned ClawHub CLI runs in skill-release.yml with publish secrets,
+      # so its lockfile gets the same gate as the root one.
+      - name: npm ci (clawhub-cli)
+        run: npm ci --prefix .github/clawhub-cli
+      - name: npm audit (clawhub-cli)
+        run: npm audit --prefix .github/clawhub-cli --audit-level=high --registry=https://registry.npmjs.org
       - name: Check for outdated deps
         run: npm outdated || true
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,6 +14,8 @@ on:
       - package.json
       - package-lock.json
       - npm-shrinkwrap.json
+      - .github/clawhub-cli/package.json
+      - .github/clawhub-cli/package-lock.json
       - requirements*.txt
       - .github/requirements*.txt
       - .github/requirements-lint-python.txt


### PR DESCRIPTION
# User description
Split out of #360. One concern — the dependency-scanning gates cover the root lockfile only — across the two workflows that implement those gates. Revertable as a unit; reverting it only narrows scan coverage.

## Why the nested lockfile deserves the root's gates

`.github/clawhub-cli/package-lock.json` pins the CLI that `skill-release.yml` runs alongside the ClawHub publish credentials. A high-severity transitive vulnerability in its 35-package tree is exposure in the most sensitive job in the repo — the same reason the root lockfile is gated.

## The change

**`ci.yml` `dependency-audit`** — after the root audit, `npm audit --prefix .github/clawhub-cli --audit-level=high`, same registry and level as the root. **No install step**: `npm audit` reads the lockfile, so nothing from that dependency tree executes in the job. (The first revision had an `npm ci --prefix` before it; Baz pointed out that runs lifecycle scripts, and the honest fix was to notice the install was never needed.) `ci.yml` runs on every PR to `main` with no path filter, so this gates CLI-only PRs unconditionally.

**`scorecard.yml` `push.paths`** — the list exists so a dependency change on `main` triggers an immediate scan rather than waiting for the Sunday cron. Adds the nested `package.json` and `package-lock.json`. Latency, not coverage: the weekly run already walks nested lockfiles.

## Verification

- Zero open Dependabot alerts on `.github/clawhub-cli/package-lock.json` (the repo's one open alert is root `package-lock.json`, medium, `@humanfs/node`). `npm audit` draws from the same advisory database, so the new step lands green. Stated plainly: I could not complete `npm audit` locally — npm's quick-audit endpoint `ECONNRESET`s from my network, root lockfile included — but that same local run, with no `node_modules` present, built the dependency tree and reached the network step, which is what shows the install step is unnecessary. The `Dependency Audit` check on this PR is the proof.
- Both workflows parse. #362 bumps `node-version` in `dependency-audit` four lines above the new step; `git merge-tree` is clean against every stack branch, #370 and #371.

## Not in this PR

Gating the tag-triggered release on this audit. That is a different control (a release gate, not a merge gate), the root lockfile has no such gate either, and failing a release because a new advisory appeared between merge and tag would make releases flaky for no integrity gain.

## Independent of #371

The lockfile exists on `main` today and these gates apply whether or not Dependabot manages it. Neither PR needs the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Extend dependency-scanning gates to audit the pinned ClawHub CLI lockfile alongside the root dependencies. Update the CI dependency audit and Scorecard path triggers so CLI dependency changes are checked on pull requests and pushed commits without installing or executing the nested dependency tree.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/372?tool=ast&topic=CLI+dependency+audit>CLI dependency audit</a>
        </td><td>Audit the pinned ClawHub CLI dependencies with the same high-severity npm gate as the root lockfile, using <code>npm audit</code> directly against the lockfile.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/ci.yml</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/372?tool=ast&topic=Scan+path+triggers>Scan path triggers</a>
        </td><td>Trigger Scorecard scans immediately when the ClawHub CLI manifest or lockfile changes, rather than waiting for the scheduled scan.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/scorecard.yml</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
<a href="https://baz.co/changes/prompt-security/clawsec/372?tool=ast">Review this PR on Baz</a><br>
<a href="https://baz.co/agents/baz">Customize your next review</a>