### PR TITLE
ci(workflows): replace read-all with least-privilege permission blocks

### DIFF
--- a/.github/workflows/archive-traffic.yml
+++ b/.github/workflows/archive-traffic.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: traffic-archive
@@ -20,6 +20,9 @@ jobs:
   archive:
     name: Capture traffic snapshot
     runs-on: ubuntu-latest
+    permissions:
+      # Pushes the traffic snapshot to the traffic-archive branch.
+      contents: write
     steps:
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   lint-typescript:
@@ -91,8 +92,9 @@ jobs:
   secret-scan:
     name: Secret Scan
     runs-on: ubuntu-latest
-    # Narrower than the workflow-wide read-all: this job runs third-party
-    # scanners over untrusted PR content and needs nothing but the checkout.
+    # Stated explicitly, not inherited: this job runs third-party scanners over
+    # untrusted PR content and needs nothing but the checkout. Keeping the block
+    # here means a future widening of the workflow default cannot widen this job.
     permissions:
       contents: read
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,8 @@ on:
   schedule:
     - cron: "17 3 * * 1"
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analyze:

--- a/.github/workflows/community-advisory.yml
+++ b/.github/workflows/community-advisory.yml
@@ -4,7 +4,8 @@ on:
   issues:
     types: [labeled]
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: community-advisory

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -13,8 +13,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -23,6 +21,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # actions/configure-pages reads the Pages site config.
+      pages: read
     # Production build only: manual dispatch, push to main, or trusted release workflows.
     # PR validation runs in .github/workflows/pages-verify.yml.
     if: |
@@ -412,6 +414,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/i18n-qa.yml
+++ b/.github/workflows/i18n-qa.yml
@@ -10,7 +10,8 @@ on:
       - '.github/workflows/i18n-qa.yml'
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   i18n-qa:

--- a/.github/workflows/poll-ghsa-without-cve.yml
+++ b/.github/workflows/poll-ghsa-without-cve.yml
@@ -3,7 +3,8 @@ name: Poll GHSA Without CVE
 on:
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: poll-ghsa-without-cve

--- a/.github/workflows/poll-nvd-cves.yml
+++ b/.github/workflows/poll-nvd-cves.yml
@@ -12,7 +12,8 @@ on:
         default: 'false'
         type: boolean
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: poll-nvd-cves

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,8 @@ on:
   workflow_dispatch:
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:

--- a/.github/workflows/skill-release.yml
+++ b/.github/workflows/skill-release.yml
@@ -24,7 +24,8 @@ on:
         required: true
         type: string
 
-permissions: read-all
+permissions:
+  contents: read
 
 # The ClawHub CLI version is pinned (with integrity hashes) in
 # .github/clawhub-cli/package-lock.json — bump it there.

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: wiki-sync
@@ -22,6 +22,9 @@ concurrency:
 jobs:
   sync-wiki:
     runs-on: ubuntu-latest
+    permissions:
+      # Pushes the generated export to the repository wiki.
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
# User description
Replaces #368, rebased onto `main` and targeting `main` (it previously targeted #367's branch).

## The change

`permissions: read-all` grants every read scope to every job. Each workflow now declares a minimal workflow-level default, and each job that needs more declares only what it needs.

## ⛔ Carries a fix for a bug CI cannot demonstrate

#359 moved `pages`/`id-token` to the `deploy` job — but the `build` job runs `actions/configure-pages`, which calls the Pages API unconditionally and throws on failure. **A job-level `permissions:` block replaces rather than merges the workflow default**, so `build` was left with no `pages` scope at all.

`deploy-pages`' build job runs only on push-to-main or `workflow_run`, never on a pull request, so a fully green PR proves nothing here. #359 was green on all 22 checks while carrying this.

Verified after this change:

| job | permissions |
|---|---|
| `build` | `contents: read`, **`pages: read`** |
| `deploy` | `contents: read`, `pages: write`, `id-token: write` |

## Every narrowed job checked against what it actually does

I enumerated each job's write operations and compared them to its granted scopes:

- `poll-nvd-cves` / `poll-and-update` — does `git push` and `gh pr create|edit`; has `contents: write`, `pull-requests: write`, `actions: write`. ✅
- `archive-traffic`, `wiki-sync` — `git push`; both `contents: write`. ✅
- `skill-release` / `release-tag` — `gh release create|edit|upload`; `contents: write`. ✅
- `skill-release` / `publish-clawhub`, `republish-clawhub` — only `gh release view|download`, so `contents: read` is correct. ✅
- `community-advisory` / `process-advisory` — runs `peter-evans/create-pull-request`, which uses `token: secrets.POLL_NVD_CVES_PAT`, **not** the job token, and no step reads the issues API (issue data comes from the `github.event` payload). `contents: read` is sufficient. ✅ Worth flagging since `main`'s `read-all` also granted `issues: read` and `pull-requests: read` that this drops — neither is used.

## Verification

- 53/53 repo tests pass with this and the five other open PRs applied together; all 13 workflows parse; every `on:` trigger unchanged.
- Cherry-picks clean onto `main`; `git merge-tree` clean against `main` and all five other open PRs, in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Replace broad <code>read-all</code> workflow permissions with least-privilege <code>contents: read</code> defaults and explicit job-level scopes. Preserve required publishing, synchronization, and GitHub Pages operations by granting targeted write permissions and restoring <code>pages: read</code> for the build job.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/clawsec/377?tool=ast&topic=Least-Privilege+CI>Least-Privilege CI</a>
        </td><td>Narrow workflow and job permissions while retaining scopes required for repository updates, releases, advisory processing, and synchronization tasks.<details><summary>Modified files (10)</summary><ul><li>.github/workflows/archive-traffic.yml</li>
<li>.github/workflows/ci.yml</li>
<li>.github/workflows/codeql.yml</li>
<li>.github/workflows/community-advisory.yml</li>
<li>.github/workflows/i18n-qa.yml</li>
<li>.github/workflows/poll-ghsa-without-cve.yml</li>
<li>.github/workflows/poll-nvd-cves.yml</li>
<li>.github/workflows/scorecard.yml</li>
<li>.github/workflows/skill-release.yml</li>
<li>.github/workflows/wiki-sync.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>ci: extend the depende...</td><td>September 07, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>ci(workflows): replace...</td><td>September 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/clawsec/377?tool=ast&topic=Pages+Deployment>Pages Deployment</a>
        </td><td>Restore <code>pages: read</code> for <code>build</code> and assign deployment-only <code>pages: write</code> and <code>id-token: write</code> permissions to <code>deploy</code>, accounting for non-merging job-level permission blocks.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/deploy-pages.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>david.a@prompt.security</td><td>ci(workflows): referen...</td><td>September 07, 2026</td></tr>
<tr><td>David.a@prompt.security</td><td>ci(workflows): replace...</td><td>September 07, 2026</td></tr></table></details></td></tr></table>
<a href="https://baz.co/changes/prompt-security/clawsec/377?tool=ast">Review this PR on Baz</a><br>
<a href="https://baz.co/agents/baz">Customize your next review</a>