### PR TITLE
ci(release): publish releases with gh instead of a third-party action

### DIFF
--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -50,6 +50,9 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          # This workflow signs and publishes releases; never restore a
+          # cache into that trust path. The input defaults to true.
+          package-manager-cache: false
 
       - name: Verify signing key consistency (repo + docs)
         run: ./scripts/ci/verify_signing_key_consistency.sh
@@ -293,6 +296,9 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          # This workflow signs and publishes releases; never restore a
+          # cache into that trust path. The input defaults to true.
+          package-manager-cache: false
 
       - name: Install SkillSpector
         run: |
@@ -1027,6 +1033,9 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          # This workflow signs and publishes releases; never restore a
+          # cache into that trust path. The input defaults to true.
+          package-manager-cache: false
 
       - name: Install SkillSpector
         run: |
@@ -1180,6 +1189,9 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          # This workflow signs and publishes releases; never restore a
+          # cache into that trust path. The input defaults to true.
+          package-manager-cache: false
 
       - name: Detect publishability and install defaults
         id: publishable
@@ -1750,16 +1762,39 @@ jobs:
           '
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
-        with:
-          name: "${{ steps.parse.outputs.skill_name }} ${{ steps.parse.outputs.version }}"
-          tag_name: ${{ github.ref_name }}
-          files: release-assets/*
-          body_path: ${{ runner.temp }}/skill-release-body.md
-          draft: false
-          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          RELEASE_TITLE: ${{ steps.parse.outputs.skill_name }} ${{ steps.parse.outputs.version }}
+          PRERELEASE: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+        run: |
+          set -euo pipefail
+
+          BODY_FILE="${RUNNER_TEMP}/skill-release-body.md"
+          shopt -s nullglob
+          ASSETS=(release-assets/*)
+          if [ "${#ASSETS[@]}" -eq 0 ]; then
+            echo "::error::No release assets found in release-assets/"
+            exit 1
+          fi
+
+          # Re-pushing a tag re-runs this job, so upsert rather than create.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            # Assets before metadata: if an upload fails, the release must not
+            # already be advertising notes for an asset set that never landed.
+            gh release upload "$TAG" "${ASSETS[@]}" --clobber
+            gh release edit "$TAG" \
+              --title "$RELEASE_TITLE" \
+              --notes-file "$BODY_FILE" \
+              --draft=false \
+              --prerelease="$PRERELEASE"
+          else
+            gh release create "$TAG" \
+              --title "$RELEASE_TITLE" \
+              --notes-file "$BODY_FILE" \
+              --prerelease="$PRERELEASE" \
+              "${ASSETS[@]}"
+          fi
 
       - name: Delete superseded releases
         run: |
@@ -1827,6 +1862,9 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          # This workflow signs and publishes releases; never restore a
+          # cache into that trust path. The input defaults to true.
+          package-manager-cache: false
 
       - name: Prepare verified ClawHub release package
         id: clawhub-package
@@ -2069,6 +2107,9 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          # This workflow signs and publishes releases; never restore a
+          # cache into that trust path. The input defaults to true.
+          package-manager-cache: false
 
       - name: Check if publishable
         id: publishable

--- a/scripts/ci/clawhub_release_package.mjs
+++ b/scripts/ci/clawhub_release_package.mjs
@@ -439,6 +439,18 @@ export async function verifyClawhubClientSelection({ packageDir, cliPrefix }) {
   return { files: expectedFiles.size };
 }
 
+// ClawHub synthesises skill-card.md at publish time from the skill's own
+// metadata. It is in no release zip and no source tree, so it is never in
+// expectedFiles -- which made this check impossible to pass for any skill.
+// Verified against the registry: every published version carries one, at a
+// different size per version (nanoclaw-traffic-guardian 0.0.2 -> 2595B,
+// 0.0.1-beta5 -> 2196B, clawsec-suite 0.1.16 -> 2849B).
+//
+// Exempting it by exact path keeps the integrity property intact: every file we
+// published must still be present with a matching sha256 and size, and any
+// other unexpected path is still a failure.
+const REGISTRY_GENERATED_FILES = new Set(["skill-card.md"]);
+
 async function verifyPublishedInspect({ packageDir, inspect, version }) {
   const expectedFiles = await collectClawhubPackageFiles(path.resolve(packageDir));
   const publishedVersion = inspect.version?.version;
@@ -465,9 +477,10 @@ async function verifyPublishedInspect({ packageDir, inspect, version }) {
   }
 
   for (const filePath of publishedFiles.keys()) {
-    if (!expectedFiles.has(filePath)) {
-      throw new Error(`Published ClawHub package contains unexpected file: ${filePath}`);
+    if (expectedFiles.has(filePath) || REGISTRY_GENERATED_FILES.has(filePath)) {
+      continue;
     }
+    throw new Error(`Published ClawHub package contains unexpected file: ${filePath}`);
   }
 
   return { version, files: expectedFiles.size };

--- a/scripts/ci/clawhub_release_package.mjs
+++ b/scripts/ci/clawhub_release_package.mjs
@@ -478,16 +478,25 @@ export async function verifyPublishedPackage({ packageDir, inspectJsonPath, vers
   return verifyPublishedInspect({ packageDir, inspect, version });
 }
 
+// ClawHub indexes a freshly published version asynchronously. Observed latency
+// on the nanoclaw-traffic-guardian 0.0.2 release was ~3m18s, against a former
+// window of 6 attempts x 5s = ~44s -- so the publish succeeded and this check
+// failed the job anyway. Back off exponentially to a ~6m ceiling: the happy path
+// still returns on the first attempt, and a genuinely unpublished version still
+// fails rather than being waited away.
 export async function verifyRegistryPackage({
   packageDir,
   slug,
   version,
-  attempts = 6,
+  attempts = 15,
   delayMs = 5000,
+  maxDelayMs = 30000,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
 }) {
   const site = process.env.CLAWHUB_SITE || "https://clawhub.ai";
   const registry = process.env.CLAWHUB_REGISTRY || site;
   let lastError = "";
+  let waitedMs = 0;
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     const result = spawnSync(
@@ -511,11 +520,15 @@ export async function verifyRegistryPackage({
 
     lastError = result.stderr || result.stdout || `clawhub inspect exited ${result.status}`;
     if (attempt < attempts) {
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      const backoffMs = Math.min(delayMs * 2 ** (attempt - 1), maxDelayMs);
+      waitedMs += backoffMs;
+      await sleep(backoffMs);
     }
   }
 
-  throw new Error(`Unable to inspect published ClawHub package after ${attempts} attempts:\n${lastError}`);
+  throw new Error(
+    `Unable to inspect published ClawHub package after ${attempts} attempts over ${Math.round(waitedMs / 1000)}s:\n${lastError}`,
+  );
 }
 
 async function main() {

--- a/scripts/test-skill-clawhub-registry-verify.mjs
+++ b/scripts/test-skill-clawhub-registry-verify.mjs
@@ -6,11 +6,12 @@
 // 6 attempts x 5s = ~44s -- so a successful publish failed the release job. These
 // assertions fail if the window is ever narrowed back below that observed latency.
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { verifyRegistryPackage } from './ci/clawhub_release_package.mjs';
+import { verifyPublishedPackage, verifyRegistryPackage } from './ci/clawhub_release_package.mjs';
 
 const OBSERVED_INDEXING_LATENCY_MS = 198_000; // 3m18s, measured on the 0.0.2 release
 
@@ -76,3 +77,70 @@ check('honours caller overrides so tests and callers stay fast', async () => {
 });
 
 console.log(`clawhub registry verify: ${passed} checks passed (window ${Math.round(totalMs / 1000)}s across ${slept.length + 1} attempts)`);
+
+
+// --- published-content verification -----------------------------------------
+// ClawHub adds skill-card.md itself. Tolerating it must not become "tolerate
+// anything": every file we published must still match, and any other extra path
+// must still fail.
+const pkgDir = await mkdtemp(path.join(tmpdir(), 'clawhub-pkg-'));
+const sha = (text) => createHash('sha256').update(text).digest('hex');
+const skillJson = JSON.stringify({ name: 'demo', version: '1.0.0', sbom: { files: [] } }, null, 2);
+const skillMd = '---\nname: demo\nversion: 1.0.0\n---\n\nbody\n';
+await writeFile(path.join(pkgDir, 'skill.json'), skillJson);
+await writeFile(path.join(pkgDir, 'SKILL.md'), skillMd);
+
+const entry = (p, text) => ({ path: p, sha256: sha(text), size: Buffer.byteLength(text) });
+const ours = [entry('skill.json', skillJson), entry('SKILL.md', skillMd)];
+const inspectPath = path.join(pkgDir, '..', 'inspect.json');
+const writeInspect = async (files) => {
+  await writeFile(inspectPath, JSON.stringify({ version: { version: '1.0.0', files } }));
+  return inspectPath;
+};
+const expectThrow = async (files, pattern, label) => {
+  try {
+    await verifyPublishedPackage({ packageDir: pkgDir, inspectJsonPath: await writeInspect(files), version: '1.0.0' });
+  } catch (error) {
+    assert.match(error.message, pattern, label);
+    return;
+  }
+  throw new Error(`${label}: expected a rejection but verification passed`);
+};
+
+try {
+  const card = 'generated card\n';
+  assert.deepEqual(
+    await verifyPublishedPackage({
+      packageDir: pkgDir,
+      inspectJsonPath: await writeInspect([...ours, entry('skill-card.md', card)]),
+      version: '1.0.0',
+    }),
+    { version: '1.0.0', files: 2 },
+  );
+  passed += 1;
+
+  await expectThrow([...ours, entry('sneaky.md', 'x')], /unexpected file: sneaky\.md/, 'other extra files still rejected');
+  passed += 1;
+
+  await expectThrow(
+    [...ours, entry('nested/skill-card.md', 'x')],
+    /unexpected file: nested\/skill-card\.md/,
+    'the exemption is root-only, not any path named skill-card.md',
+  );
+  passed += 1;
+
+  await expectThrow(
+    [{ path: 'skill.json', sha256: sha('tampered'), size: Buffer.byteLength(skillJson) }, ours[1]],
+    /mismatch for skill\.json/,
+    'tampered content still rejected',
+  );
+  passed += 1;
+
+  await expectThrow([ours[0]], /missing SKILL\.md/, 'dropped files still rejected');
+  passed += 1;
+} finally {
+  await rm(pkgDir, { recursive: true, force: true });
+  await rm(inspectPath, { force: true });
+}
+
+console.log(`clawhub published-content checks passed (total ${passed})`);

--- a/scripts/test-skill-clawhub-registry-verify.mjs
+++ b/scripts/test-skill-clawhub-registry-verify.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Guards the retry window of verifyRegistryPackage.
+//
+// ClawHub indexes a published version asynchronously. The nanoclaw-traffic-guardian
+// 0.0.2 release took ~3m18s to become inspectable, while this check waited only
+// 6 attempts x 5s = ~44s -- so a successful publish failed the release job. These
+// assertions fail if the window is ever narrowed back below that observed latency.
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { verifyRegistryPackage } from './ci/clawhub_release_package.mjs';
+
+const OBSERVED_INDEXING_LATENCY_MS = 198_000; // 3m18s, measured on the 0.0.2 release
+
+let passed = 0;
+const check = (name, fn) => {
+  try {
+    fn();
+    passed += 1;
+  } catch (error) {
+    console.error(`FAIL: ${name}\n  ${error.message}`);
+    process.exit(1);
+  }
+};
+
+// `clawhub` is absent from PATH here, so every inspect attempt fails and the
+// function exhausts its window -- letting us measure the window without waiting.
+const emptyDir = await mkdtemp(path.join(tmpdir(), 'clawhub-verify-'));
+const slept = [];
+let error;
+try {
+  await verifyRegistryPackage({
+    packageDir: emptyDir,
+    slug: 'clawsec-does-not-exist',
+    version: '0.0.0',
+    sleep: async (ms) => {
+      slept.push(ms);
+    },
+  });
+  throw new Error('expected verifyRegistryPackage to throw when the version never appears');
+} catch (thrown) {
+  error = thrown;
+} finally {
+  await rm(emptyDir, { recursive: true, force: true });
+}
+
+const totalMs = slept.reduce((sum, ms) => sum + ms, 0);
+
+check('exhausts its attempts rather than hanging', () => {
+  assert.match(error.message, /Unable to inspect published ClawHub package after \d+ attempts over \d+s/);
+});
+
+check('waits longer than the observed ClawHub indexing latency', () => {
+  assert.ok(
+    totalMs > OBSERVED_INDEXING_LATENCY_MS,
+    `total backoff ${totalMs}ms must exceed the observed ${OBSERVED_INDEXING_LATENCY_MS}ms indexing latency`,
+  );
+});
+
+check('backs off exponentially, then holds at a cap', () => {
+  assert.deepEqual(slept.slice(0, 4), [5000, 10000, 20000, 30000], 'first delays must double to the cap');
+  assert.ok(
+    slept.every((ms) => ms <= 30000),
+    'no single delay may exceed the 30s cap',
+  );
+});
+
+check('reports the elapsed wait so a real failure is diagnosable', () => {
+  assert.match(error.message, new RegExp(`over ${Math.round(totalMs / 1000)}s`));
+});
+
+check('honours caller overrides so tests and callers stay fast', async () => {
+  assert.ok(slept.length >= 10, 'default window must span many attempts');
+});
+
+console.log(`clawhub registry verify: ${passed} checks passed (window ${Math.round(totalMs / 1000)}s across ${slept.length + 1} attempts)`);

--- a/scripts/test-skill-release-workflow.mjs
+++ b/scripts/test-skill-release-workflow.mjs
@@ -32,7 +32,9 @@ for (const [jobName, resolverStep] of [
   const job = workflow.slice(jobStart + 1).split(/\n {2}[\w-]+:\n/)[0];
   assert.match(
     job,
-    new RegExp(`      - name: Setup Node\n        uses: actions/setup-node@[^\n]+\n        with:\n          node-version: 24\n\n      - name: ${resolverStep}\n`),
+    // Extra `with:` keys and their comments may sit between node-version and
+    // the next step -- this workflow also sets package-manager-cache.
+    new RegExp(`      - name: Setup Node\n        uses: actions/setup-node@[^\n]+\n        with:\n          node-version: 24\n(?:          [^\n]*\n)*\n      - name: ${resolverStep}\n`),
     `${jobName}: ${resolverStep} must run after Setup Node selects Node 24`,
   );
 }
@@ -249,11 +251,33 @@ assert.match(
   'GitHub release notes must load the generated SkillSpector report content into the release body file',
 );
 
+// Splits the "Create GitHub Release" upsert into its two arms so each can be
+// asserted on independently.
+function releaseUpsertBranches() {
+  const step = workflow.slice(workflow.indexOf('      - name: Create GitHub Release'));
+  const body = step.slice(step.indexOf('if gh release view'));
+  const elseAt = body.indexOf('\n          else\n');
+  const fiAt = body.indexOf('\n          fi\n');
+  assert.ok(elseAt !== -1 && fiAt > elseAt, 'the release step must upsert via if/else');
+  return { edit: body.slice(0, elseAt), create: body.slice(elseAt, fiAt) };
+}
+
 assert.match(
   workflow,
-  /body_path: \$\{\{ runner\.temp \}\}\/skill-release-body\.md/,
-  'GitHub release creation must use body_path for the generated release body file',
+  /BODY_FILE="\$\{RUNNER_TEMP\}\/skill-release-body\.md"/,
+  'GitHub release creation must derive the release body path from RUNNER_TEMP',
 );
+
+// Assert each arm separately. A global count is satisfied by two matches in one
+// arm and none in the other -- which would let brand-new releases, the create
+// path, ship with no notes at all.
+for (const [branch, block] of Object.entries(releaseUpsertBranches())) {
+  assert.match(
+    block,
+    /--notes-file "\$BODY_FILE"/,
+    `the release ${branch} arm must take its body from the generated file`,
+  );
+}
 
 assert.doesNotMatch(
   workflow,


### PR DESCRIPTION
# User description
Replaces #367, rebuilt directly on `main` and targeting `main`. See **Why rebuilt** below — a straight rebase of #367 silently reverted a merged fix.

## 🧪 Test with a throwaway tag before merging

**This code path has never executed.** `release-tag`, `publish-clawhub` and `republish-clawhub` are all *skipped* without a tag push, so no CI run on any PR has exercised a single line of it.

## The change

`softprops/action-gh-release` → the `gh` CLI, preinstalled and pre-authenticated on GitHub-hosted runners. For a repository whose thesis is supply-chain integrity, removing a third-party action from the release-publishing path is worth the slightly longer step.

Re-pushing a tag re-runs this job, so the action's implicit upsert is made explicit: `gh release view`, then upload + edit if it exists, else create. Every configured input is preserved — title, tag, notes file, `draft:false`, and the prerelease expression.

**Worth confirming during the tag test:** `gh release edit` leaves `make_latest` unchanged where `softprops` sent it on every run, so re-running an *older* tag could differ. Arguably safer, but a real difference.

## Two Baz findings, both fixed

**Assets now upload before metadata is edited.** The reverse order leaves a window where a failed upload has the public release already advertising notes for an asset set that never landed. ([thread](https://github.com/prompt-security/clawsec/pull/367#discussion_r3947715668))

**The notes-file assertion is now per-arm.** #367 asserted a global count of 2 occurrences. Baz pointed out two matches in the edit arm and none in the create arm satisfies that — and the create arm is the path every brand-new release takes. Mutation-verified both ways: that exact mutation **passes** the counting form and **fails** the per-arm form now in place. ([thread](https://github.com/prompt-security/clawsec/pull/367#discussion_r3947715676))

## The cache claim, stated precisely

Sets `package-manager-cache: false` on all six `setup-node` steps here, keeping a restored npm cache out of the jobs that hold the signing key. The honest version: the input only gates setup-node's **implicit** cache path, which requires a `packageManager` field `package.json` does not have. So this is **defence in depth, not a live fix**.

The larger exposure is untouched and deliberately left for a separate change: `deploy-pages.yml` and `poll-ghsa-without-cve.yml` both restore an explicit `cache: 'npm'` and then sign with the real private key.

## Why rebuilt rather than rebased

Since #367 was cut, `main` moved `Setup Node` **ahead of** the publishability resolver in both `release-tag` and `republish-clawhub` so the resolver runs under Node 24, and locked it with a test. Cherry-picking #367 onto `main` reverted that reordering in both jobs — textually clean, semantically a regression. Rebuilt from `main` instead, preserving the ordering; the assertion is widened only to tolerate the extra `with:` keys, and still fails on a node-version regression or a missing Setup Node (both mutation-checked).

Also absorbs #375, which bumped `softprops/action-gh-release` to v3.0.3 on the exact line this PR deletes.

## Verification

- `scripts/test-skill-release-workflow.mjs` passes; 53/53 repo tests pass with this and the five other open PRs applied together.
- All 13 workflows parse; `skill-release.yml` triggers unchanged (`push`, `pull_request`, `workflow_dispatch`).
- `softprops` references: 0. `package-manager-cache: false`: 6. Step order in `release-tag` identical to `main`.
- `git merge-tree` clean against `main` and all five other open PRs — any merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Replace the third-party release action with an authenticated <code>gh</code> CLI upsert that uploads assets before editing existing release metadata. Harden release workflows by disabling setup-node caching on signing paths, accommodating ClawHub-generated <code>skill-card.md</code>, and extending registry verification with capped exponential backoff and targeted tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/376?tool=ast&topic=ClawHub+verification>ClawHub verification</a>
        </td><td>Harden ClawHub package verification by allowing only the registry-generated root <code>skill-card.md</code>, extending asynchronous indexing retries, and testing integrity checks and retry behavior.<details><summary>Modified files (2)</summary><ul><li>scripts/ci/clawhub_release_package.mjs</li>
<li>scripts/test-skill-clawhub-registry-verify.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>fix(ci): accept the sk...</td><td>September 08, 2026</td></tr>
<tr><td>david.a@prompt.security</td><td>fix(release): upload C...</td><td>July 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/376?tool=ast&topic=Release+publishing>Release publishing</a>
        </td><td>Publish GitHub releases through <code>gh</code> with explicit create-or-update behavior, preserving release metadata and ensuring assets upload before existing-release edits.<details><summary>Modified files (2)</summary><ul><li>.github/workflows/skill-release.yml</li>
<li>scripts/test-skill-release-workflow.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>ci(workflows): replace...</td><td>September 07, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>ci(release): publish r...</td><td>September 07, 2026</td></tr></table></details></td></tr></table>
<a href="https://baz.co/changes/prompt-security/clawsec/376?tool=ast">Review this PR on Baz</a><br>
<a href="https://baz.co/agents/baz">Customize your next review</a>

---

## Update: two ClawHub publish fixes added

The tag test that validated this PR's release path (`nanoclaw-traffic-guardian-v0.0.2`, a real release) also surfaced two bugs in `publish-clawhub`. Added here at the maintainer's request rather than as separate PRs — noting the revert coupling: reverting this PR now also reverts both fixes.

`release-tag` itself passed on the first attempt. Everything below is downstream of it.

### 1. `7c42338` — the verify window was shorter than ClawHub's indexing latency

```
14:27:33  ✔ OK. Published clawsec-nanoclaw-traffic-guardian@0.0.2
14:28:17  verify gives up — "Version not found" after 6 attempts (~44s)
14:30:51  registry finishes indexing        ← skill.updatedAt
```

`attempts = 6, delayMs = 5000` quit **2m34s early** on a publish that had already succeeded. Replaced with exponential backoff capped at 30s over 15 attempts — a ~6m ceiling, ~1.8× the observed latency. An already-indexed version still returns on the first attempt; a version that never publishes still fails rather than being waited away. `sleep` is injectable, matching the retry helper in `test-deploy-pages-checksums.mjs`, and the error now reports elapsed seconds.

### 2. `97023a7` — the real blocker: ClawHub adds `skill-card.md`

With the race gone, the re-run reached the content check and failed there:

```
Published ClawHub package contains unexpected file: skill-card.md
```

Nothing we ship contains that file. The release zip has 12 entries and none is `skill-card.md`; `prepare` builds the package from that zip plus `checksums.json`, `checksums.sig` and `signing-public.pem`. ClawHub produces it during publish from the skill's own metadata, at a different size per version:

| published version | `skill-card.md` |
|---|---|
| nanoclaw-traffic-guardian 0.0.2 | 2595 B |
| nanoclaw-traffic-guardian 0.0.1-beta5 | 2196 B |
| clawsec-suite 0.1.16 | 2849 B |

None matches the 2363 B `skill-card.md` our own trust packet writes into `release-assets/` — that one is a GitHub release asset and never enters the ClawHub payload. **Two unrelated files sharing a name.**

Because ClawHub does this on every publish, `verifyPublishedInspect` could not pass for **any** skill. The single exact path is now exempted; every other property is unchanged — files we published must still match `sha256` and `size`, dropped files still fail, tampered content still fails, and any other unexpected path still fails.

**Undetermined, deliberately:** whether the `clawhub` CLI writes the file or the server synthesises it. npm is unreachable from the machine this was investigated on, so the pinned `clawhub@0.7.0` dist could not be inspected. Worth an upstream question either way — a registry adding files to a signed payload is awkward for a project whose thesis is supply-chain integrity.

### Verification

Replayed against **production data** rather than cutting a second release — real `prepare` on the real released zip, against ClawHub's real published file list for 0.0.2:

| | result |
|---|---|
| with these fixes | **PASS** — `{version: "0.0.2", files: 5}` |
| with `main`'s script | **FAIL** — `contains unexpected file: skill-card.md` |

Also: the released artifact was sound all along — `checksums.sig` verifies against the canonical signing key (fingerprint `711424e4535f8409…`) and the zip's SHA256 matches `checksums.json`.

`scripts/test-skill-clawhub-registry-verify.mjs` (new; matches the `scripts/test-skill-*.mjs` glob `ci.yml` already runs) pins both fixes. Mutation-verified four ways — reverting to 6 fixed attempts fails, removing the 30s cap fails, blanket-allowing unexpected files fails, and exempting by basename instead of exact path fails (so `nested/skill-card.md` is still rejected). **20/20 `scripts/` suites pass.**
